### PR TITLE
Extensibility fixes in `@itwin/imodels-client-authoring`

### DIFF
--- a/clients/imodels-client-authoring/src/IModelsClient.ts
+++ b/clients/imodels-client-authoring/src/IModelsClient.ts
@@ -29,7 +29,7 @@ export interface IModelsClientOptions extends ManagementIModelsClientOptions {
  * {@link https://developer.bentley.com/apis/imodels/ iModels API documentation page}.
  */
 export class IModelsClient {
-  private _operationsOptions: OperationOptions;
+  protected _operationsOptions: OperationOptions;
 
   /**
    * Class constructor.

--- a/clients/imodels-client-authoring/src/IModelsClientExports.ts
+++ b/clients/imodels-client-authoring/src/IModelsClientExports.ts
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 export * from "@itwin/imodels-client-management/lib/base";
 export * from "@itwin/imodels-client-management/lib/operations/OperationParamExports";
+export * from "@itwin/imodels-client-management/lib/operations/checkpoint/CheckpointOperations";
+export * from "@itwin/imodels-client-management/lib/operations/named-version/NamedVersionOperations";
 export * from "./base";
 export * from "./operations";
 export * from "./Constants";

--- a/clients/imodels-client-management/src/IModelsClient.ts
+++ b/clients/imodels-client-management/src/IModelsClient.ts
@@ -25,7 +25,7 @@ export interface IModelsClientOptions {
  * {@link https://developer.bentley.com/apis/imodels/ iModels API documentation page}.
  */
 export class IModelsClient {
-  private _operationsOptions: OperationOptions;
+  protected _operationsOptions: OperationOptions;
 
   /**
    * Class constructor.


### PR DESCRIPTION
In this PR:
- Fixed `IModelsClient` classes in both packages: made the `_operationsOptions` property protected. This makes it more convenient to extend the IModelsClient class as the user does not have to declare a duplicate property to persist operation options.
- Re-exported `NamedVersionOperations` and `CheckpointOperations` classes from `@itwin/imodels-client-authoring` package. Those classes were missed in the exports because the authoring client does not extend them meaning that those operations are not exported by the [imodels-client-authoring/src/operations/OperationExports.ts](https://github.com/iTwin/imodels-clients/blob/main/clients/imodels-client-authoring/src/operations/OperationExports.ts) file. They were added to the package exports class explicitly.