### PR TITLE
Changing datetime properties to be of type `string`

### DIFF
--- a/clients/imodels-client-management/src/base/interfaces/apiEntities/BriefcaseInterfaces.ts
+++ b/clients/imodels-client-management/src/base/interfaces/apiEntities/BriefcaseInterfaces.ts
@@ -12,7 +12,7 @@ export interface MinimalBriefcase {
 export interface Briefcase extends MinimalBriefcase {
   briefcaseId: number;
   ownerId: string;
-  acquiredDateTime: Date;
+  acquiredDateTime: string;
   fileSize: number;
   deviceName: string | null;
 }

--- a/clients/imodels-client-management/src/base/interfaces/apiEntities/ChangesetInterfaces.ts
+++ b/clients/imodels-client-management/src/base/interfaces/apiEntities/ChangesetInterfaces.ts
@@ -44,7 +44,7 @@ export interface MinimalChangeset {
   index: number;
   parentId: string;
   creatorId: string;
-  pushDateTime: Date;
+  pushDateTime: string;
   state: ChangesetState;
   containingChanges: ContainingChanges;
   fileSize: number;

--- a/clients/imodels-client-management/src/base/interfaces/apiEntities/NamedVersionInterfaces.ts
+++ b/clients/imodels-client-management/src/base/interfaces/apiEntities/NamedVersionInterfaces.ts
@@ -18,7 +18,7 @@ export interface MinimalNamedVersion {
 export interface NamedVersion extends MinimalNamedVersion {
   name: string;
   description: string | null;
-  createdDateTime: Date;
+  createdDateTime: string;
   state: NamedVersionState;
 }
 

--- a/clients/imodels-client-management/src/base/interfaces/apiEntities/iModelInterfaces.ts
+++ b/clients/imodels-client-management/src/base/interfaces/apiEntities/iModelInterfaces.ts
@@ -28,7 +28,7 @@ export interface iModel extends MinimaliModel {
   name: string;
   description: string | null;
   state: iModelState;
-  createdDateTime: Date;
+  createdDateTime: string;
   projectId: string;
   extent: Extent | null;
 }

--- a/itwin-platform-access/imodels-access-backend/src/interface-adapters/ClientToPlatformAdapter.ts
+++ b/itwin-platform-access/imodels-access-backend/src/interface-adapters/ClientToPlatformAdapter.ts
@@ -16,7 +16,7 @@ export class ClientToPlatformAdapter {
       changesType: ClientToPlatformAdapter.toChangesetType(changeset.containingChanges),
       description: changeset.description,
       briefcaseId: changeset.briefcaseId,
-      pushDate: changeset.pushDateTime.toISOString(),
+      pushDate: changeset.pushDateTime,
       userCreated: changeset.creatorId
     };
   }

--- a/tests/imodels-clients-tests/src/common/AssertionUtils.ts
+++ b/tests/imodels-clients-tests/src/common/AssertionUtils.ts
@@ -31,7 +31,7 @@ export function assertiModel(params: {
   expect(params.actualiModel.name).to.equal(params.expectediModelProperties.name);
   assertOptionalProperty(params.expectediModelProperties.description, params.actualiModel.description);
   assertOptionalProperty(params.expectediModelProperties.extent, params.actualiModel.extent);
-  expect(params.actualiModel.createdDateTime as Date).to.not.be.undefined;
+  expect(params.actualiModel.createdDateTime).to.not.be.empty;
   expect(params.actualiModel.state).to.equal(iModelState.Initialized);
 }
 
@@ -51,7 +51,7 @@ export function assertBriefcase(params: {
 
   expect(params.actualBriefcase.fileSize).to.be.greaterThan(0);
   assertOptionalProperty(params.expectedBriefcaseProperties?.deviceName, params.actualBriefcase.deviceName);
-  expect(params.actualBriefcase.acquiredDateTime as Date).to.not.be.undefined;
+  expect(params.actualBriefcase.acquiredDateTime).to.not.be.empty;
 }
 
 export function assertChangeset(params: {
@@ -67,7 +67,7 @@ export function assertChangeset(params: {
   expect(params.actualChangeset.briefcaseId).to.be.greaterThan(0);
   assertOptionalProperty(params.expectedChangesetProperties.description, params.actualChangeset.description);
   expect(params.actualChangeset.creatorId).to.not.be.undefined;
-  expect(params.actualChangeset.pushDateTime as Date).to.not.be.undefined;
+  expect(params.actualChangeset.pushDateTime).to.not.be.empty;
   expect(params.actualChangeset.state).to.equal(ChangesetState.FileUploaded);
   expect(params.actualChangeset.synchronizationInfo).to.equal(null);
 


### PR DESCRIPTION
In this PR:
- Changed the datetime properties of entities to be of type `string` rather than `Date` because JavaScript does not automatically construct a valid Date instance upon deserialization. Having the dates as of type `string` is easier and if we ever need them to be `Date` instances we can implement that.
- Test assertion fixes.
- Fix in the `ClientToPlatformAdapter` in `@itwin/imodels-access-backend`: removed the unnecessary `Date` conversion to `string`