### PR TITLE
Single Changeset download bug fix

### DIFF
--- a/clients/imodels-client-authoring/src/operations/changeset/ChangesetOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/changeset/ChangesetOperations.ts
@@ -47,6 +47,7 @@ export class ChangesetOperations<TOptions extends OperationOptions> extends Mana
    * @returns downloaded Changeset. See {@link DownloadedChangeset}.
    */
   public async downloadSingle(params: DownloadSingleChangesetParams): Promise<DownloadedChangeset> {
+    this._options.fileHandler.createDirectory(params.targetDirectoryPath);
     const changeset: Changeset = await this.querySingleInternal(params);
     return this.downloadSingleChangeset({ ...params, changeset });
   }
@@ -62,10 +63,9 @@ export class ChangesetOperations<TOptions extends OperationOptions> extends Mana
    * @returns downloaded Changeset metadata along with the downloaded file path. See {@link DownloadedChangeset}.
    */
   public async downloadList(params: DownloadChangesetListParams): Promise<DownloadedChangeset[]> {
-    let result: DownloadedChangeset[] = [];
-
     this._options.fileHandler.createDirectory(params.targetDirectoryPath);
 
+    let result: DownloadedChangeset[] = [];
     for await (const changesetPage of this.getRepresentationList(params).byPage()) {
       const changesetsWithFilePath: DownloadedChangeset[] = changesetPage.map(
         (changeset: Changeset) => ({

--- a/tests/imodels-clients-tests/src/authoring/ChangesetOperations.test.ts
+++ b/tests/imodels-clients-tests/src/authoring/ChangesetOperations.test.ts
@@ -11,7 +11,7 @@ import { Constants, getTestDIContainer, getTestRunId } from "../common";
 
 type CommonDownloadParams = IModelScopedOperationParams & TargetDirectoryParam;
 
-describe.only("[Authoring] ChangesetOperations", () => {
+describe("[Authoring] ChangesetOperations", () => {
   let iModelsClient: IModelsClient;
   let iModelsClientOptions: IModelsClientOptions;
   let authorization: AuthorizationCallback;

--- a/tests/imodels-clients-tests/src/authoring/ChangesetOperations.test.ts
+++ b/tests/imodels-clients-tests/src/authoring/ChangesetOperations.test.ts
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as fs from "fs";
+import * as path from "path";
 import { expect } from "chai";
 import { AcquireBriefcaseParams, AuthorizationCallback, AzureSdkFileHandler, CreateChangesetParams, DownloadChangesetListParams, DownloadFileParams, DownloadedChangeset, IModelScopedOperationParams, IModelsClient, IModelsClientOptions, TargetDirectoryParam } from "@itwin/imodels-client-authoring";
 import { FileTransferLog, IModelMetadata, ReusableIModelMetadata, ReusableTestIModelProvider, TestAuthorizationProvider, TestIModelCreator, TestIModelFileProvider, TestIModelGroup, TestIModelGroupFactory, TestUtilTypes, TrackableTestFileHandler, assertChangeset, assertDownloadedChangeset, cleanupDirectory } from "@itwin/imodels-client-test-utils";
@@ -10,7 +11,7 @@ import { Constants, getTestDIContainer, getTestRunId } from "../common";
 
 type CommonDownloadParams = IModelScopedOperationParams & TargetDirectoryParam;
 
-describe("[Authoring] ChangesetOperations", () => {
+describe.only("[Authoring] ChangesetOperations", () => {
   let iModelsClient: IModelsClient;
   let iModelsClientOptions: IModelsClientOptions;
   let authorization: AuthorizationCallback;
@@ -87,7 +88,7 @@ describe("[Authoring] ChangesetOperations", () => {
   describe("download operations", () => {
     it("should download all changesets", async () => {
       // Arrange
-      const downloadPath = Constants.TestDownloadDirectoryPath;
+      const downloadPath = path.join(Constants.TestDownloadDirectoryPath, "download all changesets test");
       const downloadChangesetListParams: DownloadChangesetListParams = {
         authorization,
         iModelId: testIModelForRead.id,
@@ -119,7 +120,7 @@ describe("[Authoring] ChangesetOperations", () => {
 
     it("should download some changesets based on range", async () => {
       // Arrange
-      const downloadPath = Constants.TestDownloadDirectoryPath;
+      const downloadPath = path.join(Constants.TestDownloadDirectoryPath, "download range test");
       const downloadChangesetListParams: DownloadChangesetListParams = {
         authorization,
         iModelId: testIModelForRead.id,
@@ -185,7 +186,7 @@ describe("[Authoring] ChangesetOperations", () => {
     ].forEach((testCase) => {
       it(`should download changeset by ${testCase.label}`, async () => {
         // Arrange
-        const downloadPath = Constants.TestDownloadDirectoryPath;
+        const downloadPath = path.join(Constants.TestDownloadDirectoryPath, `download by ${testCase.label} test`);
         const partialDownloadChangesetParams: CommonDownloadParams = {
           authorization,
           iModelId: testIModelForRead.id,
@@ -264,7 +265,7 @@ describe("[Authoring] ChangesetOperations", () => {
         const trackedFileHandler = new TrackableTestFileHandler(azureSdkFileHandler, { downloadStub });
         const iModelsClientWithTrackedFileTransfer = new IModelsClient({ ...iModelsClientOptions, fileHandler: trackedFileHandler });
 
-        const downloadPath = Constants.TestDownloadDirectoryPath;
+        const downloadPath = path.join(Constants.TestDownloadDirectoryPath, `download ${testCase.label} retry test`);
         const partialDownloadChangesetParams: CommonDownloadParams = {
           authorization,
           iModelId: testIModelForRead.id,
@@ -300,7 +301,7 @@ describe("[Authoring] ChangesetOperations", () => {
         const trackedFileHandler = new TrackableTestFileHandler(azureSdkFileHandler, { downloadStub });
         const iModelsClientWithTrackedFileTransfer = new IModelsClient({ ...iModelsClientOptions, fileHandler: trackedFileHandler });
 
-        const downloadPath = Constants.TestDownloadDirectoryPath;
+        const downloadPath = path.join(Constants.TestDownloadDirectoryPath, `download ${testCase.label} reuse test`);
         const partialDownloadChangesetParams: CommonDownloadParams = {
           authorization,
           iModelId: testIModelForRead.id,

--- a/tests/imodels-clients-tests/src/authoring/ChangesetOperations.test.ts
+++ b/tests/imodels-clients-tests/src/authoring/ChangesetOperations.test.ts
@@ -88,7 +88,7 @@ describe("[Authoring] ChangesetOperations", () => {
   describe("download operations", () => {
     it("should download all changesets", async () => {
       // Arrange
-      const downloadPath = path.join(Constants.TestDownloadDirectoryPath, "download all changesets test");
+      const downloadPath = path.join(Constants.TestDownloadDirectoryPath, "[Authoring] ChangesetOperations", "download all changesets test");
       const downloadChangesetListParams: DownloadChangesetListParams = {
         authorization,
         iModelId: testIModelForRead.id,
@@ -120,7 +120,7 @@ describe("[Authoring] ChangesetOperations", () => {
 
     it("should download some changesets based on range", async () => {
       // Arrange
-      const downloadPath = path.join(Constants.TestDownloadDirectoryPath, "download range test");
+      const downloadPath = path.join(Constants.TestDownloadDirectoryPath, "[Authoring] ChangesetOperations", "download range test");
       const downloadChangesetListParams: DownloadChangesetListParams = {
         authorization,
         iModelId: testIModelForRead.id,
@@ -186,7 +186,7 @@ describe("[Authoring] ChangesetOperations", () => {
     ].forEach((testCase) => {
       it(`should download changeset by ${testCase.label}`, async () => {
         // Arrange
-        const downloadPath = path.join(Constants.TestDownloadDirectoryPath, `download by ${testCase.label} test`);
+        const downloadPath = path.join(Constants.TestDownloadDirectoryPath, "[Authoring] ChangesetOperations", `download by ${testCase.label} test`);
         const partialDownloadChangesetParams: CommonDownloadParams = {
           authorization,
           iModelId: testIModelForRead.id,
@@ -265,7 +265,7 @@ describe("[Authoring] ChangesetOperations", () => {
         const trackedFileHandler = new TrackableTestFileHandler(azureSdkFileHandler, { downloadStub });
         const iModelsClientWithTrackedFileTransfer = new IModelsClient({ ...iModelsClientOptions, fileHandler: trackedFileHandler });
 
-        const downloadPath = path.join(Constants.TestDownloadDirectoryPath, `download ${testCase.label} retry test`);
+        const downloadPath = path.join(Constants.TestDownloadDirectoryPath, "[Authoring] ChangesetOperations", `download ${testCase.label} retry test`);
         const partialDownloadChangesetParams: CommonDownloadParams = {
           authorization,
           iModelId: testIModelForRead.id,
@@ -301,7 +301,7 @@ describe("[Authoring] ChangesetOperations", () => {
         const trackedFileHandler = new TrackableTestFileHandler(azureSdkFileHandler, { downloadStub });
         const iModelsClientWithTrackedFileTransfer = new IModelsClient({ ...iModelsClientOptions, fileHandler: trackedFileHandler });
 
-        const downloadPath = path.join(Constants.TestDownloadDirectoryPath, `download ${testCase.label} reuse test`);
+        const downloadPath = path.join(Constants.TestDownloadDirectoryPath, "[Authoring] ChangesetOperations", `download ${testCase.label} reuse test`);
         const partialDownloadChangesetParams: CommonDownloadParams = {
           authorization,
           iModelId: testIModelForRead.id,


### PR DESCRIPTION
In this PR:
- Fixed a bug where the single Changeset download would failed if passed `targetDirectoryPath` would not exist.
- Altered tests to have unique directories for each Changeset download test case.