### PR TITLE
Static property renaming

### DIFF
--- a/clients/imodels-client-authoring/src/Constants.ts
+++ b/clients/imodels-client-authoring/src/Constants.ts
@@ -5,8 +5,8 @@
 import { Constants as ManagementiModelsClientConstants } from "@itwin/imodels-client-management";
 
 export class Constants extends ManagementiModelsClientConstants {
-  public static Time = {
-    SleepPeriodInMs: 1000,
-    iModelInitiazationTimeOutInMs: 5 * 60 * 1000
+  public static time = {
+    sleepPeriodInMs: 1000,
+    imodelInitiazationTimeOutInMs: 5 * 60 * 1000
   }
 }

--- a/clients/imodels-client-authoring/src/operations/imodel/iModelOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/imodel/iModelOperations.ts
@@ -53,8 +53,8 @@ export class iModelOperations extends ManagementiModelOperations {
   }
 
   private async waitForBaselineFileInitialization(params: RequestContextParams & { imodelId: string, timeOutInMs?: number }): Promise<void> {
-    const sleepPeriodInMs = Constants.Time.SleepPeriodInMs;
-    const timeOutInMs = params.timeOutInMs ?? Constants.Time.iModelInitiazationTimeOutInMs;
+    const sleepPeriodInMs = Constants.time.sleepPeriodInMs;
+    const timeOutInMs = params.timeOutInMs ?? Constants.time.imodelInitiazationTimeOutInMs;
     for (let retries = Math.ceil(timeOutInMs / sleepPeriodInMs); retries > 0; --retries) {
       const baselineFileState = (await this._baselineFileOperations.getByiModelId(params)).state;
 

--- a/clients/imodels-client-management/src/Constants.ts
+++ b/clients/imodels-client-management/src/Constants.ts
@@ -3,19 +3,19 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 export class Constants {
-  public static Api = {
-    BaseUrl: "https://api.bentley.com/imodels",
-    Version: "v1"
+  public static api = {
+    baseUrl: "https://api.bentley.com/imodels",
+    version: "v1"
   }
 
-  public static Headers = {
-    Accept: "Accept",
-    Authorization: "Authorization",
-    ContentType: "ContentType",
-    Prefer: "Prefer",
+  public static headers = {
+    accept: "Accept",
+    authorization: "Authorization",
+    contentType: "ContentType",
+    prefer: "Prefer",
 
-    Values: {
-      ContentType: "application/json"
+    values: {
+      contentType: "application/json"
     }
   }
 }

--- a/clients/imodels-client-management/src/base/OperationsBase.ts
+++ b/clients/imodels-client-management/src/base/OperationsBase.ts
@@ -72,14 +72,14 @@ export class OperationsBase {
 
   private formHeaders(params: RequestContextParams & { preferReturn?: PreferReturn, containsBody?: boolean }): Dictionary {
     const headers: Dictionary = {};
-    headers[Constants.Headers.Authorization] = `${params.requestContext.authorization.scheme} ${params.requestContext.authorization.token}`;
-    headers[Constants.Headers.Accept] = `application/vnd.bentley.itwin-platform.${this._apiVersion}+json`;
+    headers[Constants.headers.authorization] = `${params.requestContext.authorization.scheme} ${params.requestContext.authorization.token}`;
+    headers[Constants.headers.accept] = `application/vnd.bentley.itwin-platform.${this._apiVersion}+json`;
 
     if (params.preferReturn)
-      headers[Constants.Headers.Prefer] = `return=${params.preferReturn}`;
+      headers[Constants.headers.prefer] = `return=${params.preferReturn}`;
 
     if (params.containsBody)
-      headers[Constants.Headers.ContentType] = Constants.Headers.Values.ContentType;
+      headers[Constants.headers.contentType] = Constants.headers.values.contentType;
 
     return headers;
   }

--- a/clients/imodels-client-management/src/iModelsClient.ts
+++ b/clients/imodels-client-management/src/iModelsClient.ts
@@ -43,8 +43,8 @@ export class iModelsClient {
     return {
       restClient: options?.restClient ?? new AxiosRestClient(),
       api: {
-        baseUri: options?.api?.baseUri ?? Constants.Api.BaseUrl,
-        version: options?.api?.version ?? Constants.Api.Version
+        baseUri: options?.api?.baseUri ?? Constants.api.baseUrl,
+        version: options?.api?.version ?? Constants.api.version
       }
     };
   }


### PR DESCRIPTION
In this PR:
- changed public static properties named to start with lowercase letter as specified in the iTwin TypeScript code guidelines: https://www.itwinjs.org/learning/guidelines/typescript-coding-guidelines/
![image](https://user-images.githubusercontent.com/70565417/137469648-8cdc56a3-fb86-4d93-9780-9b47dccdfdd8.png)
