### PR TITLE
Updating platform interop packages to the latest version

### DIFF
--- a/clients/imodels-client-authoring/package.json
+++ b/clients/imodels-client-authoring/package.json
@@ -36,6 +36,6 @@
   },
   "devDependencies": {
     "@itwin/imodels-client-common-config": "~0.2.2",
-    "typescript": "~4.3.5"
+    "typescript": "~4.4.0"
   }
 }

--- a/clients/imodels-client-management/package.json
+++ b/clients/imodels-client-management/package.json
@@ -35,6 +35,6 @@
   },
   "devDependencies": {
     "@itwin/imodels-client-common-config": "~0.2.2",
-    "typescript": "~4.3.5"
+    "typescript": "~4.4.0"
   }
 }

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1,32 +1,32 @@
 dependencies:
   '@azure/storage-blob': 12.7.0
-  '@bentley/itwin-client': 3.0.0-dev.135_1f1133e0683841193b047e5518caa238
-  '@itwin/appui-abstract': 3.0.0-dev.148_1f1133e0683841193b047e5518caa238
-  '@itwin/core-backend': 3.0.0-dev.148_29276b61277a7cedb96595da2e2a4ac9
-  '@itwin/core-bentley': 3.0.0-dev.148
-  '@itwin/core-common': 3.0.0-dev.148_2cea9fa5747d2125eec0388ef83db838
-  '@itwin/core-frontend': 3.0.0-dev.148_54235d032abb96d437206068bf58c49f
-  '@itwin/core-geometry': 3.0.0-dev.148
-  '@itwin/core-orbitgt': 3.0.0-dev.148
-  '@itwin/core-quantity': 3.0.0-dev.148_1f1133e0683841193b047e5518caa238
-  '@itwin/ecschema-metadata': 3.0.0-dev.148_1f1133e0683841193b047e5518caa238
-  '@itwin/eslint-plugin': 3.0.0-dev.148_eslint@7.31.0+typescript@4.3.5
-  '@itwin/webgl-compatibility': 3.0.0-dev.148
-  '@rush-temp/imodels-access-backend': 'file:projects/imodels-access-backend.tgz_4bd45436c7446ce6f2c68b792e01fc06'
-  '@rush-temp/imodels-access-backend-tests': 'file:projects/imodels-access-backend-tests.tgz_4bd45436c7446ce6f2c68b792e01fc06'
+  '@bentley/itwin-client': 3.0.0-dev.148_f4a588df173e76e968bad38684dae86a
+  '@itwin/appui-abstract': 3.0.0-dev.177_f4a588df173e76e968bad38684dae86a
+  '@itwin/core-backend': 3.0.0-dev.177_ddaece1736e631ce5890f83b6412fe83
+  '@itwin/core-bentley': 3.0.0-dev.177
+  '@itwin/core-common': 3.0.0-dev.177_aefcd2e401c2232a5c9ebe5404309a19
+  '@itwin/core-frontend': 3.0.0-dev.177_aa4eb0ae198d06161ccf95523d3ea495
+  '@itwin/core-geometry': 3.0.0-dev.177
+  '@itwin/core-orbitgt': 3.0.0-dev.177
+  '@itwin/core-quantity': 3.0.0-dev.177_f4a588df173e76e968bad38684dae86a
+  '@itwin/ecschema-metadata': 3.0.0-dev.177_f4a588df173e76e968bad38684dae86a
+  '@itwin/eslint-plugin': 3.0.0-dev.177_eslint@7.31.0+typescript@4.4.4
+  '@itwin/webgl-compatibility': 3.0.0-dev.177
+  '@rush-temp/imodels-access-backend': 'file:projects/imodels-access-backend.tgz_b5694a69aef35f9e2c3d7f6af9a480ab'
+  '@rush-temp/imodels-access-backend-tests': 'file:projects/imodels-access-backend-tests.tgz_b5694a69aef35f9e2c3d7f6af9a480ab'
   '@rush-temp/imodels-access-frontend': 'file:projects/imodels-access-frontend.tgz'
-  '@rush-temp/imodels-access-frontend-tests': 'file:projects/imodels-access-frontend-tests.tgz_d3d027a5f0cf45c7672147e69d31b9e7'
+  '@rush-temp/imodels-access-frontend-tests': 'file:projects/imodels-access-frontend-tests.tgz_35f9c6074ef211a97243c78003389afa'
   '@rush-temp/imodels-client-authoring': 'file:projects/imodels-client-authoring.tgz'
-  '@rush-temp/imodels-client-common-config': 'file:projects/imodels-client-common-config.tgz_typescript@4.3.5'
+  '@rush-temp/imodels-client-common-config': 'file:projects/imodels-client-common-config.tgz_typescript@4.4.4'
   '@rush-temp/imodels-client-management': 'file:projects/imodels-client-management.tgz'
   '@rush-temp/imodels-client-test-utils': 'file:projects/imodels-client-test-utils.tgz'
   '@rush-temp/imodels-clients-tests': 'file:projects/imodels-clients-tests.tgz'
   '@types/chai': 4.2.22
   '@types/mocha': 9.0.0
-  '@types/node': 16.11.12
+  '@types/node': 16.11.19
   '@types/ws': 8.2.2
-  '@typescript-eslint/eslint-plugin': 4.28.5_514553717ff968e20f6d1c6e521f8616
-  '@typescript-eslint/parser': 4.28.5_eslint@7.31.0+typescript@4.3.5
+  '@typescript-eslint/eslint-plugin': 4.28.5_2d27c79b551e458fb3b3f741bd766f57
+  '@typescript-eslint/parser': 4.28.5_eslint@7.31.0+typescript@4.4.4
   axios: 0.21.4
   chai: 4.3.4
   cpx: 1.5.0
@@ -42,7 +42,7 @@ dependencies:
   puppeteer: 10.2.0
   reflect-metadata: 0.1.13
   sort-package-json: 1.53.1
-  typescript: 4.3.5
+  typescript: 4.4.4
 lockfileVersion: 5.1
 packages:
   /@azure/abort-controller/1.0.4:
@@ -66,7 +66,7 @@ packages:
       node: '>=12.0.0'
     resolution:
       integrity: sha512-7CU6DmCHIZp5ZPiZ9r3J17lTKMmYsm/zGvNkjArQwPkrLlZ1TZ+EUYfGgh2X31OLMVAQCTJZW4cXHJi02EbJnA==
-  /@azure/core-http/2.2.2:
+  /@azure/core-http/2.2.3:
     dependencies:
       '@azure/abort-controller': 1.0.4
       '@azure/core-asynciterator-polyfill': 1.0.0
@@ -87,8 +87,8 @@ packages:
     engines:
       node: '>=12.0.0'
     resolution:
-      integrity: sha512-V1DdoO9V/sFimKpdWoNBgsE+QUjQgpXYnxrTdUp5RyhsTJjvEVn/HKmTQXIHuLUUo6IyIWj+B+Dg4VaXse9dIA==
-  /@azure/core-lro/2.2.2:
+      integrity: sha512-xr8AeszxP418rI//W38NfJDDr0kbVAPZkURZnZ+Fle+lLWeURjDE5zNIuocA1wUPoKSP8iXc0ApW6nPtbLGswA==
+  /@azure/core-lro/2.2.3:
     dependencies:
       '@azure/abort-controller': 1.0.4
       '@azure/core-tracing': 1.0.0-preview.13
@@ -98,8 +98,8 @@ packages:
     engines:
       node: '>=12.0.0'
     resolution:
-      integrity: sha512-pn30b+HyJHg0+G4ZRgpL3BJa6LQnKdKl1X4JDMpuVsX+kPxs2FNoweNqD3Li199ROroIvFbi6pE29y0J2vvyIg==
-  /@azure/core-paging/1.2.0:
+      integrity: sha512-UMdlR9NsqDCLTba3EUbRjfMF4gDmWvld196JmUjbz9WWhJ2XT00OR5MXeWiR+vmGT+ETiO4hHFCi2/eGO5YVtg==
+  /@azure/core-paging/1.2.1:
     dependencies:
       '@azure/core-asynciterator-polyfill': 1.0.0
       tslib: 2.3.1
@@ -107,10 +107,10 @@ packages:
     engines:
       node: '>=12.0.0'
     resolution:
-      integrity: sha512-ZX1bCjm/MjKPCN6kQD/9GJErYSoKA8YWp6YWoo5EIzcTWlSBLXu3gNaBTUl8usGl+UShiKo7b4Gdy1NSTIlpZg==
+      integrity: sha512-UtH5iMlYsvg+nQYIl4UHlvvSrsBjOlRF4fs0j7mxd3rWdAStrKYrh2durOpHs5C9yZbVhsVDaisoyaf/lL1EVA==
   /@azure/core-tracing/1.0.0-preview.13:
     dependencies:
-      '@opentelemetry/api': 1.0.3
+      '@opentelemetry/api': 1.0.4
       tslib: 2.3.1
     dev: false
     engines:
@@ -128,9 +128,9 @@ packages:
   /@azure/storage-blob/12.7.0:
     dependencies:
       '@azure/abort-controller': 1.0.4
-      '@azure/core-http': 2.2.2
-      '@azure/core-lro': 2.2.2
-      '@azure/core-paging': 1.2.0
+      '@azure/core-http': 2.2.3
+      '@azure/core-lro': 2.2.3
+      '@azure/core-paging': 1.2.1
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/logger': 1.0.3
       events: 3.3.0
@@ -142,158 +142,158 @@ packages:
       integrity: sha512-7YEWEx03Us/YBxthzBv788R7jokwpCD5KcIsvtE5xRaijNX9o80KXpabhEwLR9DD9nmt/AlU/c1R+aXydgCduQ==
   /@babel/code-frame/7.12.11:
     dependencies:
-      '@babel/highlight': 7.16.0
+      '@babel/highlight': 7.16.7
     dev: false
     resolution:
       integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
-  /@babel/code-frame/7.16.0:
+  /@babel/code-frame/7.16.7:
     dependencies:
-      '@babel/highlight': 7.16.0
+      '@babel/highlight': 7.16.7
     dev: false
     engines:
       node: '>=6.9.0'
     resolution:
-      integrity: sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==
-  /@babel/generator/7.16.5:
+      integrity: sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
+  /@babel/generator/7.16.7:
     dependencies:
-      '@babel/types': 7.16.0
+      '@babel/types': 7.16.7
       jsesc: 2.5.2
       source-map: 0.5.7
     dev: false
     engines:
       node: '>=6.9.0'
     resolution:
-      integrity: sha512-kIvCdjZqcdKqoDbVVdt5R99icaRtrtYhYK/xux5qiWCBmfdvEYMFZ68QCrpE5cbFM1JsuArUNs1ZkuKtTtUcZA==
-  /@babel/helper-environment-visitor/7.16.5:
+      integrity: sha512-/ST3Sg8MLGY5HVYmrjOgL60ENux/HfO/CsUh7y4MalThufhE/Ff/6EibFDHi4jiDCaWfJKoqbE6oTh21c5hrRg==
+  /@babel/helper-environment-visitor/7.16.7:
     dependencies:
-      '@babel/types': 7.16.0
+      '@babel/types': 7.16.7
     dev: false
     engines:
       node: '>=6.9.0'
     resolution:
-      integrity: sha512-ODQyc5AnxmZWm/R2W7fzhamOk1ey8gSguo5SGvF0zcB3uUzRpTRmM/jmLSm9bDMyPlvbyJ+PwPEK0BWIoZ9wjg==
-  /@babel/helper-function-name/7.16.0:
+      integrity: sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==
+  /@babel/helper-function-name/7.16.7:
     dependencies:
-      '@babel/helper-get-function-arity': 7.16.0
-      '@babel/template': 7.16.0
-      '@babel/types': 7.16.0
+      '@babel/helper-get-function-arity': 7.16.7
+      '@babel/template': 7.16.7
+      '@babel/types': 7.16.7
     dev: false
     engines:
       node: '>=6.9.0'
     resolution:
-      integrity: sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==
-  /@babel/helper-get-function-arity/7.16.0:
+      integrity: sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==
+  /@babel/helper-get-function-arity/7.16.7:
     dependencies:
-      '@babel/types': 7.16.0
+      '@babel/types': 7.16.7
     dev: false
     engines:
       node: '>=6.9.0'
     resolution:
-      integrity: sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==
-  /@babel/helper-hoist-variables/7.16.0:
+      integrity: sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==
+  /@babel/helper-hoist-variables/7.16.7:
     dependencies:
-      '@babel/types': 7.16.0
+      '@babel/types': 7.16.7
     dev: false
     engines:
       node: '>=6.9.0'
     resolution:
-      integrity: sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==
-  /@babel/helper-split-export-declaration/7.16.0:
+      integrity: sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==
+  /@babel/helper-split-export-declaration/7.16.7:
     dependencies:
-      '@babel/types': 7.16.0
+      '@babel/types': 7.16.7
     dev: false
     engines:
       node: '>=6.9.0'
     resolution:
-      integrity: sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==
-  /@babel/helper-validator-identifier/7.15.7:
+      integrity: sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==
+  /@babel/helper-validator-identifier/7.16.7:
     dev: false
     engines:
       node: '>=6.9.0'
     resolution:
-      integrity: sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==
-  /@babel/highlight/7.16.0:
+      integrity: sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
+  /@babel/highlight/7.16.7:
     dependencies:
-      '@babel/helper-validator-identifier': 7.15.7
+      '@babel/helper-validator-identifier': 7.16.7
       chalk: 2.4.2
       js-tokens: 4.0.0
     dev: false
     engines:
       node: '>=6.9.0'
     resolution:
