### PR TITLE
Repository link fix

### DIFF
--- a/clients/imodels-client-authoring/README.md
+++ b/clients/imodels-client-authoring/README.md
@@ -1,6 +1,6 @@
 # @itwin/imodels-client-authoring
 
-Copyright © Bentley Systems, Incorporated. All rights reserved. See [LICENSE.md](LICENSE.md) for license terms and full copyright notice.
+Copyright © Bentley Systems, Incorporated. All rights reserved. See [LICENSE.md](./LICENSE.md) for license terms and full copyright notice.
 
 ## About this package
 

--- a/clients/imodels-client-authoring/package.json
+++ b/clients/imodels-client-authoring/package.json
@@ -12,7 +12,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/imodels-clients/tree/main/clients/imodels-client-authoring"
+    "url": "https://github.com/iTwin/imodels-clients"
   },
   "license": "MIT",
   "author": {

--- a/clients/imodels-client-management/package.json
+++ b/clients/imodels-client-management/package.json
@@ -12,7 +12,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/imodels-clients/tree/main/clients/imodels-client-management"
+    "url": "https://github.com/iTwin/imodels-clients"
   },
   "license": "MIT",
   "author": {

--- a/itwin-platform-access/imodels-access-backend/package.json
+++ b/itwin-platform-access/imodels-access-backend/package.json
@@ -11,7 +11,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/imodels-clients/tree/main/itwin-platform-access/imodels-access-backend"
+    "url": "https://github.com/iTwin/imodels-clients"
   },
   "license": "MIT",
   "author": {

--- a/itwin-platform-access/imodels-access-frontend/package.json
+++ b/itwin-platform-access/imodels-access-frontend/package.json
@@ -11,7 +11,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/imodels-clients/tree/main/itwin-platform-access/imodels-access-frontend"
+    "url": "https://github.com/iTwin/imodels-clients"
   },
   "license": "MIT",
   "author": {

--- a/tests/imodels-access-backend-tests/package.json
+++ b/tests/imodels-access-backend-tests/package.json
@@ -12,7 +12,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/imodels-clients/tree/main/tests/imodels-access-backend-tests"
+    "url": "https://github.com/iTwin/imodels-clients"
   },
   "license": "MIT",
   "author": {

--- a/tests/imodels-clients-tests/package.json
+++ b/tests/imodels-clients-tests/package.json
@@ -12,7 +12,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/imodels-clients/tree/main/tests/imodels-clients-tests"
+    "url": "https://github.com/iTwin/imodels-clients"
   },
   "license": "MIT",
   "author": {

--- a/utils/imodels-client-common-config/package.json
+++ b/utils/imodels-client-common-config/package.json
@@ -11,7 +11,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/imodels-clients/tree/main/utils/imodels-client-common-config"
+    "url": "https://github.com/iTwin/imodels-clients"
   },
   "license": "MIT",
   "author": {


### PR DESCRIPTION
In this PR:
- Fixed repository links in `package.json` files to contain a link to repository root instead of a specific folder.