### PR TITLE
Exposing platform <-> clients interoperability utils

### DIFF
--- a/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
@@ -22,9 +22,9 @@ import {
   LockedObjects, MinimalChangeset, MinimalIModel, MinimalNamedVersion, OrderByOperator, ProgressCallback,
   ProgressData, ReleaseBriefcaseParams, SPECIAL_VALUES_ME, UpdateLockParams, isIModelsApiError, take, toArray
 } from "@itwin/imodels-client-authoring";
+import { AccessTokenAdapter } from "./interface-adapters/AccessTokenAdapter";
 import { ClientToPlatformAdapter } from "./interface-adapters/ClientToPlatformAdapter";
 import { PlatformToClientAdapter } from "./interface-adapters/PlatformToClientAdapter";
-import { AccessTokenAdapter } from "./interface-adapters/AccessTokenAdapter";
 
 export class BackendIModelsAccess implements BackendHubAccess {
   protected readonly _iModelsClient: IModelsClient;

--- a/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
@@ -348,13 +348,6 @@ export class BackendIModelsAccess implements BackendHubAccess {
     return this._iModelsClient.iModels.delete(deleteIModelParams);
   }
 
-  public static getAuthorizationCallbackFromIModelHost(): AuthorizationCallback {
-    return async () => {
-      const token = await IModelHost.getAccessToken();
-      return PlatformToClientAdapter.toAuthorization(token);
-    };
-  }
-
   private getIModelScopedOperationParams(arg: IModelIdArg): IModelScopedOperationParams {
     return {
       ...this.getAuthorizationParam(arg),
@@ -365,10 +358,17 @@ export class BackendIModelsAccess implements BackendHubAccess {
   private getAuthorizationParam(tokenArg: TokenArg): AuthorizationParam {
     const authorizationCallback: AuthorizationCallback = tokenArg.accessToken
       ? PlatformToClientAdapter.toAuthorizationCallback(tokenArg.accessToken)
-      : BackendIModelsAccess.getAuthorizationCallbackFromIModelHost();
+      : this.getAuthorizationCallbackFromIModelHost();
 
     return {
       authorization: authorizationCallback
+    };
+  }
+
+  private getAuthorizationCallbackFromIModelHost(): AuthorizationCallback {
+    return async () => {
+      const token = await IModelHost.getAccessToken();
+      return PlatformToClientAdapter.toAuthorization(token);
     };
   }
 

--- a/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
@@ -26,11 +26,11 @@ import { ClientToPlatformAdapter } from "./interface-adapters/ClientToPlatformAd
 import { PlatformToClientAdapter } from "./interface-adapters/PlatformToClientAdapter";
 
 export class BackendIModelsAccess implements BackendHubAccess {
-  public readonly IModelsClient: IModelsClient;
+  protected readonly _iModelsClient: IModelsClient;
   private readonly _changeSet0 = { id: "", changesType: 0, description: "initialChangeset", parentId: "", briefcaseId: 0, pushDate: "", userCreated: "", index: 0 };
 
   constructor(iModelsClient?: IModelsClient) {
-    this.IModelsClient = iModelsClient ?? new IModelsClient();
+    this._iModelsClient = iModelsClient ?? new IModelsClient();
   }
 
   public async downloadChangesets(arg: ChangesetRangeArg & { targetDir: LocalDirName }): Promise<ChangesetFileProps[]> {
@@ -40,7 +40,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
     };
     downloadParams.urlParams = PlatformToClientAdapter.toChangesetRangeUrlParams(arg.range);
 
-    const downloadedChangesets: DownloadedChangeset[] = await this.IModelsClient.changesets.downloadList(downloadParams);
+    const downloadedChangesets: DownloadedChangeset[] = await this._iModelsClient.changesets.downloadList(downloadParams);
     const result: ChangesetFileProps[] = downloadedChangesets.map(ClientToPlatformAdapter.toChangesetFileProps);
     return result;
   }
@@ -52,7 +52,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
       targetDirectoryPath: arg.targetDir
     };
 
-    const downloadedChangeset: DownloadedChangeset = await this.IModelsClient.changesets.downloadSingle(downloadSingleChangesetParams);
+    const downloadedChangeset: DownloadedChangeset = await this._iModelsClient.changesets.downloadSingle(downloadSingleChangesetParams);
     const result: ChangesetFileProps = ClientToPlatformAdapter.toChangesetFileProps(downloadedChangeset);
     return result;
   }
@@ -63,7 +63,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
       ...PlatformToClientAdapter.toChangesetIdOrIndex(arg.changeset)
     };
 
-    const changeset: Changeset = await this.IModelsClient.changesets.getSingle(getSingleChangesetParams);
+    const changeset: Changeset = await this._iModelsClient.changesets.getSingle(getSingleChangesetParams);
     const result: ChangesetProps = ClientToPlatformAdapter.toChangesetProps(changeset);
     return result;
   }
@@ -72,7 +72,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
     const iModelOperationParams: GetChangesetListParams = this.getIModelScopedOperationParams(arg);
     iModelOperationParams.urlParams = PlatformToClientAdapter.toChangesetRangeUrlParams(arg.range);
 
-    const changesetsIterator: AsyncIterableIterator<Changeset> = this.IModelsClient.changesets.getRepresentationList(iModelOperationParams);
+    const changesetsIterator: AsyncIterableIterator<Changeset> = this._iModelsClient.changesets.getRepresentationList(iModelOperationParams);
     const changesets: Changeset[] = await toArray(changesetsIterator);
     const result: ChangesetProps[] = changesets.map(ClientToPlatformAdapter.toChangesetProps);
     return result;