-      integrity: sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==
-  /@babel/parser/7.16.5:
+      integrity: sha512-aKpPMfLvGO3Q97V0qhw/V2SWNWlwfJknuwAunU7wZLSfrM4xTBvg7E5opUVi1kJTBKihE38CPg4nBiqX83PWYw==
+  /@babel/parser/7.16.7:
     dev: false
     engines:
       node: '>=6.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-+Ce7T5iPNWzfu9C1aB5tN3Lyafs5xb3Ic7vBWyZL2KXT3QSdD1dD3CvgOzPmQKoNNRt6uauc0XwNJTQtXC2/Mw==
-  /@babel/runtime-corejs3/7.16.5:
+      integrity: sha512-sR4eaSrnM7BV7QPzGfEX5paG/6wrZM3I0HDzfIAK06ESvo9oy3xBuVBxE3MbQaKNhvg8g/ixjMWo2CGpzpHsDA==
+  /@babel/runtime-corejs3/7.16.7:
     dependencies:
-      core-js-pure: 3.19.3
+      core-js-pure: 3.20.2
       regenerator-runtime: 0.13.9
     dev: false
     engines:
       node: '>=6.9.0'
     resolution:
-      integrity: sha512-F1pMwvTiUNSAM8mc45kccMQxj31x3y3P+tA/X8hKNWp3/hUsxdGxZ3D3H8JIkxtfA8qGkaBTKvcmvStaYseAFw==
-  /@babel/runtime/7.16.5:
+      integrity: sha512-MiYR1yk8+TW/CpOD0CyX7ve9ffWTKqLk/L6pk8TPl0R8pNi+1pFY8fH9yET55KlvukQ4PAWfXsGr2YHVjcI4Pw==
+  /@babel/runtime/7.16.7:
     dependencies:
       regenerator-runtime: 0.13.9
     dev: false
     engines:
       node: '>=6.9.0'
     resolution:
-      integrity: sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==
-  /@babel/template/7.16.0:
+      integrity: sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==
+  /@babel/template/7.16.7:
     dependencies:
-      '@babel/code-frame': 7.16.0
-      '@babel/parser': 7.16.5
-      '@babel/types': 7.16.0
+      '@babel/code-frame': 7.16.7
+      '@babel/parser': 7.16.7
+      '@babel/types': 7.16.7
     dev: false
     engines:
       node: '>=6.9.0'
     resolution:
-      integrity: sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==
-  /@babel/traverse/7.16.5:
+      integrity: sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==
+  /@babel/traverse/7.16.7:
     dependencies:
-      '@babel/code-frame': 7.16.0
-      '@babel/generator': 7.16.5
-      '@babel/helper-environment-visitor': 7.16.5
-      '@babel/helper-function-name': 7.16.0
-      '@babel/helper-hoist-variables': 7.16.0
-      '@babel/helper-split-export-declaration': 7.16.0
-      '@babel/parser': 7.16.5
-      '@babel/types': 7.16.0
+      '@babel/code-frame': 7.16.7
+      '@babel/generator': 7.16.7
+      '@babel/helper-environment-visitor': 7.16.7
+      '@babel/helper-function-name': 7.16.7
+      '@babel/helper-hoist-variables': 7.16.7
+      '@babel/helper-split-export-declaration': 7.16.7
+      '@babel/parser': 7.16.7
+      '@babel/types': 7.16.7
       debug: 4.3.3
       globals: 11.12.0
     dev: false
     engines:
       node: '>=6.9.0'
     resolution:
-      integrity: sha512-FOCODAzqUMROikDYLYxl4nmwiLlu85rNqBML/A5hKRVXG2LV8d0iMqgPzdYTcIpjZEBB7D6UDU9vxRZiriASdQ==
-  /@babel/types/7.16.0:
+      integrity: sha512-8KWJPIb8c2VvY8AJrydh6+fVRo2ODx1wYBU2398xJVq0JomuLBZmVQzLPBblJgHIGYG4znCpUZUZ0Pt2vdmVYQ==
+  /@babel/types/7.16.7:
     dependencies:
-      '@babel/helper-validator-identifier': 7.15.7
+      '@babel/helper-validator-identifier': 7.16.7
       to-fast-properties: 2.0.0
     dev: false
     engines:
       node: '>=6.9.0'
     resolution:
-      integrity: sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==
+      integrity: sha512-E8HuV7FO9qLpx6OtoGfUQ2cjIYnbFwvZWYBS+87EwtdMvmUPJSwykpovFB+8insbpF0uJcpr8KMUi64XZntZcg==
   /@bentley/icons-generic-webfont/1.0.34:
     dev: false
     resolution:
       integrity: sha512-5zZgs+himE2vjf39CVlDXMHCFAwSfcoORqJBk3Vji8QVCF8AIX4IX2DO6HlsIAM7szxMNqhz1kd07Xfppro6MA==
-  /@bentley/imodeljs-native/3.0.24:
+  /@bentley/imodeljs-native/3.0.31:
     dev: false
     requiresBuild: true
     resolution:
-      integrity: sha512-WBvnFO3krBbsBU6XsMMnRJyFPMTcGlgHf/YTClX99AnKYxPmqlp8VAQ21lb4+aqgO/9WnZPhMNaXgIDi7noSfA==
-  /@bentley/itwin-client/3.0.0-dev.135_1f1133e0683841193b047e5518caa238:
+      integrity: sha512-Qsru1C58syuSUBLG0sOkVWTRqy+ww1AsrJVfFHc1jaWftcRjy6FJuLIhI5u4EiGcf6qdUJQGgwpsrQyFnBjvxA==
+  /@bentley/itwin-client/3.0.0-dev.148_f4a588df173e76e968bad38684dae86a:
     dependencies:
-      '@itwin/core-bentley': 3.0.0-dev.148
+      '@itwin/core-bentley': 3.0.0-dev.177
       deep-assign: 2.0.0
       js-base64: 3.7.2
       lodash: 4.17.21
@@ -302,10 +302,10 @@ packages:
       xpath: 0.0.27
     dev: false
     peerDependencies:
-      '@itwin/core-bentley': ^3.0.0-dev.135
+      '@itwin/core-bentley': ^3.0.0-dev.148
     resolution:
-      integrity: sha512-facpvfpiOsyvNxrOUP47Qn1T/9uUp2pxF9EweNg18HpcgdRZvfQtqGAdYoiR4qdvCVZJEqpoCz7p6t1DFFjAuA==
-  /@cspell/cspell-bundled-dicts/5.13.3:
+      integrity: sha512-Y8eF6h88rZHB0uTaWeAqMvSGY/4mH/32xB71H4JILtm3aBCjwaJVQ+1NRCR3RZgCr2yoaZz27kqJKnqwZlbeaw==
+  /@cspell/cspell-bundled-dicts/5.15.1:
     dependencies:
       '@cspell/dict-ada': 1.1.2
       '@cspell/dict-aws': 1.0.14
@@ -325,7 +325,7 @@ packages:
       '@cspell/dict-fullstack': 2.0.4
       '@cspell/dict-golang': 1.1.24
       '@cspell/dict-haskell': 1.0.13
-      '@cspell/dict-html': 1.1.9
+      '@cspell/dict-html': 2.0.3
       '@cspell/dict-html-symbol-entities': 1.0.23
       '@cspell/dict-java': 1.0.23
       '@cspell/dict-latex': 1.0.25
@@ -340,7 +340,7 @@ packages:
       '@cspell/dict-ruby': 1.0.15
       '@cspell/dict-rust': 1.0.23
       '@cspell/dict-scala': 1.0.21
-      '@cspell/dict-software-terms': 2.0.11
+      '@cspell/dict-software-terms': 2.0.12
       '@cspell/dict-swift': 1.0.1
       '@cspell/dict-typescript': 1.0.19
       '@cspell/dict-vue': 2.0.1
@@ -348,13 +348,13 @@ packages:
     engines:
       node: '>=12.13.0'
     resolution:
-      integrity: sha512-IfjMBNA0M9QsZQW68rGNfWGawAAw5gkjDstuvsEuJfFoOHBT6NB8T5asGmMPJcRdfLvLSaVSG5IYnYWxL0wu/A==
-  /@cspell/cspell-types/5.13.3:
+      integrity: sha512-OYVO7E37TOl/sM96MovfnSyUg7DXxC5St6pP/Rjqe8PaRedcGkrygDo1v7Cj0WYzGROlegFMk6h2BEnAfGFt8w==
+  /@cspell/cspell-types/5.15.1:
     dev: false
     engines:
       node: '>=12.13.0'
     resolution:
-      integrity: sha512-T70PvJQ5GV8BW7U2Q5mnrIB5poPnF7bNk7Cp95piYUcv/jlrPdWanDvdp+2gJLM+h0GUDRXscoX3Air4BmAwng==
+      integrity: sha512-rZCJnTQ5O66c5s67nKWw5imvIcs9iHLnU7WNF0AyTGGEP+kpYK/lRLGtU/GICoxTY1V6zjOR6Qow9xmSsNG6zQ==
   /@cspell/dict-ada/1.1.2:
     dev: false
     resolution:
@@ -431,10 +431,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-PV0UBgcBFbBLf/m1wfkVMM8w96kvfHoiCGLWO6BR3Q9v70IXoE4ae0+T+f0CkxcEkacMqEQk/I7vuE9MzrjaNw==
-  /@cspell/dict-html/1.1.9:
+  /@cspell/dict-html/2.0.3:
     dev: false
     resolution:
-      integrity: sha512-vvnYia0tyIS5Fdoz+gEQm77MGZZE66kOJjuNpIYyRHCXFAhWdYz3SmkRm6YKJSWSvuO+WBJYTKDvkOxSh3Fx/w==
+      integrity: sha512-6sORumQ9E7YpJ4vzYb0hHBgiXpehPAawuqmueGmx/PSRkqzMNLEwhYZuTHuIZSO291RTirPMfCkUahRoKdXOOQ==
   /@cspell/dict-java/1.0.23:
     dev: false
     resolution:
@@ -487,10 +487,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-5V/R7PRbbminTpPS3ywgdAalI9BHzcEjEj9ug4kWYvBIGwSnS7T6QCFCiu+e9LvEGUqQC+NHgLY4zs1NaBj2vA==
-  /@cspell/dict-software-terms/2.0.11:
+  /@cspell/dict-software-terms/2.0.12:
     dev: false
     resolution:
-      integrity: sha512-ix5k4m9Y5ZcozgE8QdEhiMIksreGozBETsCo5tGKAs4xDDkS4G07lOMFbek6m5poJ5qk5My0A/iz1j9f3L3aOg==
+      integrity: sha512-zsgraHo5PIDY1mTaWGA2NsxhO8g85inD758pEQL1MeKTFlGiFHT4vW+faryzhvBT5LOMH4LnTs0yGrMyn7JlkQ==
   /@cspell/dict-swift/1.0.1:
     dev: false
     resolution:
@@ -543,25 +543,25 @@ packages:
     dev: false
     resolution:
       integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
-  /@itwin/appui-abstract/3.0.0-dev.148_1f1133e0683841193b047e5518caa238:
+  /@itwin/appui-abstract/3.0.0-dev.177_f4a588df173e76e968bad38684dae86a:
     dependencies:
       '@bentley/icons-generic-webfont': 1.0.34
-      '@itwin/core-bentley': 3.0.0-dev.148
+      '@itwin/core-bentley': 3.0.0-dev.177
     dev: false
     peerDependencies:
-      '@itwin/core-bentley': ^3.0.0-dev.148
+      '@itwin/core-bentley': ^3.0.0-dev.177
     resolution:
-      integrity: sha512-3LQ+8x/xsBkYRoqBA2OwqjcTwmK2LbpBl7ZuaH1vyCtyF2idLZoDbwmhng1T3t3e8+0Ijo6kuggohXX423KtAw==
-  /@itwin/core-backend/3.0.0-dev.148_29276b61277a7cedb96595da2e2a4ac9:
+      integrity: sha512-laNZvImo5Yp8lkCirGIJKhBLGi69d4C0XbaO3WZqMzEQM7ScSzt0+vhJuZz6LXbwmdErz9wl6y4sWPrhokelXA==
+  /@itwin/core-backend/3.0.0-dev.177_ddaece1736e631ce5890f83b6412fe83:
     dependencies:
       '@azure/storage-blob': 12.7.0
-      '@bentley/imodeljs-native': 3.0.24
-      '@bentley/itwin-client': 3.0.0-dev.135_1f1133e0683841193b047e5518caa238
-      '@itwin/core-bentley': 3.0.0-dev.148
-      '@itwin/core-common': 3.0.0-dev.148_2cea9fa5747d2125eec0388ef83db838
-      '@itwin/core-geometry': 3.0.0-dev.148
-      '@itwin/core-telemetry': 3.0.0-dev.148_d828cc9f6ea6a49ebfcae53f8213ec20
-      '@itwin/ecschema-metadata': 3.0.0-dev.148_1f1133e0683841193b047e5518caa238
+      '@bentley/imodeljs-native': 3.0.31
+      '@bentley/itwin-client': 3.0.0-dev.148_f4a588df173e76e968bad38684dae86a
+      '@itwin/core-bentley': 3.0.0-dev.177
+      '@itwin/core-common': 3.0.0-dev.177_aefcd2e401c2232a5c9ebe5404309a19
+      '@itwin/core-geometry': 3.0.0-dev.177
+      '@itwin/core-telemetry': 3.0.0-dev.177_3c9d5cdbd9d964cb1b8b0b9a6759fb40
+      '@itwin/ecschema-metadata': 3.0.0-dev.177_f4a588df173e76e968bad38684dae86a
       form-data: 2.5.1
       fs-extra: 8.1.0
       js-base64: 3.7.2
