### PR TITLE
Bug fix for `ClientToPlatformAdapter.toChangesetType` in `@itwin/imodels-access-backend`

### DIFF
--- a/itwin-platform-access/imodels-access-backend/src/interface-adapters/ClientToPlatformAdapter.ts
+++ b/itwin-platform-access/imodels-access-backend/src/interface-adapters/ClientToPlatformAdapter.ts
@@ -17,7 +17,8 @@ export class ClientToPlatformAdapter {
       description: changeset.description,
       briefcaseId: changeset.briefcaseId,
       pushDate: changeset.pushDateTime,
-      userCreated: changeset.creatorId
+      userCreated: changeset.creatorId,
+      size: changeset.fileSize
     };
   }
 

--- a/itwin-platform-access/imodels-access-backend/src/interface-adapters/ClientToPlatformAdapter.ts
+++ b/itwin-platform-access/imodels-access-backend/src/interface-adapters/ClientToPlatformAdapter.ts
@@ -65,12 +65,10 @@ export class ClientToPlatformAdapter {
 
   private static toChangesetType(containingChanges: ContainingChanges): ChangesetType {
     switch (containingChanges) {
-      case ContainingChanges.Regular:
-        return ChangesetType.Regular;
       case ContainingChanges.Schema:
         return ChangesetType.Schema;
       default:
-        throw new IModelError(RepositoryStatus.InvalidResponse, "Unsupported ContainingChanges");
+        return ChangesetType.Regular;
     }
   }
 }

--- a/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
+++ b/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
@@ -32,6 +32,10 @@ describe("BackendiModelsAccess", () => {
     });
   });
 
+  beforeEach(() => {
+    cleanupDirectory(testDownloadPath);
+  });
+
   afterEach(() => {
     cleanupDirectory(testDownloadPath);
   });

--- a/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
+++ b/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
@@ -2,18 +2,21 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { IModelIdArg } from "@itwin/core-backend";
-import { BriefcaseId } from "@itwin/core-common";
+import * as fs from "fs";
+import * as path from "path";
+import { ChangesetRangeArg, IModelIdArg } from "@itwin/core-backend";
+import { BriefcaseId, ChangesetFileProps, ChangesetType, LocalDirName } from "@itwin/core-common";
 import { BackendIModelsAccess } from "@itwin/imodels-access-backend";
 import { expect } from "chai";