@@ -90,7 +90,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
       changesetProperties: PlatformToClientAdapter.toChangesetPropertiesForCreate(arg.changesetProps, changesetDescription)
     };
 
-    const createdChangeset: Changeset = await this.IModelsClient.changesets.create(createChangesetParams);
+    const createdChangeset: Changeset = await this._iModelsClient.changesets.create(createChangesetParams);
     return createdChangeset.index;
   }
 
@@ -106,7 +106,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
       }
     };
 
-    const changesetsIterator: AsyncIterableIterator<MinimalChangeset> = this.IModelsClient.changesets.getMinimalList(getChangesetListParams);
+    const changesetsIterator: AsyncIterableIterator<MinimalChangeset> = this._iModelsClient.changesets.getMinimalList(getChangesetListParams);
     const changesets: MinimalChangeset[] = await take(changesetsIterator, 1);
     if (changesets.length === 0)
       return this._changeSet0;
@@ -138,7 +138,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
         name: arg.versionName
       }
     };
-    const namedVersionsIterator: AsyncIterableIterator<MinimalNamedVersion> = this.IModelsClient.namedVersions.getMinimalList(getNamedVersionListParams);
+    const namedVersionsIterator: AsyncIterableIterator<MinimalNamedVersion> = this._iModelsClient.namedVersions.getMinimalList(getNamedVersionListParams);
     const namedVersions: MinimalNamedVersion[] = await toArray(namedVersionsIterator);
     if (namedVersions.length === 0 || !namedVersions[0].changesetId)
       throw new IModelError(IModelStatus.NotFound, `Named version ${arg.versionName} not found`);
@@ -147,7 +147,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
       ...iModelOperationParams,
       changesetId: namedVersions[0].changesetId
     };
-    const changeset: MinimalChangeset = await this.IModelsClient.changesets.getSingle(getSingleChangesetParams);
+    const changeset: MinimalChangeset = await this._iModelsClient.changesets.getSingle(getSingleChangesetParams);
     const result: ChangesetProps = ClientToPlatformAdapter.toChangesetProps(changeset);
     return result;
   }
@@ -155,7 +155,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
   public async acquireNewBriefcaseId(arg: AcquireNewBriefcaseIdArg): Promise<BriefcaseId> {
     const acquireBriefcaseParams: AcquireBriefcaseParams = this.getIModelScopedOperationParams(arg);
 
-    const briefcase: Briefcase = await this.IModelsClient.briefcases.acquire(acquireBriefcaseParams);
+    const briefcase: Briefcase = await this._iModelsClient.briefcases.acquire(acquireBriefcaseParams);
     if (!briefcase)
       throw new IModelError(BriefcaseStatus.CannotAcquire, "Could not acquire briefcase");
     return briefcase.briefcaseId;
@@ -167,7 +167,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
       briefcaseId: arg.briefcaseId
     };
 
-    return this.IModelsClient.briefcases.release(releaseBriefcaseParams);
+    return this._iModelsClient.briefcases.release(releaseBriefcaseParams);
   }
 
   public async getMyBriefcaseIds(arg: IModelIdArg): Promise<BriefcaseId[]> {
@@ -178,7 +178,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
       }
     };
 
-    const briefcasesIterator: AsyncIterableIterator<Briefcase> = this.IModelsClient.briefcases.getRepresentationList(getBriefcaseListParams);
+    const briefcasesIterator: AsyncIterableIterator<Briefcase> = this._iModelsClient.briefcases.getRepresentationList(getBriefcaseListParams);
     const briefcases: Briefcase[] = await toArray(briefcasesIterator);
     const briefcaseIds: BriefcaseId[] = briefcases.map((briefcase) => briefcase.briefcaseId);
     return briefcaseIds;
@@ -193,7 +193,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
     if (arg.onProgress)
       progressCallback = (progress: ProgressData) => arg.onProgress!(progress.bytesTransferred, progress.bytesTotal);
 
-    await this.IModelsClient.fileHandler.downloadFile({ downloadUrl: checkpoint._links.download.href, targetFilePath: arg.localFile, progressCallback });
+    await this._iModelsClient.fileHandler.downloadFile({ downloadUrl: checkpoint._links.download.href, targetFilePath: arg.localFile, progressCallback });
     return { index: checkpoint.changesetIndex, id: checkpoint.changesetId };
   }
 
@@ -205,7 +205,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
 
     let checkpoint: Checkpoint;
     try {
-      checkpoint = await this.IModelsClient.checkpoints.getSingle(getSingleCheckpointParams);
+      checkpoint = await this._iModelsClient.checkpoints.getSingle(getSingleCheckpointParams);
     } catch (error) {
       // Means that neither v1 nor v2 checkpoint exists
       if (isIModelsApiError(error) && error.code === IModelsErrorCode.CheckpointNotFound)
@@ -267,7 +267,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
       lockedObjects: PlatformToClientAdapter.toLockedObjects(locks)
     };
 
-    await this.IModelsClient.locks.update(updateLockParams);
+    await this._iModelsClient.locks.update(updateLockParams);
   }
 
   public async queryAllLocks(arg: BriefcaseDbArg): Promise<LockProps[]> {
@@ -278,7 +278,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
       }
     };
 