@@ -573,116 +573,116 @@ packages:
     engines:
       node: '>=12.22.0 < 14.0 || >=14.17.0 <17.0'
     peerDependencies:
-      '@bentley/itwin-client': ^3.0.0-dev.148
-      '@itwin/core-bentley': ^3.0.0-dev.148
-      '@itwin/core-common': ^3.0.0-dev.148
-      '@itwin/core-geometry': ^3.0.0-dev.148
-      '@itwin/ecschema-metadata': ^3.0.0-dev.148
+      '@bentley/itwin-client': ^3.0.0-dev.177
+      '@itwin/core-bentley': ^3.0.0-dev.177
+      '@itwin/core-common': ^3.0.0-dev.177
+      '@itwin/core-geometry': ^3.0.0-dev.177
+      '@itwin/ecschema-metadata': ^3.0.0-dev.177
     resolution:
-      integrity: sha512-wt410S+h9F21dTQ8HUXjY7dBAQ0cDeg8INsrkxm+3cJd09vIFDaGsQQNlITMFgplRns+V39mrr1+1A7Nt8XdKg==
-  /@itwin/core-bentley/3.0.0-dev.148:
+      integrity: sha512-RAc4owJbFpZdum+EKpI/tw5UjMtqVhXDoUBE8M/JDQSmur0YNjslybI67gv+vyLubGg6Mve0yOSGz/0Mx7BoZw==
+  /@itwin/core-bentley/3.0.0-dev.177:
     dev: false
     resolution:
-      integrity: sha512-OVNmxpb7/AAd4pm/cBdE1I+p1lBoiXI3EBaRN1hAPZzqLDk7AbWgTegfQBPXAnyP5FxX9MyeU+lplvsl2aWjXg==
-  /@itwin/core-common/3.0.0-dev.148_2cea9fa5747d2125eec0388ef83db838:
+      integrity: sha512-4UdXP9sBkO3xB+Uyer9FtZeKtKHIMPezj7ezlAhmvMqDURrXOWOy4+lqUFi95mfy+raPCvyGKwl/PRaPsfWluA==
+  /@itwin/core-common/3.0.0-dev.177_aefcd2e401c2232a5c9ebe5404309a19:
     dependencies:
-      '@itwin/core-bentley': 3.0.0-dev.148
-      '@itwin/core-geometry': 3.0.0-dev.148
+      '@itwin/core-bentley': 3.0.0-dev.177
+      '@itwin/core-geometry': 3.0.0-dev.177
       '@ungap/url-search-params': 0.1.4
       flatbuffers: 1.12.0
       js-base64: 3.7.2
       semver: 5.7.1
     dev: false
     peerDependencies:
-      '@itwin/core-bentley': ^3.0.0-dev.148
-      '@itwin/core-geometry': ^3.0.0-dev.148
+      '@itwin/core-bentley': ^3.0.0-dev.177
+      '@itwin/core-geometry': ^3.0.0-dev.177
     resolution:
-      integrity: sha512-wI7tgF1srSIdxJOjHpWAKHuZwRF9l5JwPfIBkgCOm0enLj8V19fjYJMIyyl86P6SaDMr4YhoDxHnkSVgbaJ8qA==
-  /@itwin/core-frontend/3.0.0-dev.148_54235d032abb96d437206068bf58c49f:
+      integrity: sha512-BA8vof9W1rls3UYU80q5W3jLHJTDt2ez4kFmdVE6jEa2k2KGA21+yV3ZuDhBPD/RrAMcSJdO1XFqlUAjPnGlAw==
+  /@itwin/core-frontend/3.0.0-dev.177_aa4eb0ae198d06161ccf95523d3ea495:
     dependencies:
-      '@bentley/itwin-client': 3.0.0-dev.135_1f1133e0683841193b047e5518caa238
-      '@itwin/appui-abstract': 3.0.0-dev.148_1f1133e0683841193b047e5518caa238
-      '@itwin/core-bentley': 3.0.0-dev.148
-      '@itwin/core-common': 3.0.0-dev.148_2cea9fa5747d2125eec0388ef83db838
-      '@itwin/core-geometry': 3.0.0-dev.148
-      '@itwin/core-i18n': 3.0.0-dev.148_1f1133e0683841193b047e5518caa238
-      '@itwin/core-orbitgt': 3.0.0-dev.148
-      '@itwin/core-quantity': 3.0.0-dev.148_1f1133e0683841193b047e5518caa238
-      '@itwin/core-telemetry': 3.0.0-dev.148_d828cc9f6ea6a49ebfcae53f8213ec20
-      '@itwin/webgl-compatibility': 3.0.0-dev.148
+      '@bentley/itwin-client': 3.0.0-dev.148_f4a588df173e76e968bad38684dae86a
+      '@itwin/appui-abstract': 3.0.0-dev.177_f4a588df173e76e968bad38684dae86a
+      '@itwin/core-bentley': 3.0.0-dev.177
+      '@itwin/core-common': 3.0.0-dev.177_aefcd2e401c2232a5c9ebe5404309a19
+      '@itwin/core-geometry': 3.0.0-dev.177
+      '@itwin/core-i18n': 3.0.0-dev.177_f4a588df173e76e968bad38684dae86a
+      '@itwin/core-orbitgt': 3.0.0-dev.177
+      '@itwin/core-quantity': 3.0.0-dev.177_f4a588df173e76e968bad38684dae86a
+      '@itwin/core-telemetry': 3.0.0-dev.177_3c9d5cdbd9d964cb1b8b0b9a6759fb40
+      '@itwin/webgl-compatibility': 3.0.0-dev.177
       fuse.js: 3.6.1
       semver: 5.7.1
       wms-capabilities: 0.4.0
       xml-js: 1.6.11
     dev: false
     peerDependencies:
-      '@bentley/itwin-client': ^3.0.0-dev.148
-      '@itwin/appui-abstract': ^3.0.0-dev.148
-      '@itwin/core-bentley': ^3.0.0-dev.148
-      '@itwin/core-common': ^3.0.0-dev.148
-      '@itwin/core-geometry': ^3.0.0-dev.148
-      '@itwin/core-orbitgt': ^3.0.0-dev.148
-      '@itwin/core-quantity': ^3.0.0-dev.148
-      '@itwin/webgl-compatibility': ^3.0.0-dev.148
+      '@bentley/itwin-client': ^3.0.0-dev.177
+      '@itwin/appui-abstract': ^3.0.0-dev.177
+      '@itwin/core-bentley': ^3.0.0-dev.177
+      '@itwin/core-common': ^3.0.0-dev.177
+      '@itwin/core-geometry': ^3.0.0-dev.177
+      '@itwin/core-orbitgt': ^3.0.0-dev.177
+      '@itwin/core-quantity': ^3.0.0-dev.177
+      '@itwin/webgl-compatibility': ^3.0.0-dev.177
     resolution:
-      integrity: sha512-aiXYxTKWYUSRl3qo6U4WnYMXEdLkEXXG3WryyJBAHMrUPBfVjPY6PMAUJUyHjffGxPeJMKAemRLU2a/u4aSOGA==
-  /@itwin/core-geometry/3.0.0-dev.148:
+      integrity: sha512-3FN4f/cGPDf7EmRDSsBIbeMea23Bea3boUJeZqQ1PsmuM2A7ucJeY4E9eYENLeVpBo97W+mFPfr8a8/Vz8gmww==
+  /@itwin/core-geometry/3.0.0-dev.177:
     dependencies:
-      '@itwin/core-bentley': 3.0.0-dev.148
+      '@itwin/core-bentley': 3.0.0-dev.177
       flatbuffers: 1.12.0
     dev: false
     resolution:
-      integrity: sha512-y1ECs8FTtwozAYTHLYwNTNxXA/NQNYxJt0cOr82KpdX0s0P+Zu/9EBbOp4jLwnh0ap59X7w9IyrdGfi+i8lHYw==
-  /@itwin/core-i18n/3.0.0-dev.148_1f1133e0683841193b047e5518caa238:
+      integrity: sha512-yCGgwxXy1InuaulFASHAO/6Mvj93g2RkfVz4V0EiYEQTjZn2tRMW4iIe07deOE8bxgfcoKNsldU/27y5tHWxww==
+  /@itwin/core-i18n/3.0.0-dev.177_f4a588df173e76e968bad38684dae86a:
     dependencies:
-      '@itwin/core-bentley': 3.0.0-dev.148
-      i18next: 21.6.0
+      '@itwin/core-bentley': 3.0.0-dev.177
+      i18next: 21.6.5
       i18next-browser-languagedetector: 6.1.2
       i18next-http-backend: 1.3.1
       i18next-xhr-backend: 3.2.2
     dev: false
     peerDependencies:
-      '@itwin/core-bentley': ^3.0.0-dev.148
+      '@itwin/core-bentley': ^3.0.0-dev.177
     resolution:
-      integrity: sha512-INy6KUMtn7PpmDuOi+kQTzWoHUr7vrCVF9O2Sd/pdp/f3yMaaHCeuMO9Fwc8hiMUWuRfFakxBnQF2Y5GxdFZVw==
-  /@itwin/core-orbitgt/3.0.0-dev.148:
+      integrity: sha512-1t0dnGstajF96mw8woWKIO17HW1Pogalehz1LQq5+b+cqRvWoPUjKmSyS3XEfggp8Mzm77W4ptvI6iKHR9H4lw==
+  /@itwin/core-orbitgt/3.0.0-dev.177:
     dev: false
     resolution:
-      integrity: sha512-/ncT5TBF4N4Z2KcxzSbN2nZ2Kforv0sF/h8iQ2aN3NBmS6X/ucSeBFmUwVLKEUxoFKZe5tRH3oshTV5/ZYv23g==
-  /@itwin/core-quantity/3.0.0-dev.148_1f1133e0683841193b047e5518caa238:
+      integrity: sha512-Xdg50Y3ZRv/yyhdv8Rz6xi7qBLRbNh1cqqDeqILi1YP1nNHNZPsiqj6DONuEGT4fUaq1xOmo6nZnfj/ekyZBGA==
+  /@itwin/core-quantity/3.0.0-dev.177_f4a588df173e76e968bad38684dae86a:
     dependencies:
-      '@itwin/core-bentley': 3.0.0-dev.148
+      '@itwin/core-bentley': 3.0.0-dev.177
     dev: false
     peerDependencies:
-      '@itwin/core-bentley': ^3.0.0-dev.148
+      '@itwin/core-bentley': ^3.0.0-dev.177
     resolution:
-      integrity: sha512-eIBU2322xW3Q6FUOETUkPF4ChGeiT0pPBQyWmaVdiRua/DsxzPkpo35EjVWQnJyFKQiZR1ZRtVRlw1nzpp8lww==
-  /@itwin/core-telemetry/3.0.0-dev.148_d828cc9f6ea6a49ebfcae53f8213ec20:
+      integrity: sha512-ZfYla+0jkajpqv6SlfkeiYtFmKKU8IoTze7ljPVazG+gv2rxTFURaNFDu4UrWRMONtwwGijCwZsSpFHWsDhKtg==
+  /@itwin/core-telemetry/3.0.0-dev.177_3c9d5cdbd9d964cb1b8b0b9a6759fb40:
     dependencies:
-      '@itwin/core-bentley': 3.0.0-dev.148
-      '@itwin/core-common': 3.0.0-dev.148_2cea9fa5747d2125eec0388ef83db838
+      '@itwin/core-bentley': 3.0.0-dev.177
+      '@itwin/core-common': 3.0.0-dev.177_aefcd2e401c2232a5c9ebe5404309a19
     dev: false
     peerDependencies:
       '@itwin/core-geometry': '*'
     resolution:
-      integrity: sha512-/2y8Of2gqldL81jSoFQBEox/WA33KWLeSuT6BgMGUr0Snulwbg3x25ncemW8hiDS+RpIHWZ37e41cbVL2F9ueA==
-  /@itwin/ecschema-metadata/3.0.0-dev.148_1f1133e0683841193b047e5518caa238:
+      integrity: sha512-FNhRD/d4rsfra9HGhvlqeg75xG5kn0n4yNZajIHqKBgE3mbNulwj+stCRTAK8Mq21i7Dt+0m8Om7XmqIidXNAA==
+  /@itwin/ecschema-metadata/3.0.0-dev.177_f4a588df173e76e968bad38684dae86a:
     dependencies:
-      '@itwin/core-bentley': 3.0.0-dev.148
+      '@itwin/core-bentley': 3.0.0-dev.177
       almost-equal: 1.1.0
     dev: false
     peerDependencies:
-      '@itwin/core-bentley': ^3.0.0-dev.148
+      '@itwin/core-bentley': ^3.0.0-dev.177
     resolution:
-      integrity: sha512-X/9ELuAwgIw9roE5kAL7wpWSOT8j/oWX1vT1hdkogS1iHdxk5RRFffrVhVVYTjnXJbkVrMmSGlGEDBN51DDnTA==
-  /@itwin/eslint-plugin/3.0.0-dev.148_eslint@7.31.0+typescript@4.3.5:
+      integrity: sha512-WVKZjIIgCt3E3QE3J3dkGm6jmVivg4OckXNb2qA8icy0SMHIRyVQRk1E6AXmvmiMBBL+25wK76UEMXog3zITDw==
+  /@itwin/eslint-plugin/3.0.0-dev.177_eslint@7.31.0+typescript@4.4.4:
     dependencies:
