### PR TITLE
Changeset operation documentation

### DIFF
--- a/clients/imodels-client-authoring/src/base/interfaces/CommonInterfaces.ts
+++ b/clients/imodels-client-authoring/src/base/interfaces/CommonInterfaces.ts
@@ -2,10 +2,15 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+
+/** Common properties for all downloaded files. */
 export interface DownloadedFileProps {
+  /** Absolute path of the downloaded file. */
   filePath: string;
 }
 
+/** Common parameters for all download operations. */
 export interface TargetDirectoryParam {
+  /** Absolute path of the target directory. If directory does not exist the file download operation creates it. */
   targetDirectoryPath: string;
 }

--- a/clients/imodels-client-authoring/src/base/interfaces/CommonInterfaces.ts
+++ b/clients/imodels-client-authoring/src/base/interfaces/CommonInterfaces.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-/** Common properties for all downloaded files. */
+/** Common properties of all downloaded files. */
 export interface DownloadedFileProps {
   /** Absolute path of the downloaded file. */
   filePath: string;

--- a/clients/imodels-client-authoring/src/base/interfaces/apiEntities/ChangesetInterfaces.ts
+++ b/clients/imodels-client-authoring/src/base/interfaces/apiEntities/ChangesetInterfaces.ts
@@ -5,4 +5,5 @@
 import { Changeset } from "@itwin/imodels-client-management";
 import { DownloadedFileProps } from "../CommonInterfaces";
 
+/** Changeset metadata along with the downloaded file path. */
 export type DownloadedChangeset = Changeset & DownloadedFileProps;

--- a/clients/imodels-client-authoring/src/operations/changeset/ChangesetOperationParams.ts
+++ b/clients/imodels-client-authoring/src/operations/changeset/ChangesetOperationParams.ts
@@ -7,12 +7,12 @@ import { TargetDirectoryParam } from "../../base";
 
 /** Properties that should be specified when creating a new Changeset. */
 export interface ChangesetPropertiesForCreate {
-  /** Changeset id. Changeset id must not be an empty or whitespace string. */
+  /** Id of the Changeset. Changeset id must not be an empty or whitespace string. */
   id: string;
   /** Changeset description. Changeset description must not exceed allowed 255 characters. */
   description?: string;
   /**
-   * Parent Changeset id. Parent Changeset id must not be an empty or whitespace string except for when creating the
+   * Id of the parent Changeset. Parent Changeset id must not be an empty or whitespace string except for when creating the
    * first Changeset - in such case it can be `undefined`.
    */
   parentId?: string;

--- a/clients/imodels-client-authoring/src/operations/changeset/ChangesetOperationParams.ts
+++ b/clients/imodels-client-authoring/src/operations/changeset/ChangesetOperationParams.ts
@@ -13,7 +13,7 @@ export interface ChangesetPropertiesForCreate {
   description?: string;
   /**
    * Parent Changeset id. Parent Changeset id must not be an empty or whitespace string except for when creating the
-   * first Changeset - in such case it can be skipped or set to an empty string.
+   * first Changeset - in such case it can be `undefined`.
    */
   parentId?: string;
   /** Briefcase id that is creating the Changeset. Briefcase id must be greater than 0. */

--- a/clients/imodels-client-authoring/src/operations/changeset/ChangesetOperationParams.ts
+++ b/clients/imodels-client-authoring/src/operations/changeset/ChangesetOperationParams.ts
@@ -29,7 +29,7 @@ export interface ChangesetPropertiesForCreate {
 
 /** Parameters for create Changeset operation. */
 export interface CreateChangesetParams extends IModelScopedOperationParams {
-  /** Properties for the new Changeset. */
+  /** Properties of the new Changeset. */
   changesetProperties: ChangesetPropertiesForCreate;
 }
 

--- a/clients/imodels-client-authoring/src/operations/changeset/ChangesetOperationParams.ts
+++ b/clients/imodels-client-authoring/src/operations/changeset/ChangesetOperationParams.ts
@@ -2,22 +2,39 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { ContainingChanges, GetChangesetListUrlParams, GetSingleChangesetParams, IModelScopedOperationParams } from "@itwin/imodels-client-management";
+import { ContainingChanges, GetChangesetListParams, GetSingleChangesetParams, IModelScopedOperationParams } from "@itwin/imodels-client-management";
 import { TargetDirectoryParam } from "../../base";
 
+/** Properties that should be specified when creating a new Changeset. */
 export interface ChangesetPropertiesForCreate {
+  /** Changeset id. Changeset id must not be an empty or whitespace string. */
   id: string;
+  /** Changeset description. Changeset description must not exceed allowed 255 characters. */
   description?: string;
+  /**
+   * Parent Changeset id. Parent Changeset id must not be an empty or whitespace string except for when creating the
+   * first Changeset - in such case it can be skipped or set to an empty string.
+   */
   parentId?: string;
+  /** Briefcase id that is creating the Changeset. Briefcase id must be greater than 0. */
   briefcaseId: number;
+  /**
+   * Type of changes that the Changeset contains. This property is flag value, therefore all change types, except
+   * Schema, can be combined See {@link ContainingChanges}.
+   */
   containingChanges?: ContainingChanges;
+  /** Absolute path of the Changeset file. The file must exist. */
   filePath: string;
 }
 
+/** Parameters for create Changeset operation. */
 export interface CreateChangesetParams extends IModelScopedOperationParams {
+  /** Properties for the new Changeset. */
   changesetProperties: ChangesetPropertiesForCreate;
 }
 
+/** Parameters for single Changeset download operation. */
 export type DownloadSingleChangesetParams = GetSingleChangesetParams & TargetDirectoryParam;
 
-export type DownloadChangesetListParams = IModelScopedOperationParams & TargetDirectoryParam & { urlParams?: Omit<GetChangesetListUrlParams, "$skip"> };
+/** Parameters for Changeset list download operation. */
+export type DownloadChangesetListParams = GetChangesetListParams & TargetDirectoryParam;

--- a/clients/imodels-client-authoring/src/operations/changeset/ChangesetOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/changeset/ChangesetOperations.ts
@@ -9,6 +9,14 @@ import { ChangesetPropertiesForCreate, CreateChangesetParams, DownloadChangesetL
 import { LimitedParallelQueue } from "./LimitedParallelQueue";
 
 export class ChangesetOperations<TOptions extends OperationOptions> extends ManagementChangesetOperations<TOptions>{
+  /**
+   * Creates a Changeset. Wraps the {@link https://developer.bentley.com/apis/imodels/operations/create-imodel-changeset/
+   * Create iModel Changeset} operation from iModels API. Internally it creates a Changeset instance, uploads the Changeset
+   * file and confirms Changeset file upload. The execution of this method depends on the Changeset file size - the larger
+   * the file, the longer the upload will take.
+   * @param {CreateChangesetParams} params parameters for this operation. See {@link CreateChangesetParams}.
+   * @returns newly created Changeset. See {@link Changeset}.
+   */
   public async create(params: CreateChangesetParams): Promise<Changeset> {
     const createChangesetBody = this.getCreateChangesetRequestBody(params.changesetProperties);
     const createChangesetResponse = await this.sendPostRequest<ChangesetResponse>({
@@ -30,11 +38,29 @@ export class ChangesetOperations<TOptions extends OperationOptions> extends Mana
     return confirmUploadResponse.changeset;
   }
 
+  /**
+   * Downloads a single Changeset idetified by either index or id. If an error occurs when downloading a Changeset
+   * this operation queries the failed Changeset by id and retries the download once. If the Changeset file with
+   * the expected name already exists in the target directory and the file size matches the one expected the Changeset
+   * is not downloaded again.
+   * @param {DownloadSingleChangesetParams} params parameters for this operation. See {@link DownloadSingleChangesetParams}.
+   * @returns downloaded Changeset. See {@link DownloadedChangeset}.
+   */
   public async downloadSingle(params: DownloadSingleChangesetParams): Promise<DownloadedChangeset> {
     const changeset: Changeset = await this.querySingleInternal(params);
     return this.downloadSingleChangeset({ ...params, changeset });
   }
 
+  /**
+   * Downloads Changeset list. Internally the method uses {@link ChangesetOperations.getRepresentationList} to query the
+   * Changeset collection so this operation supports most of the the same url parameters to specify what Changesets to
+   * download. One of the most common properties used are `afterIndex` and `lastIndex` to download Changeset range. This
+   * operation downloads Changesets in parallel. If an error occurs when downloading a Changeset this operation queries
+   * the failed Changeset by id and retries the download once. If the Changeset file with the expected name already
+   * exists in the target directory and the file size matches the one expected the Changeset is not downloaded again.
+   * @param {DownloadChangesetListParams} params parameters for this operation. See {@link DownloadChangesetListParams}.
+   * @returns downloaded Changeset metadata along with the downloaded file path. See {@link DownloadedChangeset}.
+   */
   public async downloadList(params: DownloadChangesetListParams): Promise<DownloadedChangeset[]> {
     let result: DownloadedChangeset[] = [];
 

--- a/clients/imodels-client-authoring/src/operations/changeset/ChangesetOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/changeset/ChangesetOperations.ts
@@ -39,7 +39,7 @@ export class ChangesetOperations<TOptions extends OperationOptions> extends Mana
   }
 
   /**
-   * Downloads a single Changeset idetified by either index or id. If an error occurs when downloading a Changeset
+   * Downloads a single Changeset identified by either index or id. If an error occurs when downloading a Changeset
    * this operation queries the failed Changeset by id and retries the download once. If the Changeset file with
    * the expected name already exists in the target directory and the file size matches the one expected the Changeset
    * is not downloaded again.

--- a/clients/imodels-client-authoring/src/operations/imodel/IModelOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/imodel/IModelOperations.ts
@@ -21,9 +21,10 @@ export class IModelOperations<TOptions extends OperationOptions> extends Managem
   /**
   * Creates an iModel from Baseline file with specified properties. Wraps the
   * {@link https://developer.bentley.com/apis/imodels/operations/create-imodel/ Create iModel} operation from iModels API.
-  * Internally it creates the iModel instace, uploads the Baseline file, confirms Baseline
-  * file upload and then repeatedly queries the Baseline file state until the iModel is initialized. The execution of this method
-  * can take up to several minutes due to waiting for initialization to complete.
+  * Internally it creates an iModel instace, uploads the Baseline file, confirms Baseline
+  * file upload and then repeatedly queries the Baseline file state until the iModel is initialized. The execution of
+  * this method can take up to several minutes due to waiting for initialization to complete. It also depends on the
+  * Baseline file size - the larger the file, the longer the upload will take.
   * @param {CreateiModelFromBaselineParams} params parameters for this operation. See {@link CreateiModelFromBaselineParams}.
   * @returns {Promise<iModel>} newly created iModel. See {@link iModel}.
   * @throws an error that implements `iModelsError` interface with code `iModelsErrorCode.BaselineFileInitializationFailed` if Baseline file initialization failed

--- a/clients/imodels-client-management/src/base/interfaces/CommonInterfaces.ts
+++ b/clients/imodels-client-management/src/base/interfaces/CommonInterfaces.ts
@@ -103,7 +103,7 @@ export interface CollectionLinks {
   next: Link | null;
 }
 
-/** Common properties for all entity list page responses. */
+/** Common properties of all entity list page responses. */
 export interface CollectionResponse {
   /** Common entity list page response links. See {@link CollectionLinks}. */
   _links: CollectionLinks;

--- a/clients/imodels-client-management/src/base/interfaces/apiEntities/ChangesetInterfaces.ts
+++ b/clients/imodels-client-management/src/base/interfaces/apiEntities/ChangesetInterfaces.ts
@@ -37,7 +37,7 @@ export interface SynchronizationInfo {
   changedFiles: string[];
 }
 
-/** DTO for links that belong to Changeset entity returned from iModels API. */
+/** DTO to hold links that belong to Changeset entity returned from iModels API. */
 export interface ChangesetLinks {
   /** Link to upload the Changeset file. Points to file storage. */
   upload: Link;
@@ -105,17 +105,17 @@ export interface Changeset extends MinimalChangeset {
   getCurrentOrPrecedingCheckpoint: () => Promise<Checkpoint | undefined>;
 }
 
-/** DTO for single Changeset API response. */
+/** DTO to hold a single Changeset API response. */
 export interface ChangesetResponse {
   changeset: Changeset;
 }
 
-/** DTO for minimal Changeset list API response. */
+/** DTO to hold minimal Changeset list API response. */
 export interface MinimalChangesetsResponse extends CollectionResponse {
   changesets: MinimalChangeset[];
 }
 
-/** DTO for representation Changeset list API response. */
+/** DTO to hold representation Changeset list API response. */
 export interface ChangesetsResponse extends CollectionResponse {
   changesets: Changeset[];
 }

--- a/clients/imodels-client-management/src/base/interfaces/apiEntities/ChangesetInterfaces.ts
+++ b/clients/imodels-client-management/src/base/interfaces/apiEntities/ChangesetInterfaces.ts
@@ -33,7 +33,7 @@ export interface Application {
 
 /** Synchronization information. */
 export interface SynchronizationInfo {
-  /** List of files that were processed by the synchronization process. */
+  /** List of files that were processed by the synchronization. */
   changedFiles: string[];
 }
 
@@ -71,7 +71,7 @@ export interface MinimalChangeset {
   parentId: string;
   /** Id of the user who created the Changeset. */
   creatorId: string;
-  /** Datetime string of when the Changeset was created, more specifically - when the Changeset instance was created. */
+  /** Datetime string of when the Changeset was created. */
   pushDateTime: string;
   /** Changeset state. See {@link ChangesetState}. */
   state: ChangesetState;

--- a/clients/imodels-client-management/src/base/interfaces/apiEntities/ChangesetInterfaces.ts
+++ b/clients/imodels-client-management/src/base/interfaces/apiEntities/ChangesetInterfaces.ts
@@ -6,67 +6,116 @@ import { CollectionResponse, Link } from "../CommonInterfaces";
 import { Checkpoint } from "./CheckpointInterfaces";
 import { NamedVersion } from "./NamedVersionInterfaces";
 
+/** Possible Changeset states. */
 export enum ChangesetState {
+  /** Changeset instance is created but file is not uploaded. The Changeset creation is not complete. */
   WaitingForFile = "waitingForFile",
+  /** The Changeset file is uploaded and creation is complete. */
   FileUploaded = "fileUploaded"
 }
 
+/** Flags that describe Changeset contents. */
 export enum ContainingChanges {
-  Regular           = 0,
-  Schema            = 1 << 0,
-  Definition        = 1 << 1,
-  SpatialData       = 1 << 2,
+  Regular = 0,
+  Schema = 1 << 0,
+  Definition = 1 << 1,
+  SpatialData = 1 << 2,
   SheetsAndDrawings = 1 << 3,
-  ViewsAndModels    = 1 << 4,
-  GlobalProperties  = 1 << 5
+  ViewsAndModels = 1 << 4,
+  GlobalProperties = 1 << 5
 }
 
+/** Application information. */
 export interface Application {
+  /** Application name. */
   name: string;
 }
 
+/** Synchronization information. */
 export interface SynchronizationInfo {
+  /** List of files that were processed by the synchronization process. */
   changedFiles: string[];
 }
 
+/** DTO for links that belong to Changeset entity returned from iModels API. */
 export interface ChangesetLinks {
+  /** Link to upload the Changeset file. Points to file storage. */
   upload: Link;
+  /** Link to download the Changeset file. Points to file storage. */
   download: Link;
+  /**
+   * Link to confirm the Changeset file upload and complete the creation process. Points to a specific
+   * Changeset in iModels API.
+   */
   complete: Link;
+  /** Link to a Named Version created on the Chageset. Points to a specific Named Version in iModels API. */
   namedVersion?: Link;
+  /**
+   * Link to a Checkpoint that is created on a current or preceding Changeset. Points to a specific Checkpoint
+   * in iModels API.
+   * */
   currentOrPrecedingCheckpoint?: Link;
 }
 
+/** Minimal representation of a Changeset. */
 export interface MinimalChangeset {
+  /** Changeset id. */
   id: string;
+  /** Changeset display name. */
   displayName: string;
+  /** Changeset description. */
   description: string;
+  /** Changeset index. */
   index: number;
+  /** Changeset parent id. Equals to empty string if the Changeset is first in sequence. */
   parentId: string;
+  /** Id of the user who created the Changeset. */
   creatorId: string;
+  /** Datetime string of when the Changeset was created, more specifically - when the Changeset instance was created. */
   pushDateTime: string;
+  /** Changeset state. See {@link ChangesetState}. */
   state: ChangesetState;
+  /** Describes what type of changes the Changeset contains. See {@link ContainingChanges}. */
   containingChanges: ContainingChanges;
+  /** Size of the Changeset file in bytes. */
   fileSize: number;
+  /** Briefcase id that was used to create the Changeset. */
   briefcaseId: number;
 }
 
+/** Full representation of a Changeset. */
 export interface Changeset extends MinimalChangeset {
+  /** Information about the application that created the Changeset. */
   application: Application | null;
+  /** Information about synchronization process that created the Changeset. */
   synchronizationInfo: SynchronizationInfo | null;
+  /** Changeset links. */
   _links: ChangesetLinks;
+  /**
+   * Function to query Named Version for the current Changeset. If the Changeset does not have a Named Version the
+   * function returns `undefined`. This function reuses authorization information passed to specific Changeset
+   * operation that originally queried the Changeset from API.
+   */
   getNamedVersion: () => Promise<NamedVersion | undefined>;
+  /**
+   * Function to query Checkpoint for the current or preceding Changeset. If neither the current Changeset nor any of
+   * the preceding ones have a Checkpoint generated the function returns `undefined`. This function reuses authorization
+   * information passed to specific Changeset operation that originally queried the Changeset from API.
+   */
   getCurrentOrPrecedingCheckpoint: () => Promise<Checkpoint | undefined>;
 }
 
+/** DTO for single Changeset API response. */
 export interface ChangesetResponse {
   changeset: Changeset;
 }
 
+/** DTO for minimal Changeset list API response. */
 export interface MinimalChangesetsResponse extends CollectionResponse {
   changesets: MinimalChangeset[];
 }
 
+/** DTO for representation Changeset list API response. */
 export interface ChangesetsResponse extends CollectionResponse {
   changesets: Changeset[];
 }

--- a/clients/imodels-client-management/src/base/interfaces/apiEntities/ChangesetInterfaces.ts
+++ b/clients/imodels-client-management/src/base/interfaces/apiEntities/ChangesetInterfaces.ts
@@ -39,9 +39,9 @@ export interface SynchronizationInfo {
 
 /** DTO to hold links that belong to Changeset entity returned from iModels API. */
 export interface ChangesetLinks {
-  /** Link to upload the Changeset file. Points to file storage. */
+  /** Link where to upload the Changeset file. Link points to a remote storage. */
   upload: Link;
-  /** Link to download the Changeset file. Points to file storage. */
+  /** Link from where to download the Changeset file. Link points to a remote storage. */
   download: Link;
   /**
    * Link to confirm the Changeset file upload and complete the creation process. Points to a specific
@@ -59,15 +59,15 @@ export interface ChangesetLinks {
 
 /** Minimal representation of a Changeset. */
 export interface MinimalChangeset {
-  /** Changeset id. */
+  /** Id of the Changeset. */
   id: string;
   /** Changeset display name. */
   displayName: string;
   /** Changeset description. */
   description: string;
-  /** Changeset index. */
+  /** Index of the Changeset. */
   index: number;
-  /** Changeset parent id. Equals to empty string if the Changeset is first in sequence. */
+  /** Id of the parent Changeset. Equals to empty string if the Changeset is first in sequence. */
   parentId: string;
   /** Id of the user who created the Changeset. */
   creatorId: string;

--- a/clients/imodels-client-management/src/base/interfaces/apiEntities/ChangesetInterfaces.ts
+++ b/clients/imodels-client-management/src/base/interfaces/apiEntities/ChangesetInterfaces.ts
@@ -16,13 +16,13 @@ export enum ChangesetState {
 
 /** Flags that describe Changeset contents. */
 export enum ContainingChanges {
-  Regular = 0,
-  Schema = 1 << 0,
-  Definition = 1 << 1,
-  SpatialData = 1 << 2,
+  Regular           = 0,
+  Schema            = 1 << 0,
+  Definition        = 1 << 1,
+  SpatialData       = 1 << 2,
   SheetsAndDrawings = 1 << 3,
-  ViewsAndModels = 1 << 4,
-  GlobalProperties = 1 << 5
+  ViewsAndModels    = 1 << 4,
+  GlobalProperties  = 1 << 5
 }
 
 /** Application information. */

--- a/clients/imodels-client-management/src/base/interfaces/apiEntities/ChangesetInterfaces.ts
+++ b/clients/imodels-client-management/src/base/interfaces/apiEntities/ChangesetInterfaces.ts
@@ -48,7 +48,7 @@ export interface ChangesetLinks {
    * Changeset in iModels API.
    */
   complete: Link;
-  /** Link to a Named Version created on the Chageset. Points to a specific Named Version in iModels API. */
+  /** Link to a Named Version created on the Changeset. Points to a specific Named Version in iModels API. */
   namedVersion?: Link;
   /**
    * Link to a Checkpoint that is created on a current or preceding Changeset. Points to a specific Checkpoint

--- a/clients/imodels-client-management/src/operations/changeset/ChangesetOperationParams.ts
+++ b/clients/imodels-client-management/src/operations/changeset/ChangesetOperationParams.ts
@@ -4,17 +4,34 @@
  *--------------------------------------------------------------------------------------------*/
 import { Changeset, CollectionRequestParams, IModelScopedOperationParams, OrderBy } from "../../base";
 
+/**
+ * Changeset entity properties that are supported in $orderBy url parameter which specifies by what property
+ * entities are ordered in a collection.
+ */
 export enum ChangesetOrderByProperty {
   Index = "index"
 }
 
+/** Url parameters supported in Changeset list query. */
 export interface GetChangesetListUrlParams extends CollectionRequestParams {
+  /** Specifies in what order should entities be returned. See {@link OrderBy}. */
   $orderBy?: OrderBy<Changeset, ChangesetOrderByProperty>;
+  /**
+   * Filters Changesets which have an index greater than specified in `afterIndex` property. For example,
+   * `afterIndex: 5` will return all Changesets that have an index equal or greater than 6. This option can be
+   * combined with {@link GetChangesetListUrlParams.lastIndex} option to query a specific Changeset range.
+   */
   afterIndex?: number;
+  /** Filters Changesets which have an index less than or equal than specified in `lastIndex` property. For example,
+   * `lastIndex: 10` will return all Changesets that have an index less than or equal to 10. This option can be
+   * combined with {@link GetChangesetListUrlParams.afterIndex} option to query a specific Changeset range.
+   */
   lastIndex?: number;
 }
 
+/** Parameters for get Changeset list operation. */
 export interface GetChangesetListParams extends IModelScopedOperationParams {
+  /** Parameters that will be appended to the entity list request url that will narrow down or alter the results. */
   urlParams?: GetChangesetListUrlParams;
 }
 
@@ -28,6 +45,11 @@ interface ChangesetIndexParam {
   changesetIndex: number;
 }
 
+/**
+ * Supported Changeset identifiers. Only one of the following properties can be specified to identify
+ * a single Changeset: `changesetId`, `changesetIndex`.
+ */
 export type ChangesetIdOrIndex = ChangesetIdParam | ChangesetIndexParam;
 
+/** Parameters for get single Changeset operation. */
 export type GetSingleChangesetParams = IModelScopedOperationParams & ChangesetIdOrIndex;

--- a/clients/imodels-client-management/src/operations/changeset/ChangesetOperationParams.ts
+++ b/clients/imodels-client-management/src/operations/changeset/ChangesetOperationParams.ts
@@ -31,7 +31,7 @@ export interface GetChangesetListUrlParams extends CollectionRequestParams {
 
 /** Parameters for get Changeset list operation. */
 export interface GetChangesetListParams extends IModelScopedOperationParams {
-  /** Parameters that will be appended to the entity list request url that will narrow down or alter the results. */
+  /** Parameters that will be appended to the entity list request url that will narrow down the results. */
   urlParams?: GetChangesetListUrlParams;
 }
 

--- a/clients/imodels-client-management/src/operations/changeset/ChangesetOperations.ts
+++ b/clients/imodels-client-management/src/operations/changeset/ChangesetOperations.ts
@@ -24,7 +24,8 @@ export class ChangesetOperations<TOptions extends OperationOptions> extends Oper
    * {@link https://developer.bentley.com/apis/imodels/operations/get-imodel-changesets/ Get iModel Changesets}
    * operation from iModels API.
    * @param {GetChangesetListParams} params parameters for this operation. See {@link GetChangesetListParams}.
-   * @returns {EntityListIterator<MinimalChangeset>} iterator for Changeset list. See {@link MinimalChangeset}.
+   * @returns {EntityListIterator<MinimalChangeset>} iterator for Changeset list. See {@link EntityListIterator},
+   * {@link MinimalChangeset}.
    */
   public getMinimalList(params: GetChangesetListParams): EntityListIterator<MinimalChangeset> {
     return new EntityListIteratorImpl(async () => this.getEntityCollectionPage<MinimalChangeset>({
@@ -41,7 +42,8 @@ export class ChangesetOperations<TOptions extends OperationOptions> extends Oper
    * {@link https://developer.bentley.com/apis/imodels/operations/get-imodel-changesets/ Get iModel Changesets}
    * operation from iModels API.
    * @param {GetChangesetListParams} params parameters for this operation. See {@link GetChangesetListParams}.
-   * @returns {EntityListIterator<Changeset>} iterator for Changeset list. See {@link Changeset}.
+   * @returns {EntityListIterator<Changeset>} iterator for Changeset list. See {@link EntityListIterator},
+   * {@link Changeset}.
    */
   public getRepresentationList(params: GetChangesetListParams): EntityListIterator<Changeset> {
     const entityCollectionAccessor = (response: unknown) => {

--- a/clients/imodels-client-management/src/operations/changeset/ChangesetOperations.ts
+++ b/clients/imodels-client-management/src/operations/changeset/ChangesetOperations.ts
@@ -59,7 +59,7 @@ export class ChangesetOperations<TOptions extends OperationOptions> extends Oper
   }
 
   /**
-   * Gets a single Changeset idetified by either index or id. This method returns a Changeset in its full
+   * Gets a single Changeset identified by either index or id. This method returns a Changeset in its full
    * representation. Wraps the {@link https://developer.bentley.com/apis/imodels/operations/get-imodel-changeset-details/
    * Get iModel Changeset} operation from iModels API.
    * @param {GetSingleChangesetParams} params parameters for this operation. See {@link GetSingleChangesetParams}.

--- a/clients/imodels-client-management/src/operations/changeset/ChangesetOperations.ts
+++ b/clients/imodels-client-management/src/operations/changeset/ChangesetOperations.ts
@@ -18,6 +18,14 @@ export class ChangesetOperations<TOptions extends OperationOptions> extends Oper
     super(options);
   }
 
+  /**
+   * Gets Changesets for a specific iModel. This method returns Changesets in their minimal representation. The
+   * returned iterator internally queries entities in pages. Wraps the
+   * {@link https://developer.bentley.com/apis/imodels/operations/get-imodel-changesets/ Get iModel Changesets}
+   * operation from iModels API.
+   * @param {GetChangesetListParams} params parameters for this operation. See {@link GetChangesetListParams}.
+   * @returns {EntityListIterator<MinimalChangeset>} iterator for Changeset list. See {@link MinimalChangeset}.
+   */
   public getMinimalList(params: GetChangesetListParams): EntityListIterator<MinimalChangeset> {
     return new EntityListIteratorImpl(async () => this.getEntityCollectionPage<MinimalChangeset>({
       authorization: params.authorization,
@@ -27,6 +35,14 @@ export class ChangesetOperations<TOptions extends OperationOptions> extends Oper
     }));
   }
 
+  /**
+   * Gets Changesets for a specific iModel. This method returns Changesets in their full representation. The returned
+   * iterator internally queries entities in pages. Wraps the
+   * {@link https://developer.bentley.com/apis/imodels/operations/get-imodel-changesets/ Get iModel Changesets}
+   * operation from iModels API.
+   * @param {GetChangesetListParams} params parameters for this operation. See {@link GetChangesetListParams}.
+   * @returns {EntityListIterator<Changeset>} iterator for Changeset list. See {@link Changeset}.
+   */
   public getRepresentationList(params: GetChangesetListParams): EntityListIterator<Changeset> {
     const entityCollectionAccessor = (response: unknown) => {
       const changesets = (response as ChangesetsResponse).changesets;
@@ -42,6 +58,13 @@ export class ChangesetOperations<TOptions extends OperationOptions> extends Oper
     }));
   }
 
+  /**
+   * Gets a single Changeset idetified by either index or id. This method returns a Changeset in its full
+   * representation. Wraps the {@link https://developer.bentley.com/apis/imodels/operations/get-imodel-changeset-details/
+   * Get iModel Changeset} operation from iModels API.
+   * @param {GetSingleChangesetParams} params parameters for this operation. See {@link GetSingleChangesetParams}.
+   * @returns {Promise<Changeset>} a Changeset with specified id or index. See {@link Changeset}.
+   */
   public async getSingle(params: GetSingleChangesetParams): Promise<Changeset> {
     const changeset: Changeset = await this.querySingleInternal(params);
     const result: Changeset = this.appendRelatedEntityCallbacks(params.authorization, changeset);

--- a/clients/imodels-client-management/src/operations/imodel/IModelOperationParams.ts
+++ b/clients/imodels-client-management/src/operations/imodel/IModelOperationParams.ts
@@ -48,7 +48,7 @@ export interface IModelProperties {
 
 /** Parameters for create iModel operation. */
 export interface CreateEmptyIModelParams extends AuthorizationParam {
-  /** Properties for the new iModel. */
+  /** Properties of the new iModel. */
   iModelProperties: IModelProperties;
 }
 


### PR DESCRIPTION
In this PR:
- Added documentation for Changeset operations in both @itwin/imodels-client-management and @itwin/imodels-client-authoring packages
- Changed `DownloadChangesetListParams` interface to allow `$skip` url parameter. This parameter is not very useful for `ChangesetOperations.downloadList` method but it unifies and simplifies the interface, now both `ChangesetOperations.downloadSingle` and `ChangesetOperations.downloadList` operations simply extend their corresponding entity query operation params with no exceptions.