### PR TITLE
Enabling "strict" compiler option

### DIFF
--- a/clients/imodels-client-management/src/base/OperationsBase.ts
+++ b/clients/imodels-client-management/src/base/OperationsBase.ts
@@ -65,13 +65,13 @@ export class OperationsBase {
     return {
       entities: params.entityCollectionAccessor(response),
       next: response._links.next
-        ? () => this.getEntityCollectionPage({ ...params, url: response._links.next.href })
+        ? () => this.getEntityCollectionPage({ ...params, url: response._links.next!.href })
         : undefined
     };
   }
 
   private formHeaders(params: RequestContextParams & { preferReturn?: PreferReturn, containsBody?: boolean }): Dictionary {
-    const headers = {};
+    const headers: Dictionary = {};
     headers[Constants.Headers.Authorization] = `${params.requestContext.authorization.scheme} ${params.requestContext.authorization.token}`;
     headers[Constants.Headers.Accept] = `application/vnd.bentley.itwin-platform.${this._apiVersion}+json`;
 

--- a/clients/imodels-client-management/src/base/rest/RestClient.ts
+++ b/clients/imodels-client-management/src/base/rest/RestClient.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-export type ParseErrorFunc = (response: { statusCode: number, body: unknown }) => Error;
+export type ParseErrorFunc = (response: { statusCode?: number, body?: unknown }) => Error;
 
 export type HttpRequestParams = { url: string, headers: unknown };
 export type HttpRequestWithBodyParams = HttpRequestParams & { body: unknown };

--- a/clients/imodels-client-management/src/operations/briefcase/BriefcaseOperations.ts
+++ b/clients/imodels-client-management/src/operations/briefcase/BriefcaseOperations.ts
@@ -11,7 +11,7 @@ export class BriefcaseOperations extends OperationsBase {
       requestContext: params.requestContext,
       url: `${this._apiBaseUrl}/${params.imodelId}/briefcases${this.formUrlParams({ ...params.urlParams })}`,
       preferReturn: PreferReturn.Minimal,
-      entityCollectionAccessor: (response: BriefcasesResponse<MinimalBriefcase>) => response.briefcases
+      entityCollectionAccessor: (response: unknown) => (response as BriefcasesResponse<MinimalBriefcase>).briefcases
     }));
   }
 
@@ -20,7 +20,7 @@ export class BriefcaseOperations extends OperationsBase {
       requestContext: params.requestContext,
       url: `${this._apiBaseUrl}/${params.imodelId}/briefcases${this.formUrlParams({ ...params.urlParams })}`,
       preferReturn: PreferReturn.Representation,
-      entityCollectionAccessor: (response: BriefcasesResponse<Briefcase>) => response.briefcases
+      entityCollectionAccessor: (response: unknown) => (response as BriefcasesResponse<Briefcase>).briefcases
     }));
   }
 

--- a/clients/imodels-client-management/src/operations/changeset/ChangesetOperations.ts
+++ b/clients/imodels-client-management/src/operations/changeset/ChangesetOperations.ts
@@ -12,7 +12,7 @@ export class ChangesetOperations extends OperationsBase {
       requestContext: params.requestContext,
       url: `${this._apiBaseUrl}/${params.imodelId}/changesets${this.formUrlParams({ ...params.urlParams })}`,
       preferReturn: PreferReturn.Minimal,
-      entityCollectionAccessor: (response: ChangesetsResponse<MinimalChangeset>) => response.changesets
+      entityCollectionAccessor: (response: unknown) => (response as ChangesetsResponse<MinimalChangeset>).changesets
     }));
   }
 
@@ -21,7 +21,7 @@ export class ChangesetOperations extends OperationsBase {
       requestContext: params.requestContext,
       url: `${this._apiBaseUrl}/${params.imodelId}/changesets${this.formUrlParams({ ...params.urlParams })}`,
       preferReturn: PreferReturn.Representation,
-      entityCollectionAccessor: (response: ChangesetsResponse<Changeset>) => response.changesets
+      entityCollectionAccessor: (response: unknown) => (response as ChangesetsResponse<Changeset>).changesets
     }));
   }
 