-      '@typescript-eslint/eslint-plugin': 4.31.2_472aff7d063412a1919d5255247160ad
-      '@typescript-eslint/parser': 4.31.2_eslint@7.31.0+typescript@4.3.5
+      '@typescript-eslint/eslint-plugin': 4.31.2_effd6c19eb91d288277d259d1bcca7c5
+      '@typescript-eslint/parser': 4.31.2_eslint@7.31.0+typescript@4.4.4
       eslint: 7.31.0
       eslint-import-resolver-node: 0.3.4
       eslint-import-resolver-typescript: 2.4.0_af3c5ebbf5d724335f85761a63ef0220
-      eslint-plugin-deprecation: 1.2.1_eslint@7.31.0+typescript@4.3.5
+      eslint-plugin-deprecation: 1.2.1_eslint@7.31.0+typescript@4.4.4
       eslint-plugin-import: 2.23.4_eslint@7.31.0
       eslint-plugin-jam3: 0.2.3
       eslint-plugin-jsdoc: 35.1.3_eslint@7.31.0
@@ -691,20 +691,20 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.31.0
       eslint-plugin-react-hooks: 4.2.0_eslint@7.31.0
       require-dir: 1.2.0
-      typescript: 4.3.5
+      typescript: 4.4.4
     dev: false
     hasBin: true
     peerDependencies:
       eslint: ^7.0.0
       typescript: ^3.7.0 || ^4.0.0
     resolution:
-      integrity: sha512-CVef8gE8VmNtk7Z0wPh6Rk9o3V8/Q30M6COmtnfmR0feyOPejgRe07FnPEWNJqKX64jrnp1AFdVfRhHkEwlylA==
-  /@itwin/webgl-compatibility/3.0.0-dev.148:
+      integrity: sha512-hFKq2IJ7BvRNsw6NHFlLod77YUNl9kWsUvN5ElHdWQ6tIUJ4IxW/JVL46HN9GRG6w8Cq0DM5vskp7aqx6YC3MQ==
+  /@itwin/webgl-compatibility/3.0.0-dev.177:
     dependencies:
-      '@itwin/core-bentley': 3.0.0-dev.148
+      '@itwin/core-bentley': 3.0.0-dev.177
     dev: false
     resolution:
-      integrity: sha512-Sk5B9k91COuFcWL2aoLzzjeZQFpf9WOVJDyagHHozyegAQqmAMtrhcH8tp5h+gX+UpjsP3LDEI1YYP0PpV0E8A==
+      integrity: sha512-26pOS+wY2Jv/AiPY+aLdRHm4J2lbOktb/bSBhX+ZosLbZrXzm2uK2m9ftO01RyGYd93fEayrjnfJ0plaTAqHiQ==
   /@nodelib/fs.scandir/2.1.5:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -729,12 +729,12 @@ packages:
       node: '>= 8'
     resolution:
       integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
-  /@opentelemetry/api/1.0.3:
+  /@opentelemetry/api/1.0.4:
     dev: false
     engines:
       node: '>=8.0.0'
     resolution:
-      integrity: sha512-puWxACExDe9nxbBB3lOymQFrLYml2dVOrd7USiVRnSbgXE+KwBu+HxFvxrzfqsiSda9IWsXJG1ef7C1O2/GmKQ==
+      integrity: sha512-BuJuXRSJNQ3QoKA6GWWDyuLpOUck+9hAXNMCnrloc1aWVoy6Xq6t9PUV08aBZ4Lutqq2LEHM486bpZqoViScog==
   /@types/chai/4.2.22:
     dev: false
     resolution:
@@ -742,7 +742,7 @@ packages:
   /@types/glob/7.2.0:
     dependencies:
       '@types/minimatch': 3.0.5
-      '@types/node': 16.11.12
+      '@types/node': 16.11.19
     dev: false
     resolution:
       integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==
@@ -764,50 +764,50 @@ packages:
       integrity: sha512-scN0hAWyLVAvLR9AyW7HoFF5sJZglyBsbPuHO4fv7JRvfmPBMfp1ozWqOf/e4wwPNxezBZXRfWzMb6iFLgEVRA==
   /@types/node-fetch/2.5.12:
     dependencies:
-      '@types/node': 16.11.12
+      '@types/node': 16.11.19
       form-data: 3.0.1
     dev: false
     resolution:
       integrity: sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==
-  /@types/node/16.11.12:
+  /@types/node/16.11.19:
     dev: false
     resolution:
-      integrity: sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==
+      integrity: sha512-BPAcfDPoHlRQNKktbsbnpACGdypPFBuX4xQlsWDE7B8XXcfII+SpOLay3/qZmCLb39kV5S1RTYwXdkx2lwLYng==
   /@types/parse-json/4.0.0:
     dev: false
     resolution:
       integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
   /@types/tunnel/0.0.3:
     dependencies:
-      '@types/node': 16.11.12
+      '@types/node': 16.11.19
     dev: false
     resolution:
       integrity: sha512-sOUTGn6h1SfQ+gbgqC364jLFBw2lnFqkgF3q0WovEHRLMrVD1sd5aufqi/aJObLekJO+Aq5z646U4Oxy6shXMA==
   /@types/ws/8.2.2:
     dependencies:
-      '@types/node': 16.11.12
+      '@types/node': 16.11.19
     dev: false
     resolution:
       integrity: sha512-NOn5eIcgWLOo6qW8AcuLZ7G8PycXu0xTxxkS6Q18VWFxgPUSOwV0pBj2a/4viNZVu25i7RIB7GttdkAIUUXOOg==
   /@types/yauzl/2.9.2:
     dependencies:
-      '@types/node': 16.11.12
+      '@types/node': 16.11.19
     dev: false
     optional: true
     resolution:
       integrity: sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==
-  /@typescript-eslint/eslint-plugin/4.28.5_514553717ff968e20f6d1c6e521f8616:
+  /@typescript-eslint/eslint-plugin/4.28.5_2d27c79b551e458fb3b3f741bd766f57:
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.28.5_eslint@7.31.0+typescript@4.3.5
-      '@typescript-eslint/parser': 4.28.5_eslint@7.31.0+typescript@4.3.5
+      '@typescript-eslint/experimental-utils': 4.28.5_eslint@7.31.0+typescript@4.4.4
+      '@typescript-eslint/parser': 4.28.5_eslint@7.31.0+typescript@4.4.4
       '@typescript-eslint/scope-manager': 4.28.5
       debug: 4.3.3
       eslint: 7.31.0
       functional-red-black-tree: 1.0.1
       regexpp: 3.2.0
       semver: 7.3.5
-      tsutils: 3.21.0_typescript@4.3.5
-      typescript: 4.3.5
+      tsutils: 3.21.0_typescript@4.4.4
+      typescript: 4.4.4
     dev: false
     engines:
       node: ^10.12.0 || >=12.0.0
@@ -820,18 +820,18 @@ packages:
         optional: true
     resolution:
       integrity: sha512-m31cPEnbuCqXtEZQJOXAHsHvtoDi9OVaeL5wZnO2KZTnkvELk+u6J6jHg+NzvWQxk+87Zjbc4lJS4NHmgImz6Q==
-  /@typescript-eslint/eslint-plugin/4.31.2_472aff7d063412a1919d5255247160ad:
+  /@typescript-eslint/eslint-plugin/4.31.2_effd6c19eb91d288277d259d1bcca7c5:
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.31.2_eslint@7.31.0+typescript@4.3.5
-      '@typescript-eslint/parser': 4.31.2_eslint@7.31.0+typescript@4.3.5
+      '@typescript-eslint/experimental-utils': 4.31.2_eslint@7.31.0+typescript@4.4.4
+      '@typescript-eslint/parser': 4.31.2_eslint@7.31.0+typescript@4.4.4
       '@typescript-eslint/scope-manager': 4.31.2
       debug: 4.3.3
       eslint: 7.31.0
       functional-red-black-tree: 1.0.1
       regexpp: 3.2.0
       semver: 7.3.5
-      tsutils: 3.21.0_typescript@4.3.5
-      typescript: 4.3.5
+      tsutils: 3.21.0_typescript@4.4.4
+      typescript: 4.4.4
     dev: false
     engines:
       node: ^10.12.0 || >=12.0.0
@@ -844,11 +844,11 @@ packages:
         optional: true
     resolution:
       integrity: sha512-w63SCQ4bIwWN/+3FxzpnWrDjQRXVEGiTt9tJTRptRXeFvdZc/wLiz3FQUwNQ2CVoRGI6KUWMNUj/pk63noUfcA==
-  /@typescript-eslint/experimental-utils/3.10.1_eslint@7.31.0+typescript@4.3.5:
+  /@typescript-eslint/experimental-utils/3.10.1_eslint@7.31.0+typescript@4.4.4:
     dependencies:
       '@types/json-schema': 7.0.9
       '@typescript-eslint/types': 3.10.1
-      '@typescript-eslint/typescript-estree': 3.10.1_typescript@4.3.5
+      '@typescript-eslint/typescript-estree': 3.10.1_typescript@4.4.4
       eslint: 7.31.0
       eslint-scope: 5.1.1
       eslint-utils: 2.1.0
@@ -860,16 +860,16 @@ packages:
       typescript: '*'
     resolution:
       integrity: sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==
-  /@typescript-eslint/experimental-utils/4.28.5_eslint@7.31.0+typescript@4.3.5:
+  /@typescript-eslint/experimental-utils/4.28.5_eslint@7.31.0+typescript@4.4.4:
     dependencies:
       '@types/json-schema': 7.0.9
       '@typescript-eslint/scope-manager': 4.28.5
       '@typescript-eslint/types': 4.28.5
-      '@typescript-eslint/typescript-estree': 4.28.5_typescript@4.3.5
+      '@typescript-eslint/typescript-estree': 4.28.5_typescript@4.4.4
       eslint: 7.31.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@7.31.0
-      typescript: 4.3.5
+      typescript: 4.4.4
     dev: false
     engines:
       node: ^10.12.0 || >=12.0.0
@@ -878,12 +878,12 @@ packages:
       typescript: '*'
     resolution:
       integrity: sha512-bGPLCOJAa+j49hsynTaAtQIWg6uZd8VLiPcyDe4QPULsvQwLHGLSGKKcBN8/lBxIX14F74UEMK2zNDI8r0okwA==
-  /@typescript-eslint/experimental-utils/4.31.2_eslint@7.31.0+typescript@4.3.5:
+  /@typescript-eslint/experimental-utils/4.31.2_eslint@7.31.0+typescript@4.4.4:
     dependencies:
       '@types/json-schema': 7.0.9
       '@typescript-eslint/scope-manager': 4.31.2
       '@typescript-eslint/types': 4.31.2
-      '@typescript-eslint/typescript-estree': 4.31.2_typescript@4.3.5
+      '@typescript-eslint/typescript-estree': 4.31.2_typescript@4.4.4
       eslint: 7.31.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@7.31.0
@@ -895,14 +895,14 @@ packages:
       typescript: '*'
     resolution:
       integrity: sha512-3tm2T4nyA970yQ6R3JZV9l0yilE2FedYg8dcXrTar34zC9r6JB7WyBQbpIVongKPlhEMjhQ01qkwrzWy38Bk1Q==
-  /@typescript-eslint/parser/4.28.5_eslint@7.31.0+typescript@4.3.5:
+  /@typescript-eslint/parser/4.28.5_eslint@7.31.0+typescript@4.4.4:
     dependencies:
       '@typescript-eslint/scope-manager': 4.28.5
       '@typescript-eslint/types': 4.28.5
-      '@typescript-eslint/typescript-estree': 4.28.5_typescript@4.3.5
+      '@typescript-eslint/typescript-estree': 4.28.5_typescript@4.4.4
       debug: 4.3.3
       eslint: 7.31.0
-      typescript: 4.3.5
+      typescript: 4.4.4
     dev: false
     engines:
       node: ^10.12.0 || >=12.0.0
@@ -914,14 +914,14 @@ packages:
         optional: true
     resolution:
       integrity: sha512-NPCOGhTnkXGMqTznqgVbA5LqVsnw+i3+XA1UKLnAb+MG1Y1rP4ZSK9GX0kJBmAZTMIktf+dTwXToT6kFwyimbw==
-  /@typescript-eslint/parser/4.31.2_eslint@7.31.0+typescript@4.3.5:
+  /@typescript-eslint/parser/4.31.2_eslint@7.31.0+typescript@4.4.4:
     dependencies:
       '@typescript-eslint/scope-manager': 4.31.2
       '@typescript-eslint/types': 4.31.2
-      '@typescript-eslint/typescript-estree': 4.31.2_typescript@4.3.5
+      '@typescript-eslint/typescript-estree': 4.31.2_typescript@4.4.4
       debug: 4.3.3
       eslint: 7.31.0
-      typescript: 4.3.5
+      typescript: 4.4.4
     dev: false
     engines:
       node: ^10.12.0 || >=12.0.0
@@ -969,7 +969,7 @@ packages:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     resolution:
       integrity: sha512-kWiTTBCTKEdBGrZKwFvOlGNcAsKGJSBc8xLvSjSppFO88AqGxGNYtF36EuEYG6XZ9vT0xX8RNiHbQUKglbSi1w==
-  /@typescript-eslint/typescript-estree/3.10.1_typescript@4.3.5:
+  /@typescript-eslint/typescript-estree/3.10.1_typescript@4.4.4:
     dependencies:
       '@typescript-eslint/types': 3.10.1
       '@typescript-eslint/visitor-keys': 3.10.1
@@ -978,8 +978,8 @@ packages:
       is-glob: 4.0.3
       lodash: 4.17.21
       semver: 7.3.5
-      tsutils: 3.21.0_typescript@4.3.5
-      typescript: 4.3.5
+      tsutils: 3.21.0_typescript@4.4.4
+      typescript: 4.4.4
     dev: false
     engines:
       node: ^10.12.0 || >=12.0.0
@@ -990,7 +990,7 @@ packages:
         optional: true
     resolution:
       integrity: sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==