-    const locksIterator: AsyncIterableIterator<Lock> = this.IModelsClient.locks.getList(getLockListParams);
+    const locksIterator: AsyncIterableIterator<Lock> = this._iModelsClient.locks.getList(getLockListParams);
     const locks: Lock[] = await toArray(locksIterator);
     if (locks.length === 0)
       return [];
@@ -295,7 +295,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
       }
     };
 
-    const locksIterator: AsyncIterableIterator<Lock> = this.IModelsClient.locks.getList(getLockListParams);
+    const locksIterator: AsyncIterableIterator<Lock> = this._iModelsClient.locks.getList(getLockListParams);
     const locks: Lock[] = await toArray(locksIterator);
     if (locks.length === 0)
       return;
@@ -310,7 +310,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
       lockedObjects: lock.lockedObjects
     };
 
-    await this.IModelsClient.locks.update(updateLockParams);
+    await this._iModelsClient.locks.update(updateLockParams);
   }
 
   public async queryIModelByName(arg: IModelNameArg): Promise<GuidString | undefined> {
@@ -322,7 +322,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
       }
     };
 
-    const iModelsIterator: AsyncIterableIterator<MinimalIModel> = this.IModelsClient.iModels.getMinimalList(getIModelListParams);
+    const iModelsIterator: AsyncIterableIterator<MinimalIModel> = this._iModelsClient.iModels.getMinimalList(getIModelListParams);
     const iModels = await toArray(iModelsIterator);
     return iModels.length === 0 ? undefined : iModels[0].id;
   }
@@ -338,14 +338,14 @@ export class BackendIModelsAccess implements BackendHubAccess {
       }
     };
 
-    const iModel: IModel = await this.IModelsClient.iModels.createFromBaseline(createIModelFromBaselineParams);
+    const iModel: IModel = await this._iModelsClient.iModels.createFromBaseline(createIModelFromBaselineParams);
     IModelJsFs.removeSync(baselineFilePath);
     return iModel.id;
   }
 
   public async deleteIModel(arg: IModelIdArg & ITwinIdArg): Promise<void> {
     const deleteIModelParams: DeleteIModelParams = this.getIModelScopedOperationParams(arg);
-    return this.IModelsClient.iModels.delete(deleteIModelParams);
+    return this._iModelsClient.iModels.delete(deleteIModelParams);
   }
 
   public static getAuthorizationCallbackFromIModelHost(): AuthorizationCallback {
@@ -416,9 +416,9 @@ export class BackendIModelsAccess implements BackendHubAccess {
     };
 
     if (changesetIdOrIndex.changesetIndex === 0)
-      return this.IModelsClient.checkpoints.getSingle(getCheckpointParams);
+      return this._iModelsClient.checkpoints.getSingle(getCheckpointParams);
 
-    const changeset: Changeset = await this.IModelsClient.changesets.getSingle(getCheckpointParams);
+    const changeset: Changeset = await this._iModelsClient.changesets.getSingle(getCheckpointParams);
     return changeset.getCurrentOrPrecedingCheckpoint();
   }
 }

--- a/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
@@ -24,6 +24,7 @@ import {
 } from "@itwin/imodels-client-authoring";
 import { ClientToPlatformAdapter } from "./interface-adapters/ClientToPlatformAdapter";
 import { PlatformToClientAdapter } from "./interface-adapters/PlatformToClientAdapter";
+import { AccessTokenAdapter } from "./interface-adapters/AccessTokenAdapter";
 
 export class BackendIModelsAccess implements BackendHubAccess {
   protected readonly _iModelsClient: IModelsClient;
@@ -357,7 +358,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
 
   private getAuthorizationParam(tokenArg: TokenArg): AuthorizationParam {
     const authorizationCallback: AuthorizationCallback = tokenArg.accessToken
-      ? PlatformToClientAdapter.toAuthorizationCallback(tokenArg.accessToken)
+      ? AccessTokenAdapter.toAuthorizationCallback(tokenArg.accessToken)
       : this.getAuthorizationCallbackFromIModelHost();
 
     return {
@@ -368,7 +369,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
   private getAuthorizationCallbackFromIModelHost(): AuthorizationCallback {
     return async () => {
       const token = await IModelHost.getAccessToken();
-      return PlatformToClientAdapter.toAuthorization(token);
+      return AccessTokenAdapter.toAuthorization(token);
     };
   }
 

--- a/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
@@ -26,11 +26,11 @@ import { ClientToPlatformAdapter } from "./interface-adapters/ClientToPlatformAd
 import { PlatformToClientAdapter } from "./interface-adapters/PlatformToClientAdapter";
 
 export class BackendIModelsAccess implements BackendHubAccess {
-  protected readonly _iModelsClient: IModelsClient;
+  public readonly IModelsClient: IModelsClient;
   private readonly _changeSet0 = { id: "", changesType: 0, description: "initialChangeset", parentId: "", briefcaseId: 0, pushDate: "", userCreated: "", index: 0 };
 
   constructor(iModelsClient?: IModelsClient) {
-    this._iModelsClient = iModelsClient ?? new IModelsClient();
+    this.IModelsClient = iModelsClient ?? new IModelsClient();
   }
 
   public async downloadChangesets(arg: ChangesetRangeArg & { targetDir: LocalDirName }): Promise<ChangesetFileProps[]> {
@@ -40,7 +40,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
     };
     downloadParams.urlParams = PlatformToClientAdapter.toChangesetRangeUrlParams(arg.range);
 
-    const downloadedChangesets: DownloadedChangeset[] = await this._iModelsClient.changesets.downloadList(downloadParams);
+    const downloadedChangesets: DownloadedChangeset[] = await this.IModelsClient.changesets.downloadList(downloadParams);
     const result: ChangesetFileProps[] = downloadedChangesets.map(ClientToPlatformAdapter.toChangesetFileProps);
     return result;
   }
@@ -52,7 +52,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
       targetDirectoryPath: arg.targetDir
     };
 
-    const downloadedChangeset: DownloadedChangeset = await this._iModelsClient.changesets.downloadSingle(downloadSingleChangesetParams);
+    const downloadedChangeset: DownloadedChangeset = await this.IModelsClient.changesets.downloadSingle(downloadSingleChangesetParams);
     const result: ChangesetFileProps = ClientToPlatformAdapter.toChangesetFileProps(downloadedChangeset);
     return result;
   }
@@ -63,7 +63,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
       ...PlatformToClientAdapter.toChangesetIdOrIndex(arg.changeset)
     };
 
