### PR TITLE
Named Version ordering fix in `FrontendIModelsAccess.getChangesetFromNamedVersion`

### DIFF
--- a/itwin-platform-access/imodels-access-frontend/src/FrontendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-frontend/src/FrontendIModelsAccess.ts
@@ -113,7 +113,7 @@ export class FrontendIModelsAccess implements FrontendHubAccess {
         };
       })
       .sort(
-        (a, b) => b.createdDateTime.getTime() - a.createdDateTime.getTime()
+        (a, b) => b.changesetIndex - a.changesetIndex
       );
 
     if (sortedNamedVersions.length === 0 || !sortedNamedVersions[0].changesetIndex || !sortedNamedVersions[0].changesetId)


### PR DESCRIPTION
In this PR:
- Changed the property by which Named Versions are ordered to get the latest named version - previously it was `createdDateTime`, changed it to `changesetIndex`.