-  /@typescript-eslint/typescript-estree/4.28.5_typescript@4.3.5:
+  /@typescript-eslint/typescript-estree/4.28.5_typescript@4.4.4:
     dependencies:
       '@typescript-eslint/types': 4.28.5
       '@typescript-eslint/visitor-keys': 4.28.5
@@ -998,8 +998,8 @@ packages:
       globby: 11.0.4
       is-glob: 4.0.3
       semver: 7.3.5
-      tsutils: 3.21.0_typescript@4.3.5
-      typescript: 4.3.5
+      tsutils: 3.21.0_typescript@4.4.4
+      typescript: 4.4.4
     dev: false
     engines:
       node: ^10.12.0 || >=12.0.0
@@ -1010,7 +1010,7 @@ packages:
         optional: true
     resolution:
       integrity: sha512-FzJUKsBX8poCCdve7iV7ShirP8V+ys2t1fvamVeD1rWpiAnIm550a+BX/fmTHrjEpQJ7ZAn+Z7ZZwJjytk9rZw==
-  /@typescript-eslint/typescript-estree/4.31.2_typescript@4.3.5:
+  /@typescript-eslint/typescript-estree/4.31.2_typescript@4.4.4:
     dependencies:
       '@typescript-eslint/types': 4.31.2
       '@typescript-eslint/visitor-keys': 4.31.2
@@ -1018,8 +1018,8 @@ packages:
       globby: 11.0.4
       is-glob: 4.0.3
       semver: 7.3.5
-      tsutils: 3.21.0_typescript@4.3.5
-      typescript: 4.3.5
+      tsutils: 3.21.0_typescript@4.4.4
+      typescript: 4.4.4
     dev: false
     engines:
       node: ^10.12.0 || >=12.0.0
@@ -1159,7 +1159,7 @@ packages:
   /anymatch/3.1.2:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.0
+      picomatch: 2.3.1
     dev: false
     engines:
       node: '>= 8'
@@ -1189,8 +1189,8 @@ packages:
       integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
   /aria-query/4.2.2:
     dependencies:
-      '@babel/runtime': 7.16.5
-      '@babel/runtime-corejs3': 7.16.5
+      '@babel/runtime': 7.16.7
+      '@babel/runtime-corejs3': 7.16.7
     dev: false
     engines:
       node: '>=6.0'
@@ -1486,12 +1486,12 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
-  /camelcase/6.2.1:
+  /camelcase/6.3.0:
     dev: false
     engines:
       node: '>=10'
     resolution:
-      integrity: sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==
+      integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
   /chai/4.3.4:
     dependencies:
       assertion-error: 1.1.0
@@ -1678,7 +1678,7 @@ packages:
   /configstore/5.0.1:
     dependencies:
       dot-prop: 5.3.0
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.9
       make-dir: 3.1.0
       unique-string: 2.0.0
       write-file-atomic: 3.0.3
@@ -1704,13 +1704,13 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
-  /core-js-pure/3.19.3:
+  /core-js-pure/3.20.2:
     dev: false
     requiresBuild: true
     resolution:
-      integrity: sha512-N3JruInmCyt7EJj5mAq3csCgGYgiSqu7p7TQp2KOztr180/OAIxyIvL1FCjzgmQk/t3Yniua50Fsak7FShI9lA==
+      integrity: sha512-CmWHvSKn2vNL6p6StNp1EmMIfVY/pqn3JLAjfZQ8WZGPOlGoO92EkX9/Mk81i6GxvoPXjUqEQnpM3rJ5QxxIOg==
   /core-js/2.6.12:
-    deprecated: 'core-js@<3.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.'
+    deprecated: 'core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.'
     dev: false
     requiresBuild: true
     resolution:
@@ -1733,7 +1733,7 @@ packages:
       integrity: sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==
   /cp-file/6.2.0:
     dependencies:
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.9
       make-dir: 2.1.0
       nested-error-stacks: 2.1.0
       pify: 4.0.1
@@ -1752,7 +1752,7 @@ packages:
       glob2base: 0.0.12
       minimatch: 3.0.4
       mkdirp: 0.5.5
-      resolve: 1.20.0
+      resolve: 1.21.0
       safe-buffer: 5.2.1
       shell-quote: 1.7.3
       subarg: 1.0.0
@@ -1789,44 +1789,44 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
-  /cspell-glob/5.13.3:
+  /cspell-glob/5.15.1:
     dependencies:
       micromatch: 4.0.4
     dev: false
     engines:
       node: '>=12.13.0'
     resolution:
-      integrity: sha512-9g1/AJs7ws1tLDXFJwcePhmab3wxrWbxEZVfmJIHhawp9rWc+cU6BZFdxJJ52EHClKa+DuKJxYsyohE1ctD9rA==
-  /cspell-io/5.13.3:
+      integrity: sha512-Q03f8/BNVba/r8wDcII5XSE/PaJrlaUSE621vPaupM4AnMEt7piklLTT1KR921el4lwNThzpr1nIaSut4G5T1Q==
+  /cspell-io/5.15.1:
     dev: false
     engines:
       node: '>=12.13.0'
     resolution:
-      integrity: sha512-4OwpSprgaUc8yZGWHUBiy5Uv528gmk7wMai6c2ZQOd8HEOkIoxWIjCVnOEYHsXBflhcrvSPxirwcsLOcGU2bkQ==
-  /cspell-lib/5.13.3:
+      integrity: sha512-JkBDZFQcuE/ve9pqpjMkUVKQgOJLWlGvvOm8GOCI9sG9dFE+eZVW5MHCS1VuGPGKfALh+xhmtcXB1+Y4MdYz4A==
+  /cspell-lib/5.15.1:
     dependencies:
-      '@cspell/cspell-bundled-dicts': 5.13.3
-      '@cspell/cspell-types': 5.13.3
+      '@cspell/cspell-bundled-dicts': 5.15.1
+      '@cspell/cspell-types': 5.15.1
       clear-module: 4.1.2
       comment-json: 4.1.1
       configstore: 5.0.1
       cosmiconfig: 7.0.1
-      cspell-glob: 5.13.3
-      cspell-io: 5.13.3
-      cspell-trie-lib: 5.13.3
+      cspell-glob: 5.15.1
+      cspell-io: 5.15.1
+      cspell-trie-lib: 5.15.1
       find-up: 5.0.0
       fs-extra: 10.0.0
       gensequence: 3.1.1
       import-fresh: 3.3.0
       resolve-from: 5.0.0
       resolve-global: 1.0.0
-      vscode-uri: 3.0.2
+      vscode-uri: 3.0.3
     dev: false
     engines:
       node: '>=12.13.0'
     resolution:
-      integrity: sha512-X4GkrxhMkNTH+H+irHHL2GluwQHhR3G0/5+bF/KOYtZ4Ypi2iVYkzcxB3xPmaeM82+NHyoNu/TU5I1jspt4GSg==
-  /cspell-trie-lib/5.13.3:
+      integrity: sha512-8x76yse70CT5+lk9Jwwt6wuBlTiflWouhcj1zUONxzJM7kstgNUdTNBoQRDoCjj/uGOQSKIwa4YGjV29vMzGAA==
+  /cspell-trie-lib/5.15.1:
     dependencies:
       fs-extra: 10.0.0
       gensequence: 3.1.1
@@ -1834,30 +1834,30 @@ packages:
     engines:
       node: '>=12.13.0'
     resolution:
-      integrity: sha512-CbydOTo7u/XxBn2tyWwIkl/KQ8ikLT4TSBM2M/3e7pZMtbAKGlV2L8P0M77mHbz5HrlL+pqrU/Ywk7TwoXmKNQ==
+      integrity: sha512-+vQeVXppreAMW/EjmYX5PUokzLgBcV31Wbj9OgJG0afxCKSXMWH6F3oTNLTCjqUx+WEPHo7Im5nXAE35y7xQwA==
   /cspell/5.6.7:
     dependencies:
-      '@cspell/cspell-types': 5.13.3
+      '@cspell/cspell-types': 5.15.1
       chalk: 4.1.2
       commander: 8.3.0
       comment-json: 4.1.1
-      cspell-glob: 5.13.3
-      cspell-lib: 5.13.3
+      cspell-glob: 5.15.1
+      cspell-lib: 5.15.1
       fs-extra: 10.0.0
       get-stdin: 8.0.0
       glob: 7.2.0
       strip-ansi: 6.0.1
-      vscode-uri: 3.0.2
+      vscode-uri: 3.0.3
     dev: false
     engines:
       node: '>=12.0.0'
     hasBin: true
     resolution:
       integrity: sha512-/euddi9URCRkQSOhJQW+z2aTBn5e0qAjgiPUhavTr9Sb5nRgmUSiHwWHsuLbFlvjcxDEPDnF2cCmmHHLWIIqig==
-  /damerau-levenshtein/1.0.7:
+  /damerau-levenshtein/1.0.8:
     dev: false
     resolution:
-      integrity: sha512-VvdQIPGdWP0SqFXghj79Wf/5LArmreyMsGLa6FG6iC4t3j7j5s71TrwWmT/4akbDQIqjfACkLZmjXhA7g2oUZw==
+      integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==
   /debug/2.6.9:
     dependencies:
       ms: 2.0.0
@@ -2113,7 +2113,7 @@ packages:
       is-shared-array-buffer: 1.0.1
       is-string: 1.0.7
       is-weakref: 1.0.2
-      object-inspect: 1.11.1
+      object-inspect: 1.12.0
       object-keys: 1.1.1
       object.assign: 4.1.2
       string.prototype.trimend: 1.0.4
@@ -2159,14 +2159,14 @@ packages:
   /eslint-import-resolver-node/0.3.4:
     dependencies:
       debug: 2.6.9
-      resolve: 1.20.0
+      resolve: 1.21.0
     dev: false
     resolution:
       integrity: sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==
   /eslint-import-resolver-node/0.3.6:
     dependencies:
       debug: 3.2.7
-      resolve: 1.20.0
+      resolve: 1.21.0
     dev: false
     resolution:
       integrity: sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==
@@ -2177,7 +2177,7 @@ packages:
       eslint-plugin-import: 2.23.4_eslint@7.31.0
       glob: 7.2.0
       is-glob: 4.0.3
-      resolve: 1.20.0
+      resolve: 1.21.0
       tsconfig-paths: 3.12.0
     dev: false
     engines:
@@ -2187,23 +2187,22 @@ packages:
       eslint-plugin-import: '*'
     resolution:
       integrity: sha512-useJKURidCcldRLCNKWemr1fFQL1SzB3G4a0li6lFGvlc5xGe1hY343bvG07cbpCzPuM/lK19FIJB3XGFSkplA==
-  /eslint-module-utils/2.7.1:
+  /eslint-module-utils/2.7.2:
     dependencies:
       debug: 3.2.7
       find-up: 2.1.0
-      pkg-dir: 2.0.0
     dev: false
     engines:
       node: '>=4'
     resolution:
-      integrity: sha512-fjoetBXQZq2tSTWZ9yWVl2KuFrTZZH3V+9iD1V1RfpDgxzJR+mPd/KZmMiA8gbPqdBzpNiEHOuT7IYEWxrH0zQ==
-  /eslint-plugin-deprecation/1.2.1_eslint@7.31.0+typescript@4.3.5:
+      integrity: sha512-zquepFnWCY2ISMFwD/DqzaM++H+7PDzOpUvotJWm/y1BAFt5R4oeULgdrTejKqLkz7MA/tgstsUMNYc7wNdTrg==
+  /eslint-plugin-deprecation/1.2.1_eslint@7.31.0+typescript@4.4.4:
     dependencies:
-      '@typescript-eslint/experimental-utils': 3.10.1_eslint@7.31.0+typescript@4.3.5
+      '@typescript-eslint/experimental-utils': 3.10.1_eslint@7.31.0+typescript@4.4.4
       eslint: 7.31.0
       tslib: 1.14.1
-      tsutils: 3.21.0_typescript@4.3.5
-      typescript: 4.3.5
+      tsutils: 3.21.0_typescript@4.4.4
+      typescript: 4.4.4
     dev: false
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0
@@ -2218,15 +2217,15 @@ packages:
       doctrine: 2.1.0
       eslint: 7.31.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.1
+      eslint-module-utils: 2.7.2
       find-up: 2.1.0
       has: 1.0.3
-      is-core-module: 2.8.0
+      is-core-module: 2.8.1
       minimatch: 3.0.4
       object.values: 1.1.5
       pkg-up: 2.0.0
       read-pkg-up: 3.0.0
-      resolve: 1.20.0
+      resolve: 1.21.0
       tsconfig-paths: 3.12.0
     dev: false
     engines:
@@ -2266,13 +2265,13 @@ packages:
       integrity: sha512-9AVpCssb7+cfEx3GJtnhJ8yLOVsHDKGMgngcfvwFBxdcOVPFhLENReL5aX1R2gNiG3psqIWFVBpSPnPQTrMZUA==
   /eslint-plugin-jsx-a11y/6.4.1_eslint@7.31.0:
     dependencies:
-      '@babel/runtime': 7.16.5
+      '@babel/runtime': 7.16.7
       aria-query: 4.2.2
       array-includes: 3.1.4
       ast-types-flow: 0.0.7
       axe-core: 4.3.5
       axobject-query: 2.2.0
-      damerau-levenshtein: 1.0.7
+      damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
       eslint: 7.31.0
       has: 1.0.3
@@ -2327,7 +2326,7 @@ packages:
       object.entries: 1.1.5
       object.fromentries: 2.0.5
       object.values: 1.1.5
-      prop-types: 15.7.2
+      prop-types: 15.8.1
       resolve: 2.0.0-next.3
       string.prototype.matchall: 4.0.6
     dev: false