-    const changeset: Changeset = await this._iModelsClient.changesets.getSingle(getSingleChangesetParams);
+    const changeset: Changeset = await this.IModelsClient.changesets.getSingle(getSingleChangesetParams);
     const result: ChangesetProps = ClientToPlatformAdapter.toChangesetProps(changeset);
     return result;
   }
@@ -72,7 +72,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
     const iModelOperationParams: GetChangesetListParams = this.getIModelScopedOperationParams(arg);
     iModelOperationParams.urlParams = PlatformToClientAdapter.toChangesetRangeUrlParams(arg.range);
 
-    const changesetsIterator: AsyncIterableIterator<Changeset> = this._iModelsClient.changesets.getRepresentationList(iModelOperationParams);
+    const changesetsIterator: AsyncIterableIterator<Changeset> = this.IModelsClient.changesets.getRepresentationList(iModelOperationParams);
     const changesets: Changeset[] = await toArray(changesetsIterator);
     const result: ChangesetProps[] = changesets.map(ClientToPlatformAdapter.toChangesetProps);
     return result;
@@ -90,7 +90,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
       changesetProperties: PlatformToClientAdapter.toChangesetPropertiesForCreate(arg.changesetProps, changesetDescription)
     };
 
-    const createdChangeset: Changeset = await this._iModelsClient.changesets.create(createChangesetParams);
+    const createdChangeset: Changeset = await this.IModelsClient.changesets.create(createChangesetParams);
     return createdChangeset.index;
   }
 
@@ -106,7 +106,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
       }
     };
 
-    const changesetsIterator: AsyncIterableIterator<MinimalChangeset> = this._iModelsClient.changesets.getMinimalList(getChangesetListParams);
+    const changesetsIterator: AsyncIterableIterator<MinimalChangeset> = this.IModelsClient.changesets.getMinimalList(getChangesetListParams);
     const changesets: MinimalChangeset[] = await take(changesetsIterator, 1);
     if (changesets.length === 0)
       return this._changeSet0;
@@ -138,7 +138,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
         name: arg.versionName
       }
     };
-    const namedVersionsIterator: AsyncIterableIterator<MinimalNamedVersion> = this._iModelsClient.namedVersions.getMinimalList(getNamedVersionListParams);
+    const namedVersionsIterator: AsyncIterableIterator<MinimalNamedVersion> = this.IModelsClient.namedVersions.getMinimalList(getNamedVersionListParams);
     const namedVersions: MinimalNamedVersion[] = await toArray(namedVersionsIterator);
     if (namedVersions.length === 0 || !namedVersions[0].changesetId)
       throw new IModelError(IModelStatus.NotFound, `Named version ${arg.versionName} not found`);
@@ -147,7 +147,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
       ...iModelOperationParams,
       changesetId: namedVersions[0].changesetId
     };
-    const changeset: MinimalChangeset = await this._iModelsClient.changesets.getSingle(getSingleChangesetParams);
+    const changeset: MinimalChangeset = await this.IModelsClient.changesets.getSingle(getSingleChangesetParams);
     const result: ChangesetProps = ClientToPlatformAdapter.toChangesetProps(changeset);
     return result;
   }
@@ -155,7 +155,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
   public async acquireNewBriefcaseId(arg: AcquireNewBriefcaseIdArg): Promise<BriefcaseId> {
     const acquireBriefcaseParams: AcquireBriefcaseParams = this.getIModelScopedOperationParams(arg);
 
-    const briefcase: Briefcase = await this._iModelsClient.briefcases.acquire(acquireBriefcaseParams);
+    const briefcase: Briefcase = await this.IModelsClient.briefcases.acquire(acquireBriefcaseParams);
     if (!briefcase)
       throw new IModelError(BriefcaseStatus.CannotAcquire, "Could not acquire briefcase");
     return briefcase.briefcaseId;
@@ -167,7 +167,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
       briefcaseId: arg.briefcaseId
     };
 
-    return this._iModelsClient.briefcases.release(releaseBriefcaseParams);
+    return this.IModelsClient.briefcases.release(releaseBriefcaseParams);
   }
 
   public async getMyBriefcaseIds(arg: IModelIdArg): Promise<BriefcaseId[]> {
@@ -178,7 +178,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
       }
     };
 
