### PR TITLE
Exposing Named Version ordering by Changeset index

### DIFF
--- a/clients/imodels-client-management/src/operations/named-version/NamedVersionOperationParams.ts
+++ b/clients/imodels-client-management/src/operations/named-version/NamedVersionOperationParams.ts
@@ -2,10 +2,20 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { AtLeastOneProperty, CollectionRequestParams, IModelScopedOperationParams, NamedVersionState } from "../../base";
+import { AtLeastOneProperty, CollectionRequestParams, IModelScopedOperationParams, NamedVersion, NamedVersionState, OrderBy } from "../../base";
+
+/**
+ * Named Versions entity properties that are supported in $orderBy url parameter which specifies by what property
+ * entities are ordered in a collection.
+ */
+ export enum NamedVersionOrderByProperty {
+  ChangesetIndex = "changesetIndex"
+}
 
 /** Url parameters supported in Named Version list query. */
 export interface GetNamedVersionListUrlParams extends CollectionRequestParams {
+  /** Specifies in what order should entities be returned. See {@link OrderBy}. */
+  $orderBy?: OrderBy<NamedVersion, NamedVersionOrderByProperty>;
   /** Filters Named Versions with a specific name. */
   name?: string;
 }

--- a/clients/imodels-client-management/src/operations/named-version/NamedVersionOperationParams.ts
+++ b/clients/imodels-client-management/src/operations/named-version/NamedVersionOperationParams.ts
@@ -8,7 +8,7 @@ import { AtLeastOneProperty, CollectionRequestParams, IModelScopedOperationParam
  * Named Versions entity properties that are supported in $orderBy url parameter which specifies by what property
  * entities are ordered in a collection.
  */
- export enum NamedVersionOrderByProperty {
+export enum NamedVersionOrderByProperty {
   ChangesetIndex = "changesetIndex"
 }
 

--- a/itwin-platform-access/imodels-access-frontend/src/FrontendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-frontend/src/FrontendIModelsAccess.ts
@@ -5,7 +5,7 @@
 import { IModelStatus } from "@itwin/core-bentley";
 import { ChangesetIndexAndId, IModelError, IModelVersion } from "@itwin/core-common";
 import { FrontendHubAccess, IModelApp, IModelIdArg } from "@itwin/core-frontend";
-import { AuthorizationCallback, Changeset, ChangesetOrderByProperty, EntityListIterator, GetChangesetListParams, GetNamedVersionListParams, GetSingleChangesetParams, IModelScopedOperationParams, IModelsClient, MinimalChangeset, MinimalNamedVersion, NamedVersion, NamedVersionOrderByProperty, OrderByOperator, take } from "@itwin/imodels-client-management";
+import { AuthorizationCallback, Changeset, ChangesetOrderByProperty, EntityListIterator, GetChangesetListParams, GetNamedVersionListParams, GetSingleChangesetParams, IModelScopedOperationParams, IModelsClient, MinimalChangeset, MinimalNamedVersion, NamedVersionOrderByProperty,OrderByOperator, take } from "@itwin/imodels-client-management";
 import { AccessTokenAdapter } from "./interface-adapters/AccessTokenAdapter";
 
 export class FrontendIModelsAccess implements FrontendHubAccess {
@@ -110,7 +110,7 @@ export class FrontendIModelsAccess implements FrontendHubAccess {
         }
       }
     };
-    const namedVersionsIterator: EntityListIterator<NamedVersion> = this._iModelsClient.namedVersions.getRepresentationList(getNamedVersionListParams);
+    const namedVersionsIterator: EntityListIterator<MinimalNamedVersion> = this._iModelsClient.namedVersions.getMinimalList(getNamedVersionListParams);
     const namedVersions = await take(namedVersionsIterator, 1);
 
     if (namedVersions.length === 0 || !namedVersions[0].changesetIndex || !namedVersions[0].changesetId)

--- a/itwin-platform-access/imodels-access-frontend/src/FrontendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-frontend/src/FrontendIModelsAccess.ts
@@ -5,7 +5,7 @@
 import { IModelStatus } from "@itwin/core-bentley";
 import { ChangesetIndexAndId, IModelError, IModelVersion } from "@itwin/core-common";
 import { FrontendHubAccess, IModelApp, IModelIdArg } from "@itwin/core-frontend";
-import { AuthorizationCallback, Changeset, ChangesetOrderByProperty, EntityListIterator, GetChangesetListParams, GetNamedVersionListParams, GetSingleChangesetParams, IModelScopedOperationParams, IModelsClient, MinimalChangeset, MinimalNamedVersion, NamedVersion, OrderByOperator, take, NamedVersionOrderByProperty } from "@itwin/imodels-client-management";
+import { AuthorizationCallback, Changeset, ChangesetOrderByProperty, EntityListIterator, GetChangesetListParams, GetNamedVersionListParams, GetSingleChangesetParams, IModelScopedOperationParams, IModelsClient, MinimalChangeset, MinimalNamedVersion, NamedVersion, NamedVersionOrderByProperty, OrderByOperator, take } from "@itwin/imodels-client-management";
 import { AccessTokenAdapter } from "./interface-adapters/AccessTokenAdapter";
 
 export class FrontendIModelsAccess implements FrontendHubAccess {

--- a/pipelines/build-test.yml
+++ b/pipelines/build-test.yml
@@ -16,7 +16,7 @@ jobs:
     pool:
         vmImage: $(imageName)
     variables:
-      - group: iModels Clients - Integration Tests - SBX
+      - group: iModels Clients - Integration Tests - DEV
     workspace:
       clean: all
 

--- a/tests/imodels-clients-tests/src/management/NamedVersionOperations.test.ts
+++ b/tests/imodels-clients-tests/src/management/NamedVersionOperations.test.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
-import { AuthorizationCallback, CreateNamedVersionParams, GetNamedVersionListParams, IModelScopedOperationParams, IModelsClient, IModelsClientOptions, NamedVersion, NamedVersionState, UpdateNamedVersionParams, toArray } from "@itwin/imodels-client-management";
+import { AuthorizationCallback, CreateNamedVersionParams, GetNamedVersionListParams, IModelScopedOperationParams, IModelsClient, IModelsClientOptions, NamedVersion, NamedVersionState, UpdateNamedVersionParams, toArray, EntityListIterator, MinimalNamedVersion, NamedVersionOrderByProperty, OrderByOperator } from "@itwin/imodels-client-management";
 import { IModelMetadata, TestAuthorizationProvider, TestIModelCreator, TestIModelFileProvider, TestIModelGroup, TestIModelGroupFactory, TestSetupError, TestUtilTypes, assertCollection, assertNamedVersion } from "@itwin/imodels-client-test-utils";
 import { Constants, getTestDIContainer, getTestRunId } from "../common";
 
@@ -84,6 +84,49 @@ describe("[Management] NamedVersionOperations", () => {
         isEntityCountCorrect: (count) => count >= namedVersionCountCreatedInSetup
       });
     });
