### PR TITLE
Exposing `creatorId` property for `Changeset`

### DIFF
--- a/clients/imodels-client-management/src/base/interfaces/apiEntities/ChangesetInterfaces.ts
+++ b/clients/imodels-client-management/src/base/interfaces/apiEntities/ChangesetInterfaces.ts
@@ -43,6 +43,7 @@ export interface MinimalChangeset {
   description: string;
   index: number;
   parentId: string;
+  creatorId: string;
   pushDateTime: Date;
   state: ChangesetState;
   containingChanges: ContainingChanges;

--- a/tests/imodels-clients-tests/src/common/AssertionUtils.ts
+++ b/tests/imodels-clients-tests/src/common/AssertionUtils.ts
@@ -66,6 +66,7 @@ export function assertChangeset(params: {
   expect(params.actualChangeset.index).to.be.greaterThan(0);
   expect(params.actualChangeset.briefcaseId).to.be.greaterThan(0);
   assertOptionalProperty(params.expectedChangesetProperties.description, params.actualChangeset.description);
+  expect(params.actualChangeset.creatorId).to.not.be.undefined;
   expect(params.actualChangeset.pushDateTime as Date).to.not.be.undefined;
   expect(params.actualChangeset.state).to.equal(ChangesetState.FileUploaded);
   expect(params.actualChangeset.synchronizationInfo).to.equal(null);


### PR DESCRIPTION
In this PR:
- Added `creatorId` property to `Changeset` entity
- Added additional assertion for changeset in integration tests.