-    const briefcasesIterator: AsyncIterableIterator<Briefcase> = this._iModelsClient.briefcases.getRepresentationList(getBriefcaseListParams);
+    const briefcasesIterator: AsyncIterableIterator<Briefcase> = this.IModelsClient.briefcases.getRepresentationList(getBriefcaseListParams);
     const briefcases: Briefcase[] = await toArray(briefcasesIterator);
     const briefcaseIds: BriefcaseId[] = briefcases.map((briefcase) => briefcase.briefcaseId);
     return briefcaseIds;
@@ -193,7 +193,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
     if (arg.onProgress)
       progressCallback = (progress: ProgressData) => arg.onProgress!(progress.bytesTransferred, progress.bytesTotal);
 
-    await this._iModelsClient.fileHandler.downloadFile({ downloadUrl: checkpoint._links.download.href, targetFilePath: arg.localFile, progressCallback });
+    await this.IModelsClient.fileHandler.downloadFile({ downloadUrl: checkpoint._links.download.href, targetFilePath: arg.localFile, progressCallback });
     return { index: checkpoint.changesetIndex, id: checkpoint.changesetId };
   }
 
@@ -205,7 +205,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
 
     let checkpoint: Checkpoint;
     try {
-      checkpoint = await this._iModelsClient.checkpoints.getSingle(getSingleCheckpointParams);
+      checkpoint = await this.IModelsClient.checkpoints.getSingle(getSingleCheckpointParams);
     } catch (error) {
       // Means that neither v1 nor v2 checkpoint exists
       if (isIModelsApiError(error) && error.code === IModelsErrorCode.CheckpointNotFound)
@@ -267,7 +267,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
       lockedObjects: PlatformToClientAdapter.toLockedObjects(locks)
     };
 
-    await this._iModelsClient.locks.update(updateLockParams);
+    await this.IModelsClient.locks.update(updateLockParams);
   }
 
   public async queryAllLocks(arg: BriefcaseDbArg): Promise<LockProps[]> {
@@ -278,7 +278,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
       }
     };
 
-    const locksIterator: AsyncIterableIterator<Lock> = this._iModelsClient.locks.getList(getLockListParams);
+    const locksIterator: AsyncIterableIterator<Lock> = this.IModelsClient.locks.getList(getLockListParams);
     const locks: Lock[] = await toArray(locksIterator);
     if (locks.length === 0)
       return [];
@@ -295,7 +295,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
       }
     };
 
-    const locksIterator: AsyncIterableIterator<Lock> = this._iModelsClient.locks.getList(getLockListParams);
+    const locksIterator: AsyncIterableIterator<Lock> = this.IModelsClient.locks.getList(getLockListParams);
     const locks: Lock[] = await toArray(locksIterator);
     if (locks.length === 0)
       return;
@@ -310,7 +310,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
       lockedObjects: lock.lockedObjects
     };
 
-    await this._iModelsClient.locks.update(updateLockParams);
+    await this.IModelsClient.locks.update(updateLockParams);
   }
 
   public async queryIModelByName(arg: IModelNameArg): Promise<GuidString | undefined> {
@@ -322,7 +322,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
       }
     };
 
-    const iModelsIterator: AsyncIterableIterator<MinimalIModel> = this._iModelsClient.iModels.getMinimalList(getIModelListParams);
+    const iModelsIterator: AsyncIterableIterator<MinimalIModel> = this.IModelsClient.iModels.getMinimalList(getIModelListParams);
     const iModels = await toArray(iModelsIterator);
     return iModels.length === 0 ? undefined : iModels[0].id;
   }
@@ -338,14 +338,21 @@ export class BackendIModelsAccess implements BackendHubAccess {
       }
     };
 
