### PR TITLE
Adding some client usage examples in the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,67 @@ This repository contains multiple packages:
 - `@itwin/imodels-client-authoring` is an API client that extends `@itwin/imodels-client-management` and exposes additional API operations to facilitate iModel editing workflows. This client should not be used directly as the operations it exposes can only be used meaningfully via [iTwin.js](https://www.itwinjs.org/) library.
 - `@itwin/imodels-client-common-config` package is used internally to share common configuration across the API clients.
 - `@itwin/imodels-clients-tests` package is used internally for API client testing.
+
+## Usage examples
+
+### Get all project iModels
+```typescript
+import { Authorization, iModelsClient, MinimaliModel } from "@itwin/imodels-client-management";
+
+/** Function that queries all iModels for a particular project and prints their ids to the console. */
+async function printiModelIds(): Promise<void> {
+  const imodelsClient: iModelsClient = new iModelsClient();
+  const imodelIterator: AsyncIterableIterator<MinimaliModel> = imodelsClient.iModels.getMinimalList({
+    authorization: () => getAuthorization(),
+    urlParams: {
+      projectId: "8a1fcd73-8c23-460d-a392-8b4afc00affc"
+    }
+  });
+
+  for await (const imodel of imodelIterator)
+    console.log(imodel.id);
+}
+
+/** Function that returns valid authorization information. */
+async function getAuthorization(): Promise<Authorization> {
+  return { scheme: "Bearer", token: "ey..." };
+}
+```
+
+### Get all iModel Changesets
+```typescript
+import { Authorization, iModelsClient, MinimalChangeset } from "@itwin/imodels-client-management";
+
+/** Function that queries all Changesets for a particular iModel and prints their ids to the console. */
+async function printChangesetIds(): Promise<void> {
+  const imodelsClient: iModelsClient = new iModelsClient();
+  const changesetIterator: AsyncIterableIterator<MinimalChangeset> = imodelsClient.Changesets.getMinimalList({
+    authorization: () => getAuthorization(),
+    imodelId: "30c8505e-fa7a-4b53-a13f-e6a193da8ffc"
+  });
+
+  for await (const changeset of changesetIterator)
+    console.log(changeset.id);
+}
+```
+
+### Create a Named Version on a Changeset
+```typescript
+import { Authorization, iModelsClient, NamedVersion } from "@itwin/imodels-client-management";
+
+/** Function that creates a Named Version on a particular changeset and prints its id to the console. */
+async function createNamedVersion(): Promise<void> {
+  const imodelsClient: iModelsClient = new iModelsClient();
+  const namedVersion: NamedVersion = await imodelsClient.NamedVersions.create({
+    authorization: () => getAuthorization(),
+    imodelId: "30c8505e-fa7a-4b53-a13f-e6a193da8ffc",
+    namedVersionProperties: {
+      name: "Milestone",
+      changesetId: "bd51c08eb44f40d49fee9a0c7d6fc018c3b5ba3f"
+    }
+  });
+
+  console.log(namedVersion.id);
+}
+```
+


### PR DESCRIPTION
In this PR:
- Added examples on how to query iModels, Changesets and create a Named Version to the README.md file