-import { IModelsClient } from "@itwin/imodels-client-authoring";
-import { Config, ReusableIModelMetadata, ReusableTestIModelProvider, TestAuthorizationProvider, TestClientOptions, TestProjectProvider } from "@itwin/imodels-clients-tests";
+import { ContainingChanges, IModelsClient } from "@itwin/imodels-client-authoring";
+import { cleanupDirectory, Config, ReusableIModelMetadata, ReusableTestIModelProvider, TestAuthorizationProvider, TestClientOptions, TestIModelFileProvider, TestProjectProvider } from "@itwin/imodels-clients-tests";
 
 describe("BackendiModelsAccess", () => {
   let backendIModelsAccess: BackendIModelsAccess;
   let accessToken: string;
   let projectId: string;
-  let testIModel: ReusableIModelMetadata;
+  let testIModelForRead: ReusableIModelMetadata;
+  let testDownloadPath = path.join(__dirname, "../lib/testDownloads");
 
   before(async () => {
     const iModelsClient = new IModelsClient(new TestClientOptions());
@@ -22,18 +25,22 @@ describe("BackendiModelsAccess", () => {
     backendIModelsAccess = new BackendIModelsAccess(iModelsClient);
     accessToken = `${(await authorization()).scheme} ${(await authorization()).token}`;
     projectId = await TestProjectProvider.getProjectId();
-    testIModel = await ReusableTestIModelProvider.getOrCreate({
+    testIModelForRead = await ReusableTestIModelProvider.getOrCreate({
       iModelsClient,
       authorization,
       projectId
     });
   });
 
+  afterEach(() => {
+    cleanupDirectory(testDownloadPath);
+  });
+
   it("should get current user briefcase ids", async () => {
     // Arrange
     const getMyBriefcaseIdsParams: IModelIdArg = {
       accessToken,
-      iModelId: testIModel.id
+      iModelId: testIModelForRead.id
     };
 
     // Act
@@ -42,6 +49,38 @@ describe("BackendiModelsAccess", () => {
     // Assert
     expect(briefcaseIds.length).to.equal(1);
     const briefcaseId = briefcaseIds[0];
-    expect(briefcaseId).to.equal(testIModel.briefcase.id);
+    expect(briefcaseId).to.equal(testIModelForRead.briefcase.id);
+  });
+
+  it("should download changesets", async () => {
+    // Arrange
+    const downloadChangesetsParams: ChangesetRangeArg & { targetDir: LocalDirName } = {
+      accessToken,
+      iModelId: testIModelForRead.id,
+      targetDir: testDownloadPath
+    };
+
+    // Act
+    const downloadedChangesets: ChangesetFileProps[] = await backendIModelsAccess.downloadChangesets(downloadChangesetsParams);
+
+    // Assert
+    expect(downloadedChangesets.length).to.be.equal(TestIModelFileProvider.changesets.length);
+    for (let i = 0; i < downloadedChangesets.length; i++) {
+      const downloadedChangeset = downloadedChangesets[i];
+      const expectedChangesetFile = TestIModelFileProvider.changesets[i];
+
+      expect(fs.existsSync(downloadedChangeset.pathname)).to.equal(true);
+      expect(downloadedChangeset.id).to.be.equal(expectedChangesetFile.id);
+      expect(downloadedChangeset.index).to.be.equal(expectedChangesetFile.index);
+      expect(downloadedChangeset.parentId).to.be.equal(expectedChangesetFile.parentId);
+      expect(downloadedChangeset.description).to.be.equal(expectedChangesetFile.description);
+      expect(downloadedChangeset.briefcaseId).to.be.equal(testIModelForRead.briefcase.id);
+      expect(downloadedChangeset.size).to.be.equal(fs.statSync(expectedChangesetFile.filePath).size);
+
+      if (expectedChangesetFile.containingChanges === ContainingChanges.Schema)
+        expect(downloadedChangeset.changesType).to.be.equal(ChangesetType.Schema);
+      else
+        expect(downloadedChangeset.changesType).to.be.equal(ChangesetType.Regular);
+    }
   });
 });

--- a/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
+++ b/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
@@ -9,14 +9,14 @@ import { BriefcaseId, ChangesetFileProps, ChangesetType, LocalDirName } from "@i
 import { BackendIModelsAccess } from "@itwin/imodels-access-backend";
 import { expect } from "chai";
 import { ContainingChanges, IModelsClient } from "@itwin/imodels-client-authoring";
-import { cleanupDirectory, Config, ReusableIModelMetadata, ReusableTestIModelProvider, TestAuthorizationProvider, TestClientOptions, TestIModelFileProvider, TestProjectProvider } from "@itwin/imodels-clients-tests";
+import { Config, ReusableIModelMetadata, ReusableTestIModelProvider, TestAuthorizationProvider, TestClientOptions, TestIModelFileProvider, TestProjectProvider, cleanupDirectory } from "@itwin/imodels-clients-tests";
 
 describe("BackendiModelsAccess", () => {
   let backendIModelsAccess: BackendIModelsAccess;
   let accessToken: string;
   let projectId: string;
   let testIModelForRead: ReusableIModelMetadata;
-  let testDownloadPath = path.join(__dirname, "../lib/testDownloads");
+  const testDownloadPath = path.join(__dirname, "../lib/testDownloads");
 
   before(async () => {
     const iModelsClient = new IModelsClient(new TestClientOptions());

--- a/tests/imodels-clients-tests/src/assets/test-imodel/changesets.json
+++ b/tests/imodels-clients-tests/src/assets/test-imodel/changesets.json
@@ -14,7 +14,7 @@
       "fileName": "7caef8ab5afcd99c9e618fb37978c3a03d0409c7.cs",
       "index": 2,
       "parentId": "a1ecbdc8c4f6173004f9f881914a57c5511a362b",
-      "containingChanges": 0
+      "containingChanges": 1
     },
     {
       "id": "a587345859410ce5c2811c7c558d4578938efa00",
@@ -22,7 +22,7 @@
       "fileName": "a587345859410ce5c2811c7c558d4578938efa00.cs",
       "index": 3,
       "parentId": "7caef8ab5afcd99c9e618fb37978c3a03d0409c7",
-      "containingChanges": 0
+      "containingChanges": 2
     },
     {
       "id": "13a61888798b687d41f7c748d7414b428766281f",
@@ -30,7 +30,7 @@
       "fileName": "13a61888798b687d41f7c748d7414b428766281f.cs",
       "index": 4,
       "parentId": "a587345859410ce5c2811c7c558d4578938efa00",
-      "containingChanges": 0
+      "containingChanges": 4
     },
     {
       "id": "ff89478c753c451bfa87c1fd83815531ad9ddbd3",
@@ -38,7 +38,7 @@
       "fileName": "ff89478c753c451bfa87c1fd83815531ad9ddbd3.cs",
       "index": 5,
       "parentId": "13a61888798b687d41f7c748d7414b428766281f",
-      "containingChanges": 0
+      "containingChanges": 6
     },
     {
       "id": "e306ddb1fa77b666b8623f9a3410a3dc6edfaac5",
@@ -46,7 +46,7 @@
       "fileName": "e306ddb1fa77b666b8623f9a3410a3dc6edfaac5.cs",
       "index": 6,
       "parentId": "ff89478c753c451bfa87c1fd83815531ad9ddbd3",
-      "containingChanges": 0
+      "containingChanges": 8
     },
     {
       "id": "fe693b7840de83bfa9b325c08740a9ea2b8512ae",
@@ -54,7 +54,7 @@
       "fileName": "fe693b7840de83bfa9b325c08740a9ea2b8512ae.cs",
       "index": 7,
       "parentId": "e306ddb1fa77b666b8623f9a3410a3dc6edfaac5",
-      "containingChanges": 0
+      "containingChanges": 10
     },
     {
       "id": "16de92c44ea1b8c984b55414e90d68ff98846f25",
@@ -62,7 +62,7 @@
       "fileName": "16de92c44ea1b8c984b55414e90d68ff98846f25.cs",
       "index": 8,
       "parentId": "fe693b7840de83bfa9b325c08740a9ea2b8512ae",
-      "containingChanges": 0
+      "containingChanges": 12
     },
     {
       "id": "9913e22a00eb1086c6be0ed3d09e692738fdfe9d",
@@ -70,7 +70,7 @@
       "fileName": "9913e22a00eb1086c6be0ed3d09e692738fdfe9d.cs",
       "index": 9,
       "parentId": "16de92c44ea1b8c984b55414e90d68ff98846f25",
-      "containingChanges": 0
+      "containingChanges": 14
     },
     {
       "id": "199ea0554609681955a9bccbe4bcd8c89eafefdf",
@@ -78,7 +78,7 @@
       "fileName": "199ea0554609681955a9bccbe4bcd8c89eafefdf.cs",
       "index": 10,
       "parentId": "9913e22a00eb1086c6be0ed3d09e692738fdfe9d",
-      "containingChanges": 0
+      "containingChanges": 16
     }
   ]
 }


### PR DESCRIPTION
In this PR:
- Fixed an issue where the `ClientToPlatformAdapter.toChangesetType` would throw an error if it encountered an value that is not 0 or 1. This is incorrect because iModels API supports more values for changeset type than the platform defined enum does so we should not throw an error but handle values that are not supported in the `ChangesetType` enum. For now for all the values received from the API that are not equal to 1 (`ChangesetType.Schema`) we return 0 (`ChangesetType.Regular`).
- Modified reusable iModel metadata to have changesets with different `containingChanges` property values.
- Added an integration test for `BackendIModelsAccess` to test the changeset download.