-    const iModel: IModel = await this._iModelsClient.iModels.createFromBaseline(createIModelFromBaselineParams);
+    const iModel: IModel = await this.IModelsClient.iModels.createFromBaseline(createIModelFromBaselineParams);
     IModelJsFs.removeSync(baselineFilePath);
     return iModel.id;
   }
 
   public async deleteIModel(arg: IModelIdArg & ITwinIdArg): Promise<void> {
     const deleteIModelParams: DeleteIModelParams = this.getIModelScopedOperationParams(arg);
-    return this._iModelsClient.iModels.delete(deleteIModelParams);
+    return this.IModelsClient.iModels.delete(deleteIModelParams);
+  }
+
+  public static getAuthorizationCallbackFromIModelHost(): AuthorizationCallback {
+    return async () => {
+      const token = await IModelHost.getAccessToken();
+      return PlatformToClientAdapter.toAuthorization(token);
+    };
   }
 
   private getIModelScopedOperationParams(arg: IModelIdArg): IModelScopedOperationParams {
@@ -358,19 +365,14 @@ export class BackendIModelsAccess implements BackendHubAccess {
   private getAuthorizationParam(tokenArg: TokenArg): AuthorizationParam {
     const authorizationCallback: AuthorizationCallback = tokenArg.accessToken
       ? PlatformToClientAdapter.toAuthorizationCallback(tokenArg.accessToken)
-      : this.getAuthorizationCallbackFromIModelHost();
+      : BackendIModelsAccess.getAuthorizationCallbackFromIModelHost();
 
     return {
       authorization: authorizationCallback
     };
   }
 
-  private getAuthorizationCallbackFromIModelHost(): AuthorizationCallback {
-    return async () => {
-      const token = await IModelHost.getAccessToken();
-      return PlatformToClientAdapter.toAuthorization(token);
-    };
-  }
+
 
   private setLockLevelToNone(lockedObjectsForBriefcase: LockedObjects[]): void {
     for (const lockedObjects of lockedObjectsForBriefcase) {
@@ -416,9 +418,9 @@ export class BackendIModelsAccess implements BackendHubAccess {
     };
 
     if (changesetIdOrIndex.changesetIndex === 0)
-      return this._iModelsClient.checkpoints.getSingle(getCheckpointParams);
+      return this.IModelsClient.checkpoints.getSingle(getCheckpointParams);
 
-    const changeset: Changeset = await this._iModelsClient.changesets.getSingle(getCheckpointParams);
+    const changeset: Changeset = await this.IModelsClient.changesets.getSingle(getCheckpointParams);
     return changeset.getCurrentOrPrecedingCheckpoint();
   }
 }

--- a/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
@@ -372,8 +372,6 @@ export class BackendIModelsAccess implements BackendHubAccess {
     };
   }
 
-
-
   private setLockLevelToNone(lockedObjectsForBriefcase: LockedObjects[]): void {
     for (const lockedObjects of lockedObjectsForBriefcase) {
       lockedObjects.lockLevel = LockLevel.None;

--- a/itwin-platform-access/imodels-access-backend/src/IModelsAccessBackendExports.ts
+++ b/itwin-platform-access/imodels-access-backend/src/IModelsAccessBackendExports.ts
@@ -2,6 +2,4 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-export * from "./interface-adapters/ClientToPlatformAdapter";
-export * from "./interface-adapters/PlatformToClientAdapter";
 export * from "./BackendIModelsAccess";

--- a/itwin-platform-access/imodels-access-backend/src/IModelsAccessBackendExports.ts
+++ b/itwin-platform-access/imodels-access-backend/src/IModelsAccessBackendExports.ts
@@ -2,4 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+export * from "./interface-adapters/ClientToPlatformAdapter";
+export * from "./interface-adapters/PlatformToClientAdapter";
 export * from "./BackendIModelsAccess";

--- a/itwin-platform-access/imodels-access-backend/src/IModelsAccessBackendExports.ts
+++ b/itwin-platform-access/imodels-access-backend/src/IModelsAccessBackendExports.ts
@@ -2,4 +2,5 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+export * from "./interface-adapters/AccessTokenAdapter";
 export * from "./BackendIModelsAccess";

--- a/itwin-platform-access/imodels-access-backend/src/interface-adapters/AccessTokenAdapter.ts
+++ b/itwin-platform-access/imodels-access-backend/src/interface-adapters/AccessTokenAdapter.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { AccessToken, RepositoryStatus } from "@itwin/core-bentley";
+import { IModelError } from "@itwin/core-common";
+import { Authorization, AuthorizationCallback } from "@itwin/imodels-client-authoring";
+
+export class AccessTokenAdapter {
+  public static toAuthorization(accessToken: AccessToken): Authorization {
+    const splitAccessToken = accessToken.split(" ");
+    if (splitAccessToken.length !== 2)
+      throw new IModelError(RepositoryStatus.InvalidRequest, "Unsupported access token format");
+
+    return {
+      scheme: splitAccessToken[0],
+      token: splitAccessToken[1]
+    };
+  }
+
+  public static toAuthorizationCallback(accessToken: AccessToken): AuthorizationCallback {
+    const authorization: Authorization = AccessTokenAdapter.toAuthorization(accessToken);
+    return async () => authorization;
+  }
+}

--- a/itwin-platform-access/imodels-access-backend/src/interface-adapters/PlatformToClientAdapter.ts
+++ b/itwin-platform-access/imodels-access-backend/src/interface-adapters/PlatformToClientAdapter.ts
@@ -3,9 +3,9 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { CreateNewIModelProps, LockMap, LockState } from "@itwin/core-backend";
-import { AccessToken, RepositoryStatus } from "@itwin/core-bentley";
+import { RepositoryStatus } from "@itwin/core-bentley";
 import { ChangesetFileProps, ChangesetRange, ChangesetType, IModelError, ChangesetIndexOrId as PlatformChangesetIdOrIndex } from "@itwin/core-common";
-import { Authorization, AuthorizationCallback, ChangesetPropertiesForCreate, ChangesetIdOrIndex as ClientChangesetIdOrIndex, ContainingChanges, GetChangesetListUrlParams, IModelProperties, LockLevel, LockedObjects } from "@itwin/imodels-client-authoring";
+import { ChangesetPropertiesForCreate, ChangesetIdOrIndex as ClientChangesetIdOrIndex, ContainingChanges, GetChangesetListUrlParams, IModelProperties, LockLevel, LockedObjects } from "@itwin/imodels-client-authoring";
 
 export class PlatformToClientAdapter {
   public static toChangesetPropertiesForCreate(changesetFileProps: ChangesetFileProps, changesetDescription: string): ChangesetPropertiesForCreate {
@@ -42,22 +42,6 @@ export class PlatformToClientAdapter {
       default:
         throw new IModelError(RepositoryStatus.InvalidRequest, "Unsupported ContainingChanges");
     }
-  }
-
-  public static toAuthorization(accessToken: AccessToken): Authorization {
-    const splitAccessToken = accessToken.split(" ");
-    if (splitAccessToken.length !== 2)
-      throw new IModelError(RepositoryStatus.InvalidRequest, "Unsupported access token format");
-
-    return {
-      scheme: splitAccessToken[0],
-      token: splitAccessToken[1]
-    };
-  }
-
-  public static toAuthorizationCallback(accessToken: AccessToken): AuthorizationCallback {
-    const authorization: Authorization = PlatformToClientAdapter.toAuthorization(accessToken);
-    return async () => authorization;
   }
 
   public static toChangesetIdOrIndex(changeset: PlatformChangesetIdOrIndex): ClientChangesetIdOrIndex {

--- a/itwin-platform-access/imodels-access-frontend/src/FrontendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-frontend/src/FrontendIModelsAccess.ts
@@ -5,7 +5,7 @@
 import { IModelStatus } from "@itwin/core-bentley";
 import { ChangesetIndexAndId, IModelError, IModelVersion } from "@itwin/core-common";
 import { FrontendHubAccess, IModelApp, IModelIdArg } from "@itwin/core-frontend";
-import { AuthorizationCallback, Changeset, ChangesetOrderByProperty, GetChangesetListParams, GetNamedVersionListParams, GetSingleChangesetParams, IModelScopedOperationParams, IModelsClient, MinimalChangeset, MinimalNamedVersion, NamedVersion, OrderByOperator, take, toArray } from "@itwin/imodels-client-management";
+import { AuthorizationCallback, Changeset, ChangesetOrderByProperty, GetChangesetListParams, GetNamedVersionListParams, GetSingleChangesetParams,IModelScopedOperationParams, IModelsClient, MinimalChangeset, MinimalNamedVersion, NamedVersion, OrderByOperator, take, toArray } from "@itwin/imodels-client-management";
 import { PlatformToClientAdapter } from "./interface-adapters/PlatformToClientAdapter";
 
 export class FrontendIModelsAccess implements FrontendHubAccess {
@@ -81,21 +81,21 @@ export class FrontendIModelsAccess implements FrontendHubAccess {
     return { index: namedVersions[0].changesetIndex, id: namedVersions[0].changesetId };
   }
 
-  public static getAuthorizationCallbackFromIModelApp(): AuthorizationCallback {
-    return async () => {
-      const token = await IModelApp.getAccessToken();
-      return PlatformToClientAdapter.toAuthorization(token);
-    };
-  }
-
   private getIModelScopedOperationParams(arg: IModelIdArg): IModelScopedOperationParams {
     const authorizationCallback: AuthorizationCallback = arg.accessToken
       ? PlatformToClientAdapter.toAuthorizationCallback(arg.accessToken)
-      : FrontendIModelsAccess.getAuthorizationCallbackFromIModelApp();
+      : this.getAuthorizationCallbackFromIModelApp();
 
     return {
       authorization: authorizationCallback,
       iModelId: arg.iModelId
+    };
+  }
+
+  private getAuthorizationCallbackFromIModelApp(): AuthorizationCallback {
+    return async () => {
+      const token = await IModelApp.getAccessToken();
+      return PlatformToClientAdapter.toAuthorization(token);
     };
   }
 

--- a/itwin-platform-access/imodels-access-frontend/src/FrontendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-frontend/src/FrontendIModelsAccess.ts
@@ -10,10 +10,10 @@ import { PlatformToClientAdapter } from "./interface-adapters/PlatformToClientAd
 
 export class FrontendIModelsAccess implements FrontendHubAccess {
   private readonly _emptyChangeset: ChangesetIndexAndId = { index: 0, id: "" };
-  public readonly IModelsClient: IModelsClient;
+  protected readonly _iModelsClient: IModelsClient;
 
   constructor(iModelsClient?: IModelsClient) {
-    this.IModelsClient = iModelsClient ?? new IModelsClient();
+    this._iModelsClient = iModelsClient ?? new IModelsClient();
   }
 
   private async getChangesetFromId(arg: IModelIdArg & { changeSetId: string }): Promise<ChangesetIndexAndId> {
@@ -22,7 +22,7 @@ export class FrontendIModelsAccess implements FrontendHubAccess {
       changesetId: arg.changeSetId
     };
 
-    const changeset: Changeset = await this.IModelsClient.changesets.getSingle(getSingleChangesetParams);
+    const changeset: Changeset = await this._iModelsClient.changesets.getSingle(getSingleChangesetParams);
     if (!changeset)
       throw new IModelError(IModelStatus.NotFound, `Changeset ${arg.changeSetId} not found`);
     return { index: changeset.index, id: changeset.id };
@@ -40,7 +40,7 @@ export class FrontendIModelsAccess implements FrontendHubAccess {
       }
     };
 
-    const changesetsIterator: AsyncIterableIterator<MinimalChangeset> = this.IModelsClient.changesets.getMinimalList(getChangesetListParams);
+    const changesetsIterator: AsyncIterableIterator<MinimalChangeset> = this._iModelsClient.changesets.getMinimalList(getChangesetListParams);
     const changesets: MinimalChangeset[] = await take(changesetsIterator, 1);
     if (!changesets.length)
       return this._emptyChangeset;
@@ -74,7 +74,7 @@ export class FrontendIModelsAccess implements FrontendHubAccess {
       }
     };
 
-    const namedVersionsIterator: AsyncIterableIterator<MinimalNamedVersion> = this.IModelsClient.namedVersions.getMinimalList(getNamedVersionListParams);
+    const namedVersionsIterator: AsyncIterableIterator<MinimalNamedVersion> = this._iModelsClient.namedVersions.getMinimalList(getNamedVersionListParams);
     const namedVersions: MinimalNamedVersion[] = await take(namedVersionsIterator, 1);
     if (namedVersions.length === 0 || !namedVersions[0].changesetId)
       throw new IModelError(IModelStatus.NotFound, `Named version ${arg.versionName} not found`);
@@ -101,7 +101,7 @@ export class FrontendIModelsAccess implements FrontendHubAccess {
 
   private async getChangesetFromLatestNamedVersion(arg: IModelIdArg): Promise<ChangesetIndexAndId> {
     const getNamedVersionListParams: GetNamedVersionListParams = this.getIModelScopedOperationParams(arg);
-    const namedVersionsIterator: AsyncIterableIterator<NamedVersion> = this.IModelsClient.namedVersions.getRepresentationList(getNamedVersionListParams);
+    const namedVersionsIterator: AsyncIterableIterator<NamedVersion> = this._iModelsClient.namedVersions.getRepresentationList(getNamedVersionListParams);
     const namedVersions = await toArray(namedVersionsIterator);
 
     const sortedNamedVersions = namedVersions

--- a/itwin-platform-access/imodels-access-frontend/src/FrontendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-frontend/src/FrontendIModelsAccess.ts
@@ -6,7 +6,7 @@ import { IModelStatus } from "@itwin/core-bentley";
 import { ChangesetIndexAndId, IModelError, IModelVersion } from "@itwin/core-common";
 import { FrontendHubAccess, IModelApp, IModelIdArg } from "@itwin/core-frontend";
 import { AuthorizationCallback, Changeset, ChangesetOrderByProperty, GetChangesetListParams, GetNamedVersionListParams, GetSingleChangesetParams,IModelScopedOperationParams, IModelsClient, MinimalChangeset, MinimalNamedVersion, NamedVersion, OrderByOperator, take, toArray } from "@itwin/imodels-client-management";
-import { PlatformToClientAdapter } from "./interface-adapters/PlatformToClientAdapter";
+import { AccessTokenAdapter } from "./interface-adapters/AccessTokenAdapter";
 
 export class FrontendIModelsAccess implements FrontendHubAccess {
   private readonly _emptyChangeset: ChangesetIndexAndId = { index: 0, id: "" };
@@ -83,7 +83,7 @@ export class FrontendIModelsAccess implements FrontendHubAccess {
 
   private getIModelScopedOperationParams(arg: IModelIdArg): IModelScopedOperationParams {
     const authorizationCallback: AuthorizationCallback = arg.accessToken
-      ? PlatformToClientAdapter.toAuthorizationCallback(arg.accessToken)
+      ? AccessTokenAdapter.toAuthorizationCallback(arg.accessToken)
       : this.getAuthorizationCallbackFromIModelApp();
 
     return {
@@ -95,7 +95,7 @@ export class FrontendIModelsAccess implements FrontendHubAccess {
   private getAuthorizationCallbackFromIModelApp(): AuthorizationCallback {
     return async () => {
       const token = await IModelApp.getAccessToken();
-      return PlatformToClientAdapter.toAuthorization(token);
+      return AccessTokenAdapter.toAuthorization(token);
     };
   }
 

--- a/itwin-platform-access/imodels-access-frontend/src/IModelsAccessFrontendExports.ts
+++ b/itwin-platform-access/imodels-access-frontend/src/IModelsAccessFrontendExports.ts
@@ -2,4 +2,5 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+export * from "./interface-adapters/AccessTokenAdapter";
 export * from "./FrontendIModelsAccess";

--- a/itwin-platform-access/imodels-access-frontend/src/IModelsAccessFrontendExports.ts
+++ b/itwin-platform-access/imodels-access-frontend/src/IModelsAccessFrontendExports.ts
@@ -2,4 +2,5 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+export * from "./interface-adapters/PlatformToClientAdapter";
 export * from "./FrontendIModelsAccess";

--- a/itwin-platform-access/imodels-access-frontend/src/IModelsAccessFrontendExports.ts
+++ b/itwin-platform-access/imodels-access-frontend/src/IModelsAccessFrontendExports.ts
@@ -2,5 +2,4 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-export * from "./interface-adapters/PlatformToClientAdapter";
 export * from "./FrontendIModelsAccess";

--- a/itwin-platform-access/imodels-access-frontend/src/interface-adapters/AccessTokenAdapter.ts
+++ b/itwin-platform-access/imodels-access-frontend/src/interface-adapters/AccessTokenAdapter.ts
@@ -6,7 +6,7 @@ import { AccessToken, RepositoryStatus } from "@itwin/core-bentley";
 import { IModelError } from "@itwin/core-common";
 import { Authorization, AuthorizationCallback } from "@itwin/imodels-client-management";
 
-export class PlatformToClientAdapter {
+export class AccessTokenAdapter {
   public static toAuthorization(accessToken: AccessToken): Authorization {
     const splitAccessToken = accessToken.split(" ");
     if (splitAccessToken.length !== 2)
@@ -19,7 +19,7 @@ export class PlatformToClientAdapter {
   }
 
   public static toAuthorizationCallback(accessToken: AccessToken): AuthorizationCallback {
-    const authorization: Authorization = PlatformToClientAdapter.toAuthorization(accessToken);
-    return async () => Promise.resolve(authorization);
+    const authorization: Authorization = AccessTokenAdapter.toAuthorization(accessToken);
+    return async () => authorization;
   }
 }


### PR DESCRIPTION
In this PR:
- Moved token conversion methods into separate adapters in both packages so that applications could reuse them when working with IModelApp/IModelHost.