### PR TITLE
Bug fix: adding missing `sleep` in `iModelOperations.waitForBaselineFileInitialization`

### DIFF
--- a/clients/imodels-client-authoring/src/operations/imodel/iModelOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/imodel/iModelOperations.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { AuthorizationParam, iModelOperations as ManagementiModelOperations, iModel, iModelsErrorCode, iModelsErrorImpl } from "@itwin/imodels-client-management";
+import { AuthorizationParam, iModelOperations as ManagementiModelOperations, iModel, iModelsErrorCode, iModelsErrorImpl, sleep } from "@itwin/imodels-client-management";
 import { iModelCreateResponse } from "../../base";
 import { BaselineFileState } from "../../base/interfaces/apiEntities/BaselineFileInterfaces";
 import { Constants } from "../../Constants";
@@ -65,6 +65,8 @@ export class iModelOperations<TOptions extends OperationOptions> extends Managem
           code: iModelsErrorCode.BaselineFileInitializationFailed,
           message: `Baseline File initialization failed with state '${baselineFileState}.'`
         });
+
+      await sleep(sleepPeriodInMs);
     }
 
     throw new iModelsErrorImpl({

--- a/clients/imodels-client-management/src/base/CommonFunctions.ts
+++ b/clients/imodels-client-management/src/base/CommonFunctions.ts
@@ -1,0 +1,7 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+export function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/clients/imodels-client-management/src/base/index.ts
+++ b/clients/imodels-client-management/src/base/index.ts
@@ -5,6 +5,7 @@
 export * from "./OperationsBase";
 export * from "./iModelsErrorParser";
 export * from "./PagedCollectionGenerator";
+export * from "./CommonFunctions";
 export * from "./interfaces/CommonInterfaces";
 export * from "./interfaces/UtilityTypes";
 export * from "./interfaces/iModelsErrorInterfaces";

--- a/tests/imodels-clients-tests/src/common/CommonTestUtils.ts
+++ b/tests/imodels-clients-tests/src/common/CommonTestUtils.ts
@@ -15,10 +15,6 @@ export class TestSetupError extends Error {
   }
 }
 
-export function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
 export async function cleanUpiModels(params: AuthorizationParam & {
   imodelsClient: ManagementiModelsClient | AuthoringiModelsClient,
   projectId: string,

--- a/tests/imodels-clients-tests/src/common/test-context-providers/imodel/TestiModelCreator.ts
+++ b/tests/imodels-clients-tests/src/common/test-context-providers/imodel/TestiModelCreator.ts
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { Changeset, CheckpointState } from "@itwin/imodels-client-authoring";
-import { TestSetupError, sleep } from "../../CommonTestUtils";
+import { Changeset, CheckpointState, sleep } from "@itwin/imodels-client-authoring";
+import { TestSetupError } from "../../CommonTestUtils";
 import { Config } from "../../Config";
 import { TestAuthorizationProvider } from "../auth/TestAuthenticationProvider";
 import { TestiModelFileProvider } from "./TestiModelFileProvider";


### PR DESCRIPTION
In this PR:
- Fixed a bug where the `iModelOperations.waitForBaselineFileInitialization` was missing an actual sleep in between iterations.