@@ -2416,7 +2415,7 @@ packages:
       semver: 7.3.5
       strip-ansi: 6.0.1
       strip-json-comments: 3.1.1
-      table: 6.7.5
+      table: 6.8.0
       text-table: 0.2.0
       v8-compile-cache: 2.3.0
     dev: false
@@ -2569,7 +2568,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
-  /fast-glob/3.2.7:
+  /fast-glob/3.2.8:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
       '@nodelib/fs.walk': 1.2.8
@@ -2580,7 +2579,7 @@ packages:
     engines:
       node: '>=8'
     resolution:
-      integrity: sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==
+      integrity: sha512-UsiHHXoDbC3iS7vBOFvld7Q9XqBu318xztdHiL10Fjov3AK5GI5bek2ZJkxZcjPguOYH39UL1W4A6w+l7tpNtw==
   /fast-json-stable-stringify/2.1.0:
     dev: false
     resolution:
@@ -2806,7 +2805,7 @@ packages:
       integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
   /fs-extra/10.0.0:
     dependencies:
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.9
       jsonfile: 6.1.0
       universalify: 2.0.0
     dev: false
@@ -2816,7 +2815,7 @@ packages:
       integrity: sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==
   /fs-extra/8.1.0:
     dependencies:
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.9
       jsonfile: 4.0.0
       universalify: 0.1.2
     dev: false
@@ -3002,9 +3001,9 @@ packages:
       '@types/glob': 7.2.0
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.2.7
+      fast-glob: 3.2.8
       glob: 7.2.0
-      ignore: 5.1.9
+      ignore: 5.2.0
       merge2: 1.4.1
       slash: 3.0.0
     dev: false
@@ -3016,8 +3015,8 @@ packages:
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.2.7
-      ignore: 5.1.9
+      fast-glob: 3.2.8
+      ignore: 5.2.0
       merge2: 1.4.1
       slash: 3.0.0
     dev: false
@@ -3025,10 +3024,10 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
-  /graceful-fs/4.2.8:
+  /graceful-fs/4.2.9:
     dev: false
     resolution:
-      integrity: sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
+      integrity: sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
   /growl/1.10.5:
     dev: false
     engines:
@@ -3158,7 +3157,7 @@ packages:
       integrity: sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
   /i18next-browser-languagedetector/6.1.2:
     dependencies:
-      '@babel/runtime': 7.16.5
+      '@babel/runtime': 7.16.7
     dev: false
     resolution:
       integrity: sha512-YDzIGHhMRvr7M+c8B3EQUKyiMBhfqox4o1qkFvt4QXuu5V2cxf74+NCr+VEkUuU0y+RwcupA238eeolW1Yn80g==
@@ -3170,17 +3169,17 @@ packages:
       integrity: sha512-o79n4GBBRpl20hByC+ne/S1UaSZ4iGAn59Hu2TEZGjN0WLB72L7WrM39Cshziyrssp6MQfdI8wjToU2Q6kpSvA==
   /i18next-xhr-backend/3.2.2:
     dependencies:
-      '@babel/runtime': 7.16.5
+      '@babel/runtime': 7.16.7
     deprecated: replaced by i18next-http-backend
     dev: false
     resolution:
       integrity: sha512-OtRf2Vo3IqAxsttQbpjYnmMML12IMB5e0fc5B7qKJFLScitYaXa1OhMX0n0X/3vrfFlpHL9Ro/H+ps4Ej2j7QQ==
-  /i18next/21.6.0:
+  /i18next/21.6.5:
     dependencies:
-      '@babel/runtime': 7.16.5
+      '@babel/runtime': 7.16.7
     dev: false
     resolution:
-      integrity: sha512-RjNuACL35wWZgtkyMcjcCmK7R72u3P6jTNbGKzrvHGI9M0iK5Vn1DsBIwOByppaXLIbe0viJ79Nz2h8w1UwPoQ==
+      integrity: sha512-1oimhzFEpkmxpY2yDyghdycyA1bCKrh9zf04qiB2HytKJCqlrA5e8JfL6KyK/oZvZABLP0GohsZ+tvhHmd+OTA==
   /ieee754/1.2.1:
     dev: false
     resolution:
@@ -3191,12 +3190,12 @@ packages:
       node: '>= 4'
     resolution:
       integrity: sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
-  /ignore/5.1.9:
+  /ignore/5.2.0:
     dev: false
     engines:
       node: '>= 4'
     resolution:
-      integrity: sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==
+      integrity: sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
   /import-fresh/3.3.0:
     dependencies:
       parent-module: 1.0.1
@@ -3302,12 +3301,12 @@ packages:
       node: '>= 0.4'
     resolution:
       integrity: sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==
-  /is-core-module/2.8.0:
+  /is-core-module/2.8.1:
     dependencies:
       has: 1.0.3
     dev: false
     resolution:
-      integrity: sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==
+      integrity: sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==
   /is-data-descriptor/0.1.4:
     dependencies:
       kind-of: 3.2.2
@@ -3595,11 +3594,11 @@ packages:
       integrity: sha512-vrRztU9VRRFDyC+aklfLoeXyNdTfga2EI3udDGn4cZ6fpSXpHLV9X6CHvfoMCPtggg8zvDDmC4b9xfu0z6/llA==
   /istanbul-lib-instrument/3.3.0:
     dependencies:
-      '@babel/generator': 7.16.5
-      '@babel/parser': 7.16.5
-      '@babel/template': 7.16.0
-      '@babel/traverse': 7.16.5
-      '@babel/types': 7.16.0
+      '@babel/generator': 7.16.7
+      '@babel/parser': 7.16.7
+      '@babel/template': 7.16.7
+      '@babel/traverse': 7.16.7
+      '@babel/types': 7.16.7
       istanbul-lib-coverage: 2.0.5
       semver: 6.3.0
     dev: false
@@ -3718,7 +3717,7 @@ packages:
   /jsonfile/4.0.0:
     dev: false
     optionalDependencies:
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.9
     resolution:
       integrity: sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
   /jsonfile/6.1.0:
@@ -3726,7 +3725,7 @@ packages:
       universalify: 2.0.0
     dev: false
     optionalDependencies:
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.9
     resolution:
       integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
   /jsx-ast-utils/3.2.1:
@@ -3791,7 +3790,7 @@ packages:
       integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
   /load-json-file/4.0.0:
     dependencies:
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.9
       parse-json: 4.0.0
       pify: 3.0.0
       strip-bom: 3.0.0
@@ -3977,7 +3976,7 @@ packages:
   /micromatch/4.0.4:
     dependencies:
       braces: 3.0.2
-      picomatch: 2.3.0
+      picomatch: 2.3.1
     dev: false
     engines:
       node: '>=8.6'
@@ -4140,7 +4139,7 @@ packages:
   /normalize-package-data/2.5.0:
     dependencies:
       hosted-git-info: 2.8.9
-      resolve: 1.20.0
+      resolve: 1.21.0
       semver: 5.7.1
       validate-npm-package-license: 3.0.4
     dev: false
@@ -4208,10 +4207,10 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-fn2Fi3gb18mRpBupde04EnVOmYw=
-  /object-inspect/1.11.1:
+  /object-inspect/1.12.0:
     dev: false
     resolution:
-      integrity: sha512-If7BjFlpkzzBeV1cqgT3OSWT3azyoxDGajR+iGnFBfVV2EWyDyWaZZW2ERDjUaY2QM8i5jI3Sj7mhsM4DDAqWA==
+      integrity: sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==
   /object-keys/1.1.1:
     dev: false
     engines:
@@ -4379,7 +4378,7 @@ packages:
       integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
   /package-hash/3.0.0:
     dependencies:
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.9
       hasha: 3.0.0
       lodash.flattendeep: 4.4.0
       release-zalgo: 1.0.0
@@ -4426,7 +4425,7 @@ packages:
       integrity: sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
   /parse-json/5.2.0:
     dependencies:
-      '@babel/code-frame': 7.16.0
+      '@babel/code-frame': 7.16.7
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -4491,12 +4490,12 @@ packages:
     dev: false
     resolution:
       integrity: sha1-elfrVQpng/kRUzH89GY9XI4AelA=
-  /picomatch/2.3.0:
+  /picomatch/2.3.1:
     dev: false
     engines:
       node: '>=8.6'
     resolution:
-      integrity: sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
+      integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
   /pify/3.0.0:
     dev: false
     engines:
@@ -4509,14 +4508,6 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
-  /pkg-dir/2.0.0:
-    dependencies:
-      find-up: 2.1.0
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=
   /pkg-dir/3.0.0:
     dependencies:
       find-up: 3.0.0
@@ -4581,14 +4572,14 @@ packages:
       node: '>=0.4.0'
     resolution:
       integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
-  /prop-types/15.7.2:
+  /prop-types/15.8.1:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
     dev: false
     resolution:
-      integrity: sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+      integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
   /proxy-from-env/1.1.0:
     dev: false
     resolution:
@@ -4728,7 +4719,7 @@ packages:
       integrity: sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
   /readdirp/2.2.1:
     dependencies:
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.9
       micromatch: 3.1.10
       readable-stream: 2.3.7
     dev: false
@@ -4738,7 +4729,7 @@ packages:
       integrity: sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==
   /readdirp/3.6.0:
     dependencies:
-      picomatch: 2.3.0
+      picomatch: 2.3.1
     dev: false
     engines:
       node: '>=8.10.0'
@@ -4869,16 +4860,18 @@ packages:
     dev: false
     resolution:
       integrity: sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
-  /resolve/1.20.0:
+  /resolve/1.21.0:
     dependencies:
-      is-core-module: 2.8.0
+      is-core-module: 2.8.1
       path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
     dev: false
+    hasBin: true
     resolution:
-      integrity: sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
+      integrity: sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==
   /resolve/2.0.0-next.3:
     dependencies:
-      is-core-module: 2.8.0
+      is-core-module: 2.8.1
       path-parse: 1.0.7
     dev: false
     resolution:
@@ -5000,7 +4993,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       get-intrinsic: 1.1.1
-      object-inspect: 1.11.1
+      object-inspect: 1.12.0
     dev: false
     resolution:
       integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
@@ -5282,6 +5275,7 @@ packages:
       qs: 6.10.2
       readable-stream: 3.6.0
       semver: 7.3.5
+    deprecated: 'Please upgrade to v7.0.0+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>. Thanks to @shadowgate15, @spence-s, and @niftylettuce. Superagent is sponsored by Forward Email @ <https://forwardemail.net>'
     dev: false
     engines:
       node: '>= 7.0.0'
@@ -5319,7 +5313,13 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
-  /table/6.7.5:
+  /supports-preserve-symlinks-flag/1.0.0:
+    dev: false
+    engines:
+      node: '>= 0.4'
+    resolution:
+      integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+  /table/6.8.0:
     dependencies:
       ajv: 8.8.2
       lodash.truncate: 4.4.2
@@ -5330,7 +5330,7 @@ packages:
     engines:
       node: '>=10.0.0'
     resolution:
-      integrity: sha512-LFNeryOqiQHqCVKzhkymKwt6ozeRhlm8IL1mE8rNUurkir4heF6PzMyRgaTa4tlyPTGGgXuvVOF/OLWiH09Lqw==
+      integrity: sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==
   /tar-fs/2.0.0:
     dependencies:
       chownr: 1.1.4
@@ -5450,10 +5450,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
-  /tsutils/3.21.0_typescript@4.3.5:
+  /tsutils/3.21.0_typescript@4.4.4:
     dependencies:
       tslib: 1.14.1
-      typescript: 4.3.5
+      typescript: 4.4.4
     dev: false
     engines:
       node: '>= 6'
@@ -5493,13 +5493,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
-  /typescript/4.3.5:
+  /typescript/4.4.4:
     dev: false
     engines:
       node: '>=4.2.0'
     hasBin: true
     resolution:
-      integrity: sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+      integrity: sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
   /uid-safe/2.1.5:
     dependencies:
       random-bytes: 1.0.0
@@ -5607,10 +5607,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==
-  /vscode-uri/3.0.2:
+  /vscode-uri/3.0.3:
     dev: false
     resolution:
-      integrity: sha512-jkjy6pjU1fxUvI51P+gCsxg1u2n8LSt0W6KrCNQceaziKzff74GoWmjVG46KieVzybO1sttPQmYfrwSHey7GUA==
+      integrity: sha512-EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA==
   /webidl-conversions/3.0.1:
     dev: false
     resolution:
@@ -5701,7 +5701,7 @@ packages:
       integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
   /write-file-atomic/2.4.3:
     dependencies:
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.9
       imurmurhash: 0.1.4
       signal-exit: 3.0.6
     dev: false
@@ -5817,7 +5817,7 @@ packages:
       integrity: sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
   /yargs-unparser/2.0.0:
     dependencies:
-      camelcase: 6.2.1
+      camelcase: 6.3.0
       decamelize: 4.0.0
       flat: 5.0.2
       is-plain-obj: 2.1.0
@@ -5868,22 +5868,22 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
-  'file:projects/imodels-access-backend-tests.tgz_4bd45436c7446ce6f2c68b792e01fc06':
+  'file:projects/imodels-access-backend-tests.tgz_b5694a69aef35f9e2c3d7f6af9a480ab':
     dependencies:
