### PR TITLE
Adding @itwin/imodels-access-frontend tests to pipeline

### DIFF
--- a/pipelines/templates/build-test.yml
+++ b/pipelines/templates/build-test.yml
@@ -29,6 +29,17 @@ steps:
       TEST_USERS_ADMIN2_FULLY_FEATURED_PASSWORD: $(TEST_USERS_ADMIN2_FULLY_FEATURED_PASSWORD)
 
   - script: npm run test:integration
+    displayName: npm run test:integration (@itwin/imodels-access-frontend tests)
+    workingDirectory: tests/imodels-access-frontend-tests
+    env:
+      AUTH_CLIENT_ID: $(AUTH_CLIENT_ID)
+      AUTH_CLIENT_SECRET: $(AUTH_CLIENT_SECRET)
+      TEST_USERS_ADMIN1_EMAIL: $(TEST_USERS_ADMIN1_EMAIL)
+      TEST_USERS_ADMIN1_PASSWORD: $(TEST_USERS_ADMIN1_PASSWORD)
+      TEST_USERS_ADMIN2_FULLY_FEATURED_EMAIL: $(TEST_USERS_ADMIN2_FULLY_FEATURED_EMAIL)
+      TEST_USERS_ADMIN2_FULLY_FEATURED_PASSWORD: $(TEST_USERS_ADMIN2_FULLY_FEATURED_PASSWORD)
+
+  - script: npm run test:integration
     displayName: npm run test:integration (@itwin/imodels-access-backend tests)
     workingDirectory: tests/imodels-access-backend-tests
     env:


### PR DESCRIPTION
In this PR:
- Added integration test run step to run tests from `@itwin/imodels-access-frontend-tests` package.