### PR TITLE
Exposing `changesetIndex` property in `NamedVersion` entity

### DIFF
--- a/clients/imodels-client-management/src/base/interfaces/apiEntities/NamedVersionInterfaces.ts
+++ b/clients/imodels-client-management/src/base/interfaces/apiEntities/NamedVersionInterfaces.ts
@@ -13,6 +13,7 @@ export interface MinimalNamedVersion {
   id: string;
   displayName: string;
   changesetId: string | null;
+  changesetIndex: number;
 }
 
 export interface NamedVersion extends MinimalNamedVersion {

--- a/tests/imodels-clients-tests/src/common/AssertionUtils.ts
+++ b/tests/imodels-clients-tests/src/common/AssertionUtils.ts
@@ -94,7 +94,7 @@ export function assertDownloadedChangeset(params: {
 
 export function assertNamedVersion(params: {
   actualNamedVersion: NamedVersion;
-  expectedNamedVersionProperties: NamedVersionPropertiesForCreate;
+  expectedNamedVersionProperties: NamedVersionPropertiesForCreate & { changesetIndex: number };
 }): void {
   expect(params.actualNamedVersion).to.not.be.undefined;
   expect(params.actualNamedVersion.id).to.not.be.empty;
@@ -103,6 +103,7 @@ export function assertNamedVersion(params: {
   expect(params.actualNamedVersion.name).to.equal(params.expectedNamedVersionProperties.name);
   assertOptionalProperty(params.expectedNamedVersionProperties.description, params.actualNamedVersion.description);
   assertOptionalProperty(params.expectedNamedVersionProperties.changesetId, params.actualNamedVersion.changesetId);
+  expect(params.actualNamedVersion.changesetIndex).to.equal(params.expectedNamedVersionProperties.changesetIndex);
   expect(params.actualNamedVersion.state).to.equal(NamedVersionState.Visible);
 }
 

--- a/tests/imodels-clients-tests/src/management/NamedVersionOperations.test.ts
+++ b/tests/imodels-clients-tests/src/management/NamedVersionOperations.test.ts
@@ -144,7 +144,10 @@ describe("[Management] NamedVersionOperations", () => {
     // Assert
     assertNamedVersion({
       actualNamedVersion: namedVersion,
-      expectedNamedVersionProperties: createNamedVersionParams.namedVersionProperties
+      expectedNamedVersionProperties: {
+        ...createNamedVersionParams.namedVersionProperties,
+        changesetIndex: 0
+      }
     });
   });
 
@@ -167,7 +170,10 @@ describe("[Management] NamedVersionOperations", () => {
     // Assert
     assertNamedVersion({
       actualNamedVersion: namedVersion,
-      expectedNamedVersionProperties: createNamedVersionParams.namedVersionProperties
+      expectedNamedVersionProperties: {
+        ...createNamedVersionParams.namedVersionProperties,
+        changesetIndex
+      }
     });
   });
 


### PR DESCRIPTION
In this PR:
- Exposed `changesetIndex` property in `NamedVersion` entity
- Adjusted the tests to assert the new property