-      '@itwin/core-backend': 3.0.0-dev.148_29276b61277a7cedb96595da2e2a4ac9
-      '@itwin/core-bentley': 3.0.0-dev.148
-      '@itwin/core-common': 3.0.0-dev.148_2cea9fa5747d2125eec0388ef83db838
-      '@itwin/ecschema-metadata': 3.0.0-dev.148_1f1133e0683841193b047e5518caa238
+      '@itwin/core-backend': 3.0.0-dev.177_ddaece1736e631ce5890f83b6412fe83
+      '@itwin/core-bentley': 3.0.0-dev.177
+      '@itwin/core-common': 3.0.0-dev.177_aefcd2e401c2232a5c9ebe5404309a19
+      '@itwin/ecschema-metadata': 3.0.0-dev.177_f4a588df173e76e968bad38684dae86a
       '@types/chai': 4.2.22
       '@types/mocha': 9.0.0
-      '@types/node': 16.11.12
+      '@types/node': 16.11.19
       cpx: 1.5.0
       dotenv: 10.0.0
       inversify: 5.0.5
       mocha: 9.0.3
       nyc: 14.0.0
       reflect-metadata: 0.1.13
-      typescript: 4.3.5
+      typescript: 4.4.4
     dev: false
     id: 'file:projects/imodels-access-backend-tests.tgz'
     name: '@rush-temp/imodels-access-backend-tests'
@@ -5891,17 +5891,17 @@ packages:
       '@bentley/itwin-client': '*'
       '@itwin/core-geometry': '*'
     resolution:
-      integrity: sha512-btKoGImimMuK5jxNKIUdEEuIiZmDL9CfHlimE9gk2uK8RHs0xsdeh4KJ/HK6mUX+BEJ6A18DLxUVsLc+YLjPlA==
+      integrity: sha512-8Bl8nLHlqkT8WITOjfeut4z7y0SytxhBzqQGaviJQKOKyqolZcnMoGVfY0ZOc3ekSFvhv8NF6JuvZ8Xx2OxWLA==
       tarball: 'file:projects/imodels-access-backend-tests.tgz'
     version: 0.0.0
-  'file:projects/imodels-access-backend.tgz_4bd45436c7446ce6f2c68b792e01fc06':
+  'file:projects/imodels-access-backend.tgz_b5694a69aef35f9e2c3d7f6af9a480ab':
     dependencies:
-      '@itwin/core-backend': 3.0.0-dev.148_29276b61277a7cedb96595da2e2a4ac9
-      '@itwin/core-bentley': 3.0.0-dev.148
-      '@itwin/core-common': 3.0.0-dev.148_2cea9fa5747d2125eec0388ef83db838
-      '@itwin/ecschema-metadata': 3.0.0-dev.148_1f1133e0683841193b047e5518caa238
+      '@itwin/core-backend': 3.0.0-dev.177_ddaece1736e631ce5890f83b6412fe83
+      '@itwin/core-bentley': 3.0.0-dev.177
+      '@itwin/core-common': 3.0.0-dev.177_aefcd2e401c2232a5c9ebe5404309a19
+      '@itwin/ecschema-metadata': 3.0.0-dev.177_f4a588df173e76e968bad38684dae86a
       '@types/ws': 8.2.2
-      typescript: 4.3.5
+      typescript: 4.4.4
     dev: false
     id: 'file:projects/imodels-access-backend.tgz'
     name: '@rush-temp/imodels-access-backend'
@@ -5909,23 +5909,23 @@ packages:
       '@bentley/itwin-client': '*'
       '@itwin/core-geometry': '*'
     resolution:
-      integrity: sha512-Sx25F+0jUnASXr27uUjDck9t4T55t/NC/LX0qofRm+1IFcjnTeFTCkW8Hqv78fKOSqVwaMvmf86X0zq0BwpuOQ==
+      integrity: sha512-uQqXzhaweInIWH2kR7psD4kC79d4Rw2nNlk8PmhyB3bcbN/bAKxhB9PwbKrWB/i2LFbjX3a5Xq1tLmi1TzEsqw==
       tarball: 'file:projects/imodels-access-backend.tgz'
     version: 0.0.0
-  'file:projects/imodels-access-frontend-tests.tgz_d3d027a5f0cf45c7672147e69d31b9e7':
+  'file:projects/imodels-access-frontend-tests.tgz_35f9c6074ef211a97243c78003389afa':
     dependencies:
-      '@itwin/core-common': 3.0.0-dev.148_2cea9fa5747d2125eec0388ef83db838
-      '@itwin/core-frontend': 3.0.0-dev.148_54235d032abb96d437206068bf58c49f
+      '@itwin/core-common': 3.0.0-dev.177_aefcd2e401c2232a5c9ebe5404309a19
+      '@itwin/core-frontend': 3.0.0-dev.177_aa4eb0ae198d06161ccf95523d3ea495
       '@types/chai': 4.2.22
       '@types/mocha': 9.0.0
-      '@types/node': 16.11.12
+      '@types/node': 16.11.19
       cpx: 1.5.0
       dotenv: 10.0.0
       inversify: 5.0.5
       mocha: 9.0.3
       nyc: 14.0.0
       reflect-metadata: 0.1.13
-      typescript: 4.3.5
+      typescript: 4.4.4
     dev: false
     id: 'file:projects/imodels-access-frontend-tests.tgz'
     name: '@rush-temp/imodels-access-frontend-tests'
@@ -5938,42 +5938,42 @@ packages:
       '@itwin/core-quantity': '*'
       '@itwin/webgl-compatibility': '*'
     resolution:
-      integrity: sha512-crYk6CyquOoC0TLHuXa/wwQR3Ro/2bGmqXcK95AGRNup6iYADuGcB5fC60M+6gS2K9GBn29gt8n1P+qa0y4krg==
+      integrity: sha512-7bBpspRdC74rF6mqaSpokKPHaaaKagy3x9Vnqv/pWEhrpEzrtPB8k15HoVJU9h76M7bA512KI2h2VbPfDKxzgg==
       tarball: 'file:projects/imodels-access-frontend-tests.tgz'
     version: 0.0.0
   'file:projects/imodels-access-frontend.tgz':
     dependencies:
-      '@bentley/itwin-client': 3.0.0-dev.135_1f1133e0683841193b047e5518caa238
-      '@itwin/appui-abstract': 3.0.0-dev.148_1f1133e0683841193b047e5518caa238
-      '@itwin/core-bentley': 3.0.0-dev.148
-      '@itwin/core-common': 3.0.0-dev.148_2cea9fa5747d2125eec0388ef83db838
-      '@itwin/core-frontend': 3.0.0-dev.148_54235d032abb96d437206068bf58c49f
-      '@itwin/core-geometry': 3.0.0-dev.148
-      '@itwin/core-orbitgt': 3.0.0-dev.148
-      '@itwin/core-quantity': 3.0.0-dev.148_1f1133e0683841193b047e5518caa238
-      '@itwin/webgl-compatibility': 3.0.0-dev.148
-      typescript: 4.3.5
+      '@bentley/itwin-client': 3.0.0-dev.148_f4a588df173e76e968bad38684dae86a
+      '@itwin/appui-abstract': 3.0.0-dev.177_f4a588df173e76e968bad38684dae86a
+      '@itwin/core-bentley': 3.0.0-dev.177
+      '@itwin/core-common': 3.0.0-dev.177_aefcd2e401c2232a5c9ebe5404309a19
+      '@itwin/core-frontend': 3.0.0-dev.177_aa4eb0ae198d06161ccf95523d3ea495
+      '@itwin/core-geometry': 3.0.0-dev.177
+      '@itwin/core-orbitgt': 3.0.0-dev.177
+      '@itwin/core-quantity': 3.0.0-dev.177_f4a588df173e76e968bad38684dae86a
+      '@itwin/webgl-compatibility': 3.0.0-dev.177
+      typescript: 4.4.4
     dev: false
     name: '@rush-temp/imodels-access-frontend'
     resolution:
-      integrity: sha512-dYAhlAD9zG9HiHeD18g4aygETX7yQw4gYI8Evdh6YMzMKC1keY1GkfTfMftF+vMTQgkMoiIqn2PSvm5vfgEofQ==
+      integrity: sha512-608wB1yCQq+71asFsfOI0ZRr4P+sSJ2d7XkOmaTbSze7O8/gZ5xA4/6Ofa6WYyzSCzkG4LC2fZ53kQruWOt0gw==
       tarball: 'file:projects/imodels-access-frontend.tgz'
     version: 0.0.0
   'file:projects/imodels-client-authoring.tgz':
     dependencies:
       '@azure/storage-blob': 12.7.0
-      typescript: 4.3.5
+      typescript: 4.4.4
     dev: false
     name: '@rush-temp/imodels-client-authoring'
     resolution:
-      integrity: sha512-Dm8JkKspPLx+ptkW5Mzg+1yPBglp040CoKaChc0BWwl49iKYSlgKDTrnE4sw8hBAZjZh5Ctq26KxS656Zh+hZg==
+      integrity: sha512-dRKO8x+kBtTxsONtSO0Ax+2LEfix4vK3fDZi5+tOHttcJya9pEccQKb1iN8w7O1bEnKFR/ZxPmzO7608krBmFw==
       tarball: 'file:projects/imodels-client-authoring.tgz'
     version: 0.0.0
-  'file:projects/imodels-client-common-config.tgz_typescript@4.3.5':
+  'file:projects/imodels-client-common-config.tgz_typescript@4.4.4':
     dependencies:
-      '@itwin/eslint-plugin': 3.0.0-dev.148_eslint@7.31.0+typescript@4.3.5
-      '@typescript-eslint/eslint-plugin': 4.28.5_514553717ff968e20f6d1c6e521f8616
-      '@typescript-eslint/parser': 4.28.5_eslint@7.31.0+typescript@4.3.5
+      '@itwin/eslint-plugin': 3.0.0-dev.177_eslint@7.31.0+typescript@4.4.4
+      '@typescript-eslint/eslint-plugin': 4.28.5_2d27c79b551e458fb3b3f741bd766f57
+      '@typescript-eslint/parser': 4.28.5_eslint@7.31.0+typescript@4.4.4
       cspell: 5.6.7
       eslint: 7.31.0
       eslint-plugin-import: 2.23.4_eslint@7.31.0
@@ -5991,35 +5991,35 @@ packages:
   'file:projects/imodels-client-management.tgz':
     dependencies:
       axios: 0.21.4
-      typescript: 4.3.5
+      typescript: 4.4.4
     dev: false
     name: '@rush-temp/imodels-client-management'
     resolution:
-      integrity: sha512-sgOcgr7iR3s0RGKnwXzqPoHmuY0TNYHmdkYmN1Pq3/y2eHNd4g+9yFNRgBcxdcb4NcNG9NJ0Wb/JBgbm41vSjg==
+      integrity: sha512-8eZbltmSAHPvA0VazWZZ9+t9lgH0xFVrc41ByhE2iR2XlEGEk3UTh1Km95I+uKZaWFQ8tC3VPp8U0undg0oKzg==
       tarball: 'file:projects/imodels-client-management.tgz'
     version: 0.0.0
   'file:projects/imodels-client-test-utils.tgz':
     dependencies:
       '@types/chai': 4.2.22
-      '@types/node': 16.11.12
+      '@types/node': 16.11.19
       axios: 0.21.4
       chai: 4.3.4
       fs-extra: 10.0.0
       inversify: 5.0.5
       puppeteer: 10.2.0
       reflect-metadata: 0.1.13
-      typescript: 4.3.5
+      typescript: 4.4.4
     dev: false
     name: '@rush-temp/imodels-client-test-utils'
     resolution:
-      integrity: sha512-WvASlEJ31tvf70LLmT03+tm9JXhB8zW5avpNfiYHNTbnZy9xlcyW6URfm49CUsxmw6qkshDTS9TjhBFv0s35Sw==
+      integrity: sha512-iOCkf9F+EZ/rydiXp9UseHBWgW4OJ6E7FnIbyft0Peg5/WbnVCqgX7WWcs6cMMXqxCLHCQbdx3UNE5/YgeZohQ==
       tarball: 'file:projects/imodels-client-test-utils.tgz'
     version: 0.0.0
   'file:projects/imodels-clients-tests.tgz':
     dependencies:
       '@types/chai': 4.2.22
       '@types/mocha': 9.0.0
-      '@types/node': 16.11.12
+      '@types/node': 16.11.19
       axios: 0.21.4
       chai: 4.3.4
       cpx: 1.5.0
@@ -6030,11 +6030,11 @@ packages:
       nyc: 14.0.0
       puppeteer: 10.2.0
       reflect-metadata: 0.1.13
-      typescript: 4.3.5
+      typescript: 4.4.4
     dev: false
     name: '@rush-temp/imodels-clients-tests'
     resolution:
-      integrity: sha512-pNP0Qp7juKGTV3pQVJNQsJbTktYz5J6D8o4ARNidieMVYAtwSvZJd375WtjaIXPOlLYP0SEDVH9L+WkDQ3NLKQ==
+      integrity: sha512-AL61C5f0g18DKosjl3mi8Pm0dnqdXEH2Ep2R1PKrUxnZDJYvZh8J6FEu12tpfe5tCcmTOjGIvbXQZrhvlmX9ug==
       tarball: 'file:projects/imodels-clients-tests.tgz'
     version: 0.0.0
 registry: ''
@@ -6082,4 +6082,4 @@ specifiers:
   puppeteer: ~10.2.0
   reflect-metadata: ~0.1.13
   sort-package-json: ~1.53.1
-  typescript: ~4.3.5
+  typescript: ~4.4.0

--- a/itwin-platform-access/imodels-access-backend/package.json
+++ b/itwin-platform-access/imodels-access-backend/package.json
@@ -39,7 +39,7 @@
     "@itwin/ecschema-metadata": "rc",
     "@itwin/imodels-client-common-config": "~0.2.2",
     "@types/ws": "~8.2.0",
-    "typescript": "~4.3.5"
+    "typescript": "~4.4.0"
   },
   "peerDependencies": {
     "@itwin/core-backend": "rc",

--- a/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
@@ -230,9 +230,8 @@ export class BackendIModelsAccess implements BackendHubAccess {
 
     const v2CheckpointAccessProps = ClientToPlatformAdapter.toV2CheckpointAccessProps(checkpoint.containerAccessInfo);
 
-    const transfer = new IModelHost.platform.CloudDbTransfer({
+    const transfer = new IModelHost.platform.CloudDbTransfer("download", {
       ...v2CheckpointAccessProps,
-      direction: "download",
       writeable: false,
       localFile: arg.localFile
     });
@@ -251,8 +250,8 @@ export class BackendIModelsAccess implements BackendHubAccess {
       }
       await transfer.promise;
       onProgress?.(total, total); // make sure we call progress func one last time when download completes
-    } catch (err) {
-      throw (err.message === "cancelled") ? new IModelError(BriefcaseStatus.DownloadCancelled, "download cancelled") : err;
+    } catch (err: unknown) {
+      throw ((err as Error)?.message === "cancelled") ? new IModelError(BriefcaseStatus.DownloadCancelled, "download cancelled") : err;
     } finally {
       if (timer)
         clearInterval(timer);

--- a/itwin-platform-access/imodels-access-backend/src/interface-adapters/ClientToPlatformAdapter.ts
+++ b/itwin-platform-access/imodels-access-backend/src/interface-adapters/ClientToPlatformAdapter.ts
@@ -43,10 +43,10 @@ export class ClientToPlatformAdapter {
       throw new IModelError(IModelStatus.NotFound, "Invalid V2 checkpoint");
 
     return {
-      container: containerAccessInfo.container,
-      auth: containerAccessInfo.sas,
-      user: containerAccessInfo.account,
-      dbAlias: containerAccessInfo.dbName,
+      containerId: containerAccessInfo.container,
+      sasToken: containerAccessInfo.sas,
+      accountName: containerAccessInfo.account,
+      dbName: containerAccessInfo.dbName,
       storageType: "azure?sas=1"
     };
   }

--- a/itwin-platform-access/imodels-access-frontend/package.json
+++ b/itwin-platform-access/imodels-access-frontend/package.json
@@ -43,7 +43,7 @@
     "@itwin/core-quantity": "rc",
     "@itwin/imodels-client-common-config": "~0.2.2",
     "@itwin/webgl-compatibility": "rc",
-    "typescript": "~4.3.5"
+    "typescript": "~4.4.0"
   },
   "peerDependencies": {
     "@itwin/core-bentley": "rc",

--- a/tests/imodels-access-backend-tests/package.json
+++ b/tests/imodels-access-backend-tests/package.json
@@ -50,6 +50,6 @@
     "@types/node": "^16.4.6",
     "cpx": "~1.5.0",
     "nyc": "14.0.0",
-    "typescript": "~4.3.5"
+    "typescript": "~4.4.0"
   }
 }

--- a/tests/imodels-access-frontend-tests/package.json
+++ b/tests/imodels-access-frontend-tests/package.json
@@ -48,6 +48,6 @@
     "@types/node": "^16.4.6",
     "cpx": "~1.5.0",
     "nyc": "14.0.0",
-    "typescript": "~4.3.5"
+    "typescript": "~4.4.0"
   }
 }

--- a/tests/imodels-clients-tests/package.json
+++ b/tests/imodels-clients-tests/package.json
@@ -52,6 +52,6 @@
     "@types/node": "^16.4.6",
     "cpx": "~1.5.0",
     "nyc": "14.0.0",
-    "typescript": "~4.3.5"
+    "typescript": "~4.4.0"
   }
 }

--- a/tests/imodels-clients-tests/src/authoring/CheckpointOperations.test.ts
+++ b/tests/imodels-clients-tests/src/authoring/CheckpointOperations.test.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { expect } from "chai";
 import { AuthorizationCallback, CheckpointState, GetSingleCheckpointParams, IModelScopedOperationParams, IModelsClient, IModelsClientOptions, IModelsErrorCode } from "@itwin/imodels-client-authoring";
 import { NamedVersionMetadata, ReusableIModelMetadata, ReusableTestIModelProvider, TestAuthorizationProvider, TestUtilTypes, assertCheckpoint, assertError } from "@itwin/imodels-client-test-utils";
 import { getTestDIContainer } from "../common";
@@ -128,17 +127,16 @@ describe("[Authoring] CheckpointOperations", () => {
       };
 
       // Act
-      let errorThrown: Error | undefined;
+      let objectThrown: unknown;
       try {
         await testCase.functionUnderTest(iModelScopedOperationParams);
       } catch (e) {
-        errorThrown = e;
+        objectThrown = e;
       }
 
       // Assert
-      expect(errorThrown).to.not.be.undefined;
       assertError({
-        actualError: errorThrown!,
+        objectThrown,
         expectedError: {
           code: IModelsErrorCode.IModelNotFound,
           message: "Requested iModel is not available."
@@ -173,17 +171,16 @@ describe("[Authoring] CheckpointOperations", () => {
       };
 
       // Act
-      let errorThrown: Error | undefined;
+      let objectThrown: unknown;
       try {
         await testCase.functionUnderTest(iModelScopedOperationParams);
       } catch (e) {
-        errorThrown = e;
+        objectThrown = e;
       }
 
       // Assert
-      expect(errorThrown).to.not.be.undefined;
       assertError({
-        actualError: errorThrown!,
+        objectThrown,
         expectedError: {
           code: IModelsErrorCode.ChangesetNotFound,
           message: "Requested Changeset is not available."
@@ -201,17 +198,16 @@ describe("[Authoring] CheckpointOperations", () => {
     };
 
     // Act
-    let errorThrown: Error | undefined;
+    let objectThrown: unknown;
     try {
       await iModelsClient.checkpoints.getSingle(getSingleCheckpointParams);
     } catch (e) {
-      errorThrown = e;
+      objectThrown = e;
     }
 
     // Assert
-    expect(errorThrown).to.not.be.undefined;
     assertError({
-      actualError: errorThrown!,
+      objectThrown,
       expectedError: {
         code: IModelsErrorCode.NamedVersionNotFound,
         message: "Requested Named Version is not available."

--- a/tests/imodels-clients-tests/src/authoring/LockOperations.test.ts
+++ b/tests/imodels-clients-tests/src/authoring/LockOperations.test.ts
@@ -207,17 +207,16 @@ describe("[Authoring] LockOperations", () => {
     };
 
     // Act
-    let errorThrown: Error | undefined;
+    let objectThrown: unknown;
     try {
       await iModelsClient.locks.update(updateLockParams);
     } catch (e) {
-      errorThrown = e;
+      objectThrown = e;
     }
 
     // Assert
-    expect(errorThrown).to.not.be.undefined;
     assertError({
-      actualError: errorThrown!,
+      objectThrown,
       expectedError: {
         code: IModelsErrorCode.LockNotFound,
         message: "Requested Lock(s) is not available."
@@ -240,17 +239,16 @@ describe("[Authoring] LockOperations", () => {
     };
 
     // Act
-    let errorThrown: Error | undefined;
+    let objectThrown: unknown;
     try {
       await iModelsClient.locks.update(updateLockParams);
     } catch (e) {
-      errorThrown = e;
+      objectThrown = e;
     }
 
     // Assert
-    expect(errorThrown).to.not.be.undefined;
     assertError({
-      actualError: errorThrown!,
+      objectThrown,
       expectedError: {
         code: IModelsErrorCode.IModelNotFound,
         message: "Requested iModel is not available."
@@ -273,17 +271,16 @@ describe("[Authoring] LockOperations", () => {
     };
 
     // Act
-    let errorThrown: Error | undefined;
+    let objectThrown: unknown;
     try {
       await iModelsClient.locks.update(updateLockParams);
     } catch (e) {
-      errorThrown = e;
+      objectThrown = e;
     }
 
     // Assert
-    expect(errorThrown).to.not.be.undefined;
     assertError({
-      actualError: errorThrown!,
+      objectThrown,
       expectedError: {
         code: IModelsErrorCode.BriefcaseNotFound,
         message: "Requested Briefcase is not available."
@@ -310,17 +307,16 @@ describe("[Authoring] LockOperations", () => {
     };
 
     // Act
-    let errorThrown: Error | undefined;
+    let objectThrown: unknown;
     try {
       await iModelsClient.locks.update(updateLockParams);
     } catch (e) {
-      errorThrown = e;
+      objectThrown = e;
     }
 
     // Assert
-    expect(errorThrown).to.not.be.undefined;
     assertError({
-      actualError: errorThrown!,
+      objectThrown,
       expectedError: {
         code: IModelsErrorCode.ChangesetNotFound,
         message: "Requested Changeset is not available."
@@ -363,17 +359,16 @@ describe("[Authoring] LockOperations", () => {
     };
 
     // Act
-    let errorThrown: Error | undefined;
+    let objectThrown: unknown;
     try {
       await iModelsClient.locks.update(updateLockParams2);
     } catch (e) {
-      errorThrown = e;
+      objectThrown = e;
     }
 
     // Assert
-    expect(errorThrown).to.not.be.undefined;
     assertError({
-      actualError: errorThrown!,
+      objectThrown,
       expectedError: {
         code: IModelsErrorCode.ConflictWithAnotherUser,
         message: "Lock(s) is owned by another briefcase."
@@ -413,17 +408,16 @@ describe("[Authoring] LockOperations", () => {
     };
 
     // Act
-    let errorThrown: Error | undefined;
+    let objectThrown: unknown;
     try {
       await iModelsClient.locks.update(updateLockParams2);
     } catch (e) {
-      errorThrown = e;
+      objectThrown = e;
     }
 
     // Assert
-    expect(errorThrown).to.not.be.undefined;
     assertError({
-      actualError: errorThrown!,
+      objectThrown,
       expectedError: {
         code: IModelsErrorCode.NewerChangesExist,
         message: "One or more objects have been locked in a newer Changeset."

--- a/tests/imodels-clients-tests/src/management/IModelOperations.test.ts
+++ b/tests/imodels-clients-tests/src/management/IModelOperations.test.ts
@@ -208,17 +208,16 @@ describe("[Management] IModelOperations", () => {
     };
 
     // Act
-    let errorThrown: Error | undefined;
+    let objectThrown: unknown;
     try {
       await iModelsClient.iModels.createEmpty(createIModelParams);
     } catch (e) {
-      errorThrown = e;
+      objectThrown = e;
     }
 
     // Assert
-    expect(errorThrown).to.not.be.undefined;
     assertError({
-      actualError: errorThrown!,
+      objectThrown,
       expectedError: {
         code: IModelsErrorCode.Unauthorized,
         message: "The user is unauthorized. Please provide valid authentication credentials."
@@ -238,17 +237,16 @@ describe("[Management] IModelOperations", () => {
     };
 
     // Act
-    let errorThrown: Error | undefined;
+    let objectThrown: unknown;
     try {
       await iModelsClient.iModels.createEmpty(createIModelParams);
     } catch (e) {
-      errorThrown = e;
+      objectThrown = e;
     }
 
     // Assert
-    expect(errorThrown).to.not.be.undefined;
     assertError({
-      actualError: errorThrown!,
+      objectThrown,
       expectedError: {
         code: IModelsErrorCode.InvalidIModelsRequest,
         message: "Cannot create iModel. Details:\n1. InvalidValue: Provided 'description' is not valid. The value exceeds allowed 255 characters. Target: description.\n",

--- a/tests/imodels-clients-tests/src/management/IModelsErrorParser.test.ts
+++ b/tests/imodels-clients-tests/src/management/IModelsErrorParser.test.ts
@@ -40,7 +40,7 @@ describe("IModelsErrorParser", () => {
       "2. MissingRequiredProperty: Required property is missing. Target: name.\n" +
       "3. InvalidRequestBody: Failed to parse request body. Make sure it is a valid JSON.\n";
     assertError({
-      actualError: parsedError,
+      objectThrown: parsedError,
       expectedError: {
         code: IModelsErrorCode.InvalidIModelsRequest,
         message: expectedErrorMessage,

--- a/utils/imodels-client-test-utils/package.json
+++ b/utils/imodels-client-test-utils/package.json
@@ -41,6 +41,6 @@
     "@itwin/imodels-client-common-config": "~0.2.2",
     "@types/chai": "~4.2.21",
     "@types/node": "^16.4.6",
-    "typescript": "~4.3.5"
+    "typescript": "~4.4.0"
   }
 }

--- a/utils/imodels-client-test-utils/src/AssertionUtils.ts
+++ b/utils/imodels-client-test-utils/src/AssertionUtils.ts
@@ -146,9 +146,11 @@ export function assertLock(params: {
   }
 }
 
-export function assertError(params: { actualError: Error, expectedError: Partial<IModelsError> }): void {
-  const iModelsError = params.actualError as IModelsError;
+export function assertError(params: { objectThrown: unknown, expectedError: Partial<IModelsError> }): void {
+  expect(params.objectThrown).is.not.undefined;
+  expect(params.objectThrown instanceof Error);
 
+  const iModelsError = params.objectThrown as IModelsError;
   expect(iModelsError).to.not.be.undefined;
   expect(iModelsError.code).to.equal(params.expectedError.code);
   expect(iModelsError.name).to.equal(params.expectedError.code);


### PR DESCRIPTION
In this PR:
- Updated code in `@itwin/imodels-access-frontend` and `@itwin/imodels-access-backend` packages to the latest platform version, which required:
  - property name changes in `ClientToPlatformAdapter.toV2CheckpointAccessProps`
  - update to typescript version 4.4.0, which required:
    - updates in tests to not rely on `Error` type for thrown objects 