--- a/clients/imodels-client-management/src/operations/imodel/iModelOperations.ts
+++ b/clients/imodels-client-management/src/operations/imodel/iModelOperations.ts
@@ -11,7 +11,7 @@ export class iModelOperations extends OperationsBase {
       requestContext: params.requestContext,
       url: `${this._apiBaseUrl}${this.formUrlParams({ ...params.urlParams })}`,
       preferReturn: PreferReturn.Minimal,
-      entityCollectionAccessor: (response: iModelsResponse<MinimaliModel>) => response.iModels
+      entityCollectionAccessor: (response: unknown) => (response as iModelsResponse<MinimaliModel>).iModels
     }));
   }
 
@@ -20,7 +20,7 @@ export class iModelOperations extends OperationsBase {
       requestContext: params.requestContext,
       url: `${this._apiBaseUrl}${this.formUrlParams({ ...params.urlParams })}`,
       preferReturn: PreferReturn.Representation,
-      entityCollectionAccessor: (response: iModelsResponse<iModel>) => response.iModels
+      entityCollectionAccessor: (response: unknown) => (response as iModelsResponse<iModel>).iModels
     }));
   }
 

--- a/tests/imodels-clients-tests/src/authoring/BriefcaseOperations.test.ts
+++ b/tests/imodels-clients-tests/src/authoring/BriefcaseOperations.test.ts
@@ -52,7 +52,7 @@ describe("[Authoring] BriefcaseOperations", () => {
     // Assert
     assertBriefcase({
       actualBriefcase: briefcase,
-      expectedBriefcaseProperties: acquireBriefcaseParams.briefcaseProperties
+      expectedBriefcaseProperties: acquireBriefcaseParams.briefcaseProperties!
     });
   });
 });

