### PR TITLE
Making all methods in `FileHandler` async

### DIFF
--- a/clients/imodels-client-authoring/src/base/files/AzureSdkFileHandler.ts
+++ b/clients/imodels-client-authoring/src/base/files/AzureSdkFileHandler.ts
@@ -71,7 +71,7 @@ export class AzureSdkFileHandler implements FileHandler {
       return;
 
     const parentDirectory = path.dirname(directoryPath);
-    this.createDirectory(parentDirectory);
+    await this.createDirectory(parentDirectory);
     fs.mkdirSync(directoryPath);
   }
 

--- a/clients/imodels-client-authoring/src/base/files/AzureSdkFileHandler.ts
+++ b/clients/imodels-client-authoring/src/base/files/AzureSdkFileHandler.ts
@@ -27,7 +27,7 @@ export class AzureSdkFileHandler implements FileHandler {
 
     let uploadOptions: BlockBlobParallelUploadOptions | undefined;
     if (params.progressCallback) {
-      const fileSize = this.getFileSize(params.sourceFilePath);
+      const fileSize = await this.getFileSize(params.sourceFilePath);
       uploadOptions = {
         onProgress: this.adaptProgressCallback(params.progressCallback, fileSize)
       };
@@ -54,19 +54,19 @@ export class AzureSdkFileHandler implements FileHandler {
     await blockBlobClient.downloadToFile(params.targetFilePath, undefined, undefined, downloadOptions);
   }
 
-  public exists(filePath: string): boolean {
+  public async exists(filePath: string): Promise<boolean> {
     return fs.existsSync(filePath);
   }
 
-  public getFileSize(filePath: string): number {
+  public async getFileSize(filePath: string): Promise<number> {
     return fs.statSync(filePath).size;
   }
 
-  public unlink(filePath: string): void {
+  public async unlink(filePath: string): Promise<void> {
     return fs.unlinkSync(filePath);
   }
 
-  public createDirectory(directoryPath: string): void {
+  public async createDirectory(directoryPath: string): Promise<void> {
     if (fs.existsSync(directoryPath))
       return;
 
@@ -75,7 +75,7 @@ export class AzureSdkFileHandler implements FileHandler {
     fs.mkdirSync(directoryPath);
   }
 
-  public join(...paths: string[]): string {
+  public async join(...paths: string[]): Promise<string> {
     return path.join(...paths);
   }
 

--- a/clients/imodels-client-authoring/src/base/files/FileHandler.ts
+++ b/clients/imodels-client-authoring/src/base/files/FileHandler.ts
@@ -58,31 +58,31 @@ export interface FileHandler {
    * @param {string} filePath path of the file.
    * @returns `true` if the file exists, `false` otherwise.
    */
-  exists(filePath: string): boolean;
+  exists(filePath: string): Promise<boolean>;
 
   /**
    * Determines size of the specified file.
    * @param {string} filePath path of the file.
    * @returns file size in bytes.
    */
-  getFileSize(filePath: string): number;
+  getFileSize(filePath: string): Promise<number>;
 
   /**
    * Deletes the specified file.
    * @param {string} filePath path of the file.
    */
-  unlink(filePath: string): void;
+  unlink(filePath: string): Promise<void>;
 
   /**
    * Creates specified directory recursively.
    * @param {string} directoryPath directory to create.
    */
-  createDirectory(directoryPath: string): void;
+  createDirectory(directoryPath: string): Promise<void>;
 
   /**
    * Joins all path segments together into a normalized path.
    * @param {string[]} paths path segments to join.
    * @returns normalized path.
    */
-  join(...paths: string[]): string;
+  join(...paths: string[]): Promise<string>;
 }

--- a/clients/imodels-client-authoring/src/base/files/FileHandler.ts
+++ b/clients/imodels-client-authoring/src/base/files/FileHandler.ts
@@ -42,47 +42,49 @@ export interface FileHandler {
   /**
    * Uploads file from the local source to the remote target and reports progress via the user-passed progress callback.
    * @param {UploadFileParams} params parameters for this operation. See {@link UploadFileParams}.
-   * @returns a promise that resolves after operation completes.
+   * @returns {Promise<void>} a promise that resolves after operation completes.
    */
   uploadFile(params: UploadFileParams): Promise<void>;
 
   /**
    * Downloads file from the remote target to the local source and reports progress via the user-passed progress callback.
    * @param {DownloadFileParams} params parameters for this operation. See {@link DownloadFileParams}.
-   * @returns a promise that resolves after operation completes.
+   * @returns {Promise<void>} a promise that resolves after operation completes.
    */
   downloadFile(params: DownloadFileParams): Promise<void>;
 
   /**
    * Determines if a file with the specified path exists in the file system.
    * @param {string} filePath path of the file.
-   * @returns `true` if the file exists, `false` otherwise.
+   * @returns {Promise<boolean>} `true` if the file exists, `false` otherwise.
    */
   exists(filePath: string): Promise<boolean>;
 
   /**
    * Determines size of the specified file.
    * @param {string} filePath path of the file.
-   * @returns file size in bytes.
+   * @returns {Promise<number>} file size in bytes.
    */
   getFileSize(filePath: string): Promise<number>;
 
   /**
    * Deletes the specified file.
    * @param {string} filePath path of the file.
+   * @returns {Promise<void>} a promise that resolves after operation completes.
    */
   unlink(filePath: string): Promise<void>;
 
   /**
    * Creates specified directory recursively.
    * @param {string} directoryPath directory to create.
+   * @returns {Promise<void>} a promise that resolves after operation completes.
    */
   createDirectory(directoryPath: string): Promise<void>;
 
   /**
    * Joins all path segments together into a normalized path.
    * @param {string[]} paths path segments to join.
-   * @returns normalized path.
+   * @returns {Promise<string>} normalized path.
    */
   join(...paths: string[]): Promise<string>;
 }

--- a/clients/imodels-client-authoring/src/operations/imodel/IModelOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/imodel/IModelOperations.ts
@@ -31,7 +31,7 @@ export class IModelOperations<TOptions extends OperationOptions> extends Managem
   * or did not complete in time. See {@link iModelsErrorCode}.
   */
   public async createFromBaseline(params: CreateIModelFromBaselineParams): Promise<IModel> {
-    const createIModelBody = this.getCreateIModelFromBaselineRequestBody(params.iModelProperties);
+    const createIModelBody = await this.getCreateIModelFromBaselineRequestBody(params.iModelProperties);
     const createIModelResponse = await this.sendPostRequest<IModelCreateResponse>({
       authorization: params.authorization,
       url: this._options.urlFormatter.getCreateIModelUrl(),
@@ -58,11 +58,11 @@ export class IModelOperations<TOptions extends OperationOptions> extends Managem
     });
   }
 
-  private getCreateIModelFromBaselineRequestBody(iModelProperties: IModelPropertiesForCreateFromBaseline): object {
+  private async getCreateIModelFromBaselineRequestBody(iModelProperties: IModelPropertiesForCreateFromBaseline): Promise<object> {
     return {
       ...this.getCreateEmptyIModelRequestBody(iModelProperties),
       baselineFile: {
-        size: this._options.fileHandler.getFileSize(iModelProperties.filePath)
+        size: await this._options.fileHandler.getFileSize(iModelProperties.filePath)
       }
     };
   }

--- a/utils/imodels-client-test-utils/src/TrackableTestFileHandler.ts
+++ b/utils/imodels-client-test-utils/src/TrackableTestFileHandler.ts
@@ -43,7 +43,7 @@ export class TrackableTestFileHandler implements FileHandler {
   }
 
   public async unlink(filePath: string): Promise<void> {
-    this._underlyingHandler.unlink(filePath);
+    return this._underlyingHandler.unlink(filePath);
   }
 
   public async createDirectory(directoryPath: string): Promise<void> {

--- a/utils/imodels-client-test-utils/src/TrackableTestFileHandler.ts
+++ b/utils/imodels-client-test-utils/src/TrackableTestFileHandler.ts
@@ -34,23 +34,23 @@ export class TrackableTestFileHandler implements FileHandler {
     return this._underlyingHandler.downloadFile(params);
   }
 
-  public exists(filePath: string): boolean {
+  public async exists(filePath: string): Promise<boolean> {
     return this._underlyingHandler.exists(filePath);
   }
 
-  public getFileSize(filePath: string): number {
+  public async getFileSize(filePath: string): Promise<number> {
     return this._underlyingHandler.getFileSize(filePath);
   }
 
-  public unlink(filePath: string): void {
+  public async unlink(filePath: string): Promise<void> {
     this._underlyingHandler.unlink(filePath);
   }
 
-  public createDirectory(directoryPath: string): void {
+  public async createDirectory(directoryPath: string): Promise<void> {
     return this._underlyingHandler.createDirectory(directoryPath);
   }
 
-  public  join(...paths: string[]): string {
+  public async  join(...paths: string[]): Promise<string> {
     return this._underlyingHandler.join(...paths);
   }
 }


### PR DESCRIPTION
In this PR:
- Updated all methods in `FileHandler` interface to be async. This allows for better extensibility.
- Updated the rest of the code to accommodate the new change.