+  });
+
+  it("should order items by changeset index when querying minimal collection (ascending order)", async () => {
+    // Arrange
+    const getNamedVersionListParams: GetNamedVersionListParams = {
+      authorization,
+      iModelId: testIModel.id,
+      urlParams: {
+        $orderBy: {
+          property: NamedVersionOrderByProperty.ChangesetIndex
+        }
+      }
+    };
+
+    // Act
+    const namedVersions: EntityListIterator<MinimalNamedVersion> = iModelsClient.namedVersions.getMinimalList(getNamedVersionListParams);
+
+    // Assert
+    const namedVersionChangesetIndexes = (await toArray(namedVersions)).map((namedVersion) => namedVersion.changesetIndex);
+    for (let i = 0; i < namedVersionChangesetIndexes.length - 1; i++)
+      expect(namedVersionChangesetIndexes[i]).to.be.lessThan(namedVersionChangesetIndexes[i + 1]);
+  });
+
+  it("should order items by changeset index when querying minimal collection (descending order)", async () => {
+    // Arrange
+    const getNamedVersionListParams: GetNamedVersionListParams = {
+      authorization,
+      iModelId: testIModel.id,
+      urlParams: {
+        $orderBy: {
+          property: NamedVersionOrderByProperty.ChangesetIndex,
+          operator: OrderByOperator.Descending
+        }
+      }
+    };
+
+    // Act
+    const namedVersions: EntityListIterator<MinimalNamedVersion> = iModelsClient.namedVersions.getMinimalList(getNamedVersionListParams);
+
+    // Assert
+    const namedVersionChangesetIndexes = (await toArray(namedVersions)).map((namedVersion) => namedVersion.changesetIndex);
+    for (let i = 0; i < namedVersionChangesetIndexes.length - 1; i++)
+      expect(namedVersionChangesetIndexes[i]).to.be.greaterThan(namedVersionChangesetIndexes[i + 1]);
   });
 
   it("should return versions that match the name filter when querying representation collection", async () => {

--- a/tests/imodels-clients-tests/src/management/NamedVersionOperations.test.ts
+++ b/tests/imodels-clients-tests/src/management/NamedVersionOperations.test.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
-import { AuthorizationCallback, CreateNamedVersionParams, GetNamedVersionListParams, IModelScopedOperationParams, IModelsClient, IModelsClientOptions, NamedVersion, NamedVersionState, UpdateNamedVersionParams, toArray, EntityListIterator, MinimalNamedVersion, NamedVersionOrderByProperty, OrderByOperator } from "@itwin/imodels-client-management";
+import { AuthorizationCallback, CreateNamedVersionParams, EntityListIterator, GetNamedVersionListParams, IModelScopedOperationParams, IModelsClient, IModelsClientOptions, MinimalNamedVersion, NamedVersion, NamedVersionOrderByProperty, NamedVersionState, OrderByOperator, UpdateNamedVersionParams, toArray } from "@itwin/imodels-client-management";
 import { IModelMetadata, TestAuthorizationProvider, TestIModelCreator, TestIModelFileProvider, TestIModelGroup, TestIModelGroupFactory, TestSetupError, TestUtilTypes, assertCollection, assertNamedVersion } from "@itwin/imodels-client-test-utils";
 import { Constants, getTestDIContainer, getTestRunId } from "../common";
 

--- a/utils/imodels-client-test-utils/src/test-context-providers/project/ProjectsClient.ts
+++ b/utils/imodels-client-test-utils/src/test-context-providers/project/ProjectsClient.ts
@@ -30,8 +30,7 @@ export class ProjectsClient {
     const authorizationInfo = await params.authorization();
     const requestConfig = {
       headers: {
-        Authorization: `${authorizationInfo.scheme} ${authorizationInfo.token}`,
-        Accept: "application/vnd.bentley.v1+json"
+        Authorization: `${authorizationInfo.scheme} ${authorizationInfo.token}`
       }
     };
 

--- a/utils/imodels-client-test-utils/src/test-context-providers/project/ProjectsClient.ts
+++ b/utils/imodels-client-test-utils/src/test-context-providers/project/ProjectsClient.ts
@@ -30,21 +30,28 @@ export class ProjectsClient {
     const authorizationInfo = await params.authorization();
     const requestConfig = {
       headers: {
-        Authorization: `${authorizationInfo.scheme} ${authorizationInfo.token}`
+        Authorization: `${authorizationInfo.scheme} ${authorizationInfo.token}`,
+        Accept: "application/vnd.bentley.v1+json"
       }
     };
 
     const getProjectsWithNameUrl = `${this._config.baseUrl}?displayName=${params.projectName}`;
-    const getProjectsWithNameResponse: AxiosResponse<ProjectsResponse> = await axios.get(getProjectsWithNameUrl, requestConfig);
-    if (getProjectsWithNameResponse.data.projects.length > 0)
-      return getProjectsWithNameResponse.data.projects[0].id;
-
-    const createProjectUrl = this._config.baseUrl;
-    const createProjectBody = {
-      displayName: params.projectName,
-      projectNumber: `${params.projectName} ${new Date()}`
-    };
-    const createProjectResponse: AxiosResponse<ProjectResponse> = await axios.post(createProjectUrl, createProjectBody, requestConfig);
-    return createProjectResponse.data.project.id;
+    try {
+      const getProjectsWithNameResponse: AxiosResponse<ProjectsResponse> = await axios.get(getProjectsWithNameUrl, requestConfig);
+      if (getProjectsWithNameResponse.data.projects.length > 0)
+        return getProjectsWithNameResponse.data.projects[0].id;
+  
+      const createProjectUrl = this._config.baseUrl;
+      const createProjectBody = {
+        displayName: params.projectName,
+        projectNumber: `${params.projectName} ${new Date()}`
+      };
+      const createProjectResponse: AxiosResponse<ProjectResponse> = await axios.post(createProjectUrl, createProjectBody, requestConfig);
+      return createProjectResponse.data.project.id;
+    } catch(e) {
+      console.log(e);
+      throw e;
+    }
+   
   }
 }

--- a/utils/imodels-client-test-utils/src/test-context-providers/project/ProjectsClient.ts
+++ b/utils/imodels-client-test-utils/src/test-context-providers/project/ProjectsClient.ts
@@ -36,22 +36,16 @@ export class ProjectsClient {
     };
 
     const getProjectsWithNameUrl = `${this._config.baseUrl}?displayName=${params.projectName}`;
-    try {
-      const getProjectsWithNameResponse: AxiosResponse<ProjectsResponse> = await axios.get(getProjectsWithNameUrl, requestConfig);
-      if (getProjectsWithNameResponse.data.projects.length > 0)
-        return getProjectsWithNameResponse.data.projects[0].id;
-  
-      const createProjectUrl = this._config.baseUrl;
-      const createProjectBody = {
-        displayName: params.projectName,
-        projectNumber: `${params.projectName} ${new Date()}`
-      };
-      const createProjectResponse: AxiosResponse<ProjectResponse> = await axios.post(createProjectUrl, createProjectBody, requestConfig);
-      return createProjectResponse.data.project.id;
-    } catch(e) {
-      console.log(e);
-      throw e;
-    }
-   
+    const getProjectsWithNameResponse: AxiosResponse<ProjectsResponse> = await axios.get(getProjectsWithNameUrl, requestConfig);
+    if (getProjectsWithNameResponse.data.projects.length > 0)
+      return getProjectsWithNameResponse.data.projects[0].id;
+
+    const createProjectUrl = this._config.baseUrl;
+    const createProjectBody = {
+      displayName: params.projectName,
+      projectNumber: `${params.projectName} ${new Date()}`
+    };
+    const createProjectResponse: AxiosResponse<ProjectResponse> = await axios.post(createProjectUrl, createProjectBody, requestConfig);
+    return createProjectResponse.data.project.id;
   }
 }


### PR DESCRIPTION
In this PR:
- Exposed Named Version ordering capabilities: added `$orderBy` property to `GetNamedVersionListUrlParams` interface which enables `getMinimalList` and `getRepresentationList` methods to send the new url param and receive ordered Named Versions in response.
- Consumed the new functionality in `FrontendIModelsAccess.getChangesetFromLatestNamedVersion` method and removed the client-side filtering.
- Added integration tests to ensure correct behavior.
- Pointed integration tests to run against DEV instead of SBX.