--- a/tests/imodels-clients-tests/src/common/AssertionUtils.ts
+++ b/tests/imodels-clients-tests/src/common/AssertionUtils.ts
@@ -82,14 +82,15 @@ export function assertError(params: { actualError: Error, expectedError: Partial
   expect(imodelsError.message).to.equal(params.expectedError.message);
 
   if (params.expectedError.details) {
-    expect(imodelsError.details.length).to.equal(params.expectedError.details.length);
+    expect(imodelsError.details).to.not.be.undefined;
+    expect(imodelsError.details!.length).to.equal(params.expectedError.details.length);
 
     for (const expectedDetail of params.expectedError.details) {
       const detailVerificationFunc = (detail: iModelsErrorDetail) =>
         detail.code === expectedDetail.code &&
         detail.message === expectedDetail.message &&
         detail.target === expectedDetail.target;
-      expect(imodelsError.details.find(detailVerificationFunc)).to.not.be.undefined;
+      expect(imodelsError.details!.find(detailVerificationFunc)).to.not.be.undefined;
     }
   } else {
     expect(imodelsError.details).to.be.undefined;

--- a/tests/imodels-clients-tests/src/common/CommonTestUtils.ts
+++ b/tests/imodels-clients-tests/src/common/CommonTestUtils.ts
@@ -57,7 +57,7 @@ export async function findiModelWithName(params: {
   requestContext: RequestContext,
   projectId: string,
   expectediModelname: string
-}): Promise<iModel | undefined> {
+}): Promise<iModel> {
   const imodels = params.imodelsClient.iModels.getRepresentationList({
     requestContext: params.requestContext,
     urlParams: {
@@ -68,5 +68,5 @@ export async function findiModelWithName(params: {
     if (imodel.displayName === params.expectediModelname)
       return imodel;
 
-  return undefined;
+  throw new TestSetupError(`Failed to find an iModel with name ${params.expectediModelname}.`);
 }

--- a/tests/imodels-clients-tests/src/common/Config.ts
+++ b/tests/imodels-clients-tests/src/common/Config.ts
@@ -47,27 +47,27 @@ export class Config {
     this.validateAllValuesPresent();
 
     return {
-      testProjectName: process.env.TEST_PROJECT_NAME,
-      testiModelName: process.env.TEST_IMODEL_NAME,
+      testProjectName: process.env.TEST_PROJECT_NAME!,
+      testiModelName: process.env.TEST_IMODEL_NAME!,
       auth: {
-        authority: process.env.AUTH_AUTHORITY,
-        clientId: process.env.AUTH_CLIENT_ID,
-        clientSecret: process.env.AUTH_CLIENT_SECRET,
-        redirectUrl: process.env.AUTH_REDIRECT_URL
+        authority: process.env.AUTH_AUTHORITY!,
+        clientId: process.env.AUTH_CLIENT_ID!,
+        clientSecret: process.env.AUTH_CLIENT_SECRET!,
+        redirectUrl: process.env.AUTH_REDIRECT_URL!
       },
       apis: {
         imodels: {
-          baseUrl: process.env.APIS_IMODELS_BASE_URL,
-          scopes: process.env.APIS_IMODELS_SCOPES
+          baseUrl: process.env.APIS_IMODELS_BASE_URL!,
+          scopes: process.env.APIS_IMODELS_SCOPES!
         },
         projects: {
-          baseUrl: process.env.APIS_PROJECTS_BASE_URL,
-          scopes: process.env.APIS_PROJECTS_SCOPES
+          baseUrl: process.env.APIS_PROJECTS_BASE_URL!,
+          scopes: process.env.APIS_PROJECTS_SCOPES!
         }
       },
       testUser: {
-        email: process.env.TEST_USER_EMAIL,
-        password: process.env.TEST_USER_PASSWORD
+        email: process.env.TEST_USER_EMAIL!,
+        password: process.env.TEST_USER_PASSWORD!
       }
     };
   }

--- a/tests/imodels-clients-tests/src/management/iModelOperations.test.ts
+++ b/tests/imodels-clients-tests/src/management/iModelOperations.test.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import { expect } from "chai";
 import { CreateEmptyiModelParams, GetiModelListParams, RequestContext, iModel, iModelsClient, iModelsErrorCode } from "@itwin/imodels-client-management";
 import { Constants, TestAuthenticationProvider, TestClientOptions, TestProjectProvider, TestiModelGroup, assertCollection, assertError, assertiModel } from "../common";
 
@@ -90,7 +91,7 @@ describe("[Management] iModelOperations", () => {
     };
 
     // Act
-    let errorThrown: Error;
+    let errorThrown: Error | undefined = undefined;
     try {
       await imodelsClient.iModels.createEmpty(createiModelParams);
     } catch (e) {
@@ -98,8 +99,9 @@ describe("[Management] iModelOperations", () => {
     }
 
     // Assert
+    expect(errorThrown).to.not.be.undefined;
     assertError({
-      actualError: errorThrown,
+      actualError: errorThrown!,
       expectedError: {
         code: iModelsErrorCode.Unauthorized,
         message: "The user is unauthorized. Please provide valid authentication credentials."
@@ -119,7 +121,7 @@ describe("[Management] iModelOperations", () => {
     };
 
     // Act
-    let errorThrown: Error;
+    let errorThrown: Error | undefined = undefined;
     try {
       await imodelsClient.iModels.createEmpty(createiModelParams);
     } catch (e) {
@@ -127,8 +129,9 @@ describe("[Management] iModelOperations", () => {
     }
 
     // Assert
+    expect(errorThrown).to.not.be.undefined;
     assertError({
-      actualError: errorThrown,
+      actualError: errorThrown!,
       expectedError: {
         code: iModelsErrorCode.InvalidiModelsRequest,
         message: "Cannot create iModel.",

--- a/utils/imodels-client-common-config/.eslintrc.json
+++ b/utils/imodels-client-common-config/.eslintrc.json
@@ -86,6 +86,7 @@
     "require-await": [
       "error"
     ],
+    "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/naming-convention": [
       "error",
       {

--- a/utils/imodels-client-common-config/tsconfig.json
+++ b/utils/imodels-client-common-config/tsconfig.json
@@ -9,5 +9,6 @@
     ],
     "noUnusedLocals": true,
     "declaration": true,
+    "strict": true
   }
 }


### PR DESCRIPTION
In this PR:
- Enabled "strict" compiler option in base tsconfig.json
- Disabled the @typescript-eslint/no-non-null-assertion eslint rule. The non-null assertion operator is needed to handle cases where we check if the property is not null beforehand and then want to access it. 
- Fixed code in both tests and actual packages