### PR TITLE
Locks transformation fix in `@itwin/imodels-access-backend-tests`

### DIFF
--- a/itwin-platform-access/imodels-access-backend/src/interface-adapters/PlatformToClientAdapter.ts
+++ b/itwin-platform-access/imodels-access-backend/src/interface-adapters/PlatformToClientAdapter.ts
@@ -84,7 +84,7 @@ export class PlatformToClientAdapter {
 
   private static groupLocksByLockLevel(locks: LockMap): Map<LockLevel, string[]> {
     const result: Map<LockLevel, string[]> = new Map();
-    for (let [objectId, lockState] of locks) {
+    for (const [objectId, lockState] of locks) {
       const lockLevel: LockLevel = PlatformToClientAdapter.toLockLevel(lockState);
       const lockedObjectsIds: string[] | undefined = result.get(lockLevel);
       if (lockedObjectsIds)

--- a/itwin-platform-access/imodels-access-backend/src/interface-adapters/PlatformToClientAdapter.ts
+++ b/itwin-platform-access/imodels-access-backend/src/interface-adapters/PlatformToClientAdapter.ts
@@ -84,12 +84,8 @@ export class PlatformToClientAdapter {
 
   private static groupLocksByLockLevel(locks: LockMap): Map<LockLevel, string[]> {
     const result: Map<LockLevel, string[]> = new Map();
-    for (const objectId in locks) {
-      if (!Object.prototype.hasOwnProperty.call(locks, objectId))
-        continue;
-      const lockState: LockState = locks.get(objectId)!;
+    for (let [objectId, lockState] of locks) {
       const lockLevel: LockLevel = PlatformToClientAdapter.toLockLevel(lockState);
-
       const lockedObjectsIds: string[] | undefined = result.get(lockLevel);
       if (lockedObjectsIds)
         lockedObjectsIds.push(objectId);

--- a/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
+++ b/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
@@ -117,6 +117,19 @@ describe("BackendIModelsAccess", () => {
   });
 
   describe("locks", () => {
+    let testIModelForWriteBriefcaseIds: BriefcaseId[] = [];
+
+    afterEach(async () => {
+      for (const briefcaseId of testIModelForWriteBriefcaseIds) {
+        await backendIModelsAccess.releaseBriefcase({
+          accessToken,
+          iModelId: testIModelForWrite.id,
+          briefcaseId
+        });
+      }
+      testIModelForWriteBriefcaseIds = [];
+    });
+
     it("should successfully acquire new locks", async () => {
       // Arrange
       const acquireNewBriefcaseIdParams: AcquireNewBriefcaseIdArg = {
@@ -124,6 +137,7 @@ describe("BackendIModelsAccess", () => {
         iModelId: testIModelForWrite.id
       };
       const briefcaseId = await backendIModelsAccess.acquireNewBriefcaseId(acquireNewBriefcaseIdParams);
+      testIModelForWriteBriefcaseIds.push(briefcaseId);
 
       const briefcaseDbParams: BriefcaseDbArg = {
         accessToken,
@@ -154,6 +168,7 @@ describe("BackendIModelsAccess", () => {
         iModelId: testIModelForWrite.id
       };
       const briefcaseId = await backendIModelsAccess.acquireNewBriefcaseId(acquireNewBriefcaseIdParams);
+      testIModelForWriteBriefcaseIds.push(briefcaseId);
 
       const briefcaseDbParams: BriefcaseDbArg = {
         accessToken,

--- a/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
+++ b/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
@@ -9,7 +9,7 @@ import { BriefcaseId, ChangesetFileProps, ChangesetType, LocalDirName } from "@i
 import { BackendIModelsAccess } from "@itwin/imodels-access-backend";
 import { expect } from "chai";
 import { ContainingChanges, IModelsClient, IModelsClientOptions } from "@itwin/imodels-client-authoring";
-import { ReusableIModelMetadata, ReusableTestIModelProvider, TestAuthorizationProvider, TestIModelFileProvider, TestUtilTypes, cleanupDirectory, TestIModelGroup, TestIModelGroupFactory, createGuidValue, IModelMetadata, TestIModelCreator } from "@itwin/imodels-client-test-utils";
+import { IModelMetadata, ReusableIModelMetadata, ReusableTestIModelProvider, TestAuthorizationProvider, TestIModelCreator, TestIModelFileProvider, TestIModelGroup, TestIModelGroupFactory, TestUtilTypes, cleanupDirectory, createGuidValue } from "@itwin/imodels-client-test-utils";
 import { getTestDIContainer } from "./TestDiContainerProvider";
 
 describe("BackendIModelsAccess", () => {
@@ -121,7 +121,7 @@ describe("BackendIModelsAccess", () => {
       // Arrange
       const acquireNewBriefcaseIdParams: AcquireNewBriefcaseIdArg = {
         accessToken,
-        iModelId: testIModelForWrite.id,
+        iModelId: testIModelForWrite.id
       };
       const briefcaseId = await backendIModelsAccess.acquireNewBriefcaseId(acquireNewBriefcaseIdParams);
 
@@ -134,25 +134,24 @@ describe("BackendIModelsAccess", () => {
       const locksToAcquire: LockMap = new Map<string, LockState>([
         ["0x1", LockState.Exclusive],
         ["0x2", LockState.Exclusive],
-        ["0x3", LockState.Shared],
+        ["0x3", LockState.Shared]
       ]);
 
       // Act
-      await backendIModelsAccess.acquireLocks(briefcaseDbParams, locksToAcquire)
+      await backendIModelsAccess.acquireLocks(briefcaseDbParams, locksToAcquire);
 
       // Assert
-      assertLocks({
+      await assertLocks({
         lockQueryParams: briefcaseDbParams,
         expectedLocks: locksToAcquire
       });
     });
 
-
     it("should successfully release locks", async () => {
       // Arrange
       const acquireNewBriefcaseIdParams: AcquireNewBriefcaseIdArg = {
         accessToken,
-        iModelId: testIModelForWrite.id,
+        iModelId: testIModelForWrite.id
       };
       const briefcaseId = await backendIModelsAccess.acquireNewBriefcaseId(acquireNewBriefcaseIdParams);
 
@@ -165,11 +164,11 @@ describe("BackendIModelsAccess", () => {
       const locksToAcquire: LockMap = new Map<string, LockState>([
         ["0x1", LockState.Exclusive],
         ["0x2", LockState.Exclusive],
-        ["0x3", LockState.Shared],
+        ["0x3", LockState.Shared]
       ]);
 
-      await backendIModelsAccess.acquireLocks(briefcaseDbParams, locksToAcquire)
-      assertLocks({
+      await backendIModelsAccess.acquireLocks(briefcaseDbParams, locksToAcquire);
+      await assertLocks({
         lockQueryParams: briefcaseDbParams,
         expectedLocks: locksToAcquire
       });
@@ -185,10 +184,10 @@ describe("BackendIModelsAccess", () => {
     async function assertLocks(params: { lockQueryParams: BriefcaseDbArg, expectedLocks: LockMap }): Promise<void> {
       const actualLocks: LockProps[] = await backendIModelsAccess.queryAllLocks(params.lockQueryParams);
       expect(actualLocks.length).to.equal(params.expectedLocks.size);
-      for (let [expectedObjectId, expectedLockState] of params.expectedLocks) {
-        const actualLock = actualLocks.find(lock => lock.id === expectedObjectId && lock.state === expectedLockState);
+      for (const [expectedObjectId, expectedLockState] of params.expectedLocks) {
+        const actualLock = actualLocks.find((lock) => lock.id === expectedObjectId && lock.state === expectedLockState);
         expect(actualLock).to.not.be.undefined;
       }
     }
-  })
+  });
 });

--- a/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
+++ b/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
@@ -4,19 +4,24 @@
  *--------------------------------------------------------------------------------------------*/
 import * as fs from "fs";
 import * as path from "path";
-import { ChangesetRangeArg, IModelIdArg } from "@itwin/core-backend";
+import { AcquireNewBriefcaseIdArg, BriefcaseDbArg, ChangesetRangeArg, IModelIdArg, LockMap, LockProps, LockState } from "@itwin/core-backend";
 import { BriefcaseId, ChangesetFileProps, ChangesetType, LocalDirName } from "@itwin/core-common";
 import { BackendIModelsAccess } from "@itwin/imodels-access-backend";
 import { expect } from "chai";
 import { ContainingChanges, IModelsClient, IModelsClientOptions } from "@itwin/imodels-client-authoring";
-import { ReusableIModelMetadata, ReusableTestIModelProvider, TestAuthorizationProvider, TestIModelFileProvider, TestUtilTypes, cleanupDirectory } from "@itwin/imodels-client-test-utils";
+import { ReusableIModelMetadata, ReusableTestIModelProvider, TestAuthorizationProvider, TestIModelFileProvider, TestUtilTypes, cleanupDirectory, TestIModelGroup, TestIModelGroupFactory, createGuidValue, IModelMetadata, TestIModelCreator } from "@itwin/imodels-client-test-utils";
 import { getTestDIContainer } from "./TestDiContainerProvider";
 
 describe("BackendIModelsAccess", () => {
+  const testRunId = createGuidValue();
+
   let backendIModelsAccess: BackendIModelsAccess;
   let accessToken: string;
+
   let testIModelFileProvider: TestIModelFileProvider;
+  let testIModelGroup: TestIModelGroup;
   let testIModelForRead: ReusableIModelMetadata;
+  let testIModelForWrite: IModelMetadata;
   const testDownloadPath = path.join(__dirname, "../lib/testDownloads");
 
   before(async () => {
@@ -33,8 +38,18 @@ describe("BackendIModelsAccess", () => {
 
     testIModelFileProvider = container.get(TestIModelFileProvider);
 
+    const testIModelGroupFactory = container.get(TestIModelGroupFactory);
+    testIModelGroup = testIModelGroupFactory.create({
+      testRunId,
+      packageName: "IModelsAccessBackendTests",
+      testSuiteName: "BackendIModelsAccess"
+    });
+
     const reusableTestIModelProvider = container.get(ReusableTestIModelProvider);
     testIModelForRead = await reusableTestIModelProvider.getOrCreate();
+
+    const testIModelCreator = container.get(TestIModelCreator);
+    testIModelForWrite = await testIModelCreator.createEmpty(testIModelGroup.getPrefixedUniqueIModelName("Test iModel for write"));
   });
 
   beforeEach(() => {
@@ -45,51 +60,135 @@ describe("BackendIModelsAccess", () => {
     cleanupDirectory(testDownloadPath);
   });
 
-  it("should get current user briefcase ids", async () => {
-    // Arrange
-    const getMyBriefcaseIdsParams: IModelIdArg = {
-      accessToken,
-      iModelId: testIModelForRead.id
-    };
-
-    // Act
-    const briefcaseIds: BriefcaseId[] = await backendIModelsAccess.getMyBriefcaseIds(getMyBriefcaseIdsParams);
-
-    // Assert
-    expect(briefcaseIds.length).to.equal(1);
-    const briefcaseId = briefcaseIds[0];
-    expect(briefcaseId).to.equal(testIModelForRead.briefcase.id);
+  after(async () => {
+    await testIModelGroup.cleanupIModels();
   });
 
-  it("should download changesets", async () => {
-    // Arrange
-    const downloadChangesetsParams: ChangesetRangeArg & { targetDir: LocalDirName } = {
-      accessToken,
-      iModelId: testIModelForRead.id,
-      targetDir: testDownloadPath
-    };
+  describe("briefcases", () => {
+    it("should get current user briefcase ids", async () => {
+      // Arrange
+      const getMyBriefcaseIdsParams: IModelIdArg = {
+        accessToken,
+        iModelId: testIModelForRead.id
+      };
 
-    // Act
-    const downloadedChangesets: ChangesetFileProps[] = await backendIModelsAccess.downloadChangesets(downloadChangesetsParams);
+      // Act
+      const briefcaseIds: BriefcaseId[] = await backendIModelsAccess.getMyBriefcaseIds(getMyBriefcaseIdsParams);
 
-    // Assert
-    expect(downloadedChangesets.length).to.be.equal(testIModelFileProvider.changesets.length);
-    for (let i = 0; i < downloadedChangesets.length; i++) {
-      const downloadedChangeset = downloadedChangesets[i];
-      const expectedChangesetFile = testIModelFileProvider.changesets[i];
+      // Assert
+      expect(briefcaseIds.length).to.equal(1);
+      const briefcaseId = briefcaseIds[0];
+      expect(briefcaseId).to.equal(testIModelForRead.briefcase.id);
+    });
+  });
 
-      expect(fs.existsSync(downloadedChangeset.pathname)).to.equal(true);
-      expect(downloadedChangeset.id).to.be.equal(expectedChangesetFile.id);
-      expect(downloadedChangeset.index).to.be.equal(expectedChangesetFile.index);
-      expect(downloadedChangeset.parentId).to.be.equal(expectedChangesetFile.parentId);
-      expect(downloadedChangeset.description).to.be.equal(expectedChangesetFile.description);
-      expect(downloadedChangeset.briefcaseId).to.be.equal(testIModelForRead.briefcase.id);
-      expect(downloadedChangeset.size).to.be.equal(fs.statSync(expectedChangesetFile.filePath).size);
+  describe("changesets", () => {
+    it("should download changesets", async () => {
+      // Arrange
+      const downloadChangesetsParams: ChangesetRangeArg & { targetDir: LocalDirName } = {
+        accessToken,
+        iModelId: testIModelForRead.id,
+        targetDir: testDownloadPath
+      };
 
-      if (expectedChangesetFile.containingChanges === ContainingChanges.Schema)
-        expect(downloadedChangeset.changesType).to.be.equal(ChangesetType.Schema);
-      else
-        expect(downloadedChangeset.changesType).to.be.equal(ChangesetType.Regular);
+      // Act
+      const downloadedChangesets: ChangesetFileProps[] = await backendIModelsAccess.downloadChangesets(downloadChangesetsParams);
+
+      // Assert
+      expect(downloadedChangesets.length).to.be.equal(testIModelFileProvider.changesets.length);
+      for (let i = 0; i < downloadedChangesets.length; i++) {
+        const downloadedChangeset = downloadedChangesets[i];
+        const expectedChangesetFile = testIModelFileProvider.changesets[i];
+
+        expect(fs.existsSync(downloadedChangeset.pathname)).to.equal(true);
+        expect(downloadedChangeset.id).to.be.equal(expectedChangesetFile.id);
+        expect(downloadedChangeset.index).to.be.equal(expectedChangesetFile.index);
+        expect(downloadedChangeset.parentId).to.be.equal(expectedChangesetFile.parentId);
+        expect(downloadedChangeset.description).to.be.equal(expectedChangesetFile.description);
+        expect(downloadedChangeset.briefcaseId).to.be.equal(testIModelForRead.briefcase.id);
+        expect(downloadedChangeset.size).to.be.equal(fs.statSync(expectedChangesetFile.filePath).size);
+
+        if (expectedChangesetFile.containingChanges === ContainingChanges.Schema)
+          expect(downloadedChangeset.changesType).to.be.equal(ChangesetType.Schema);
+        else
+          expect(downloadedChangeset.changesType).to.be.equal(ChangesetType.Regular);
+      }
+    });
+  });
+
+  describe("locks", () => {
+    it("should successfully acquire new locks", async () => {
+      // Arrange
+      const acquireNewBriefcaseIdParams: AcquireNewBriefcaseIdArg = {
+        accessToken,
+        iModelId: testIModelForWrite.id,
+      };
+      const briefcaseId = await backendIModelsAccess.acquireNewBriefcaseId(acquireNewBriefcaseIdParams);
+
+      const briefcaseDbParams: BriefcaseDbArg = {
+        accessToken,
+        iModelId: testIModelForWrite.id,
+        briefcaseId,
+        changeset: { id: "", index: 0 }
+      };
+      const locksToAcquire: LockMap = new Map<string, LockState>([
+        ["0x1", LockState.Exclusive],
+        ["0x2", LockState.Exclusive],
+        ["0x3", LockState.Shared],
+      ]);
+
+      // Act
+      await backendIModelsAccess.acquireLocks(briefcaseDbParams, locksToAcquire)
+
+      // Assert
+      assertLocks({
+        lockQueryParams: briefcaseDbParams,
+        expectedLocks: locksToAcquire
+      });
+    });
+
+
+    it("should successfully release locks", async () => {
+      // Arrange
+      const acquireNewBriefcaseIdParams: AcquireNewBriefcaseIdArg = {
+        accessToken,
+        iModelId: testIModelForWrite.id,
+      };
+      const briefcaseId = await backendIModelsAccess.acquireNewBriefcaseId(acquireNewBriefcaseIdParams);
+
+      const briefcaseDbParams: BriefcaseDbArg = {
+        accessToken,
+        iModelId: testIModelForWrite.id,
+        briefcaseId,
+        changeset: { id: "", index: 0 }
+      };
+      const locksToAcquire: LockMap = new Map<string, LockState>([
+        ["0x1", LockState.Exclusive],
+        ["0x2", LockState.Exclusive],
+        ["0x3", LockState.Shared],
+      ]);
+
+      await backendIModelsAccess.acquireLocks(briefcaseDbParams, locksToAcquire)
+      assertLocks({
+        lockQueryParams: briefcaseDbParams,
+        expectedLocks: locksToAcquire
+      });
+
+      // Act
+      await backendIModelsAccess.releaseAllLocks(briefcaseDbParams);
+
+      // Assert
+      const actualLocks: LockProps[] = await backendIModelsAccess.queryAllLocks(briefcaseDbParams);
+      expect(actualLocks.length).to.be.equal(0);
+    });
+
+    async function assertLocks(params: { lockQueryParams: BriefcaseDbArg, expectedLocks: LockMap }): Promise<void> {
+      const actualLocks: LockProps[] = await backendIModelsAccess.queryAllLocks(params.lockQueryParams);
+      expect(actualLocks.length).to.equal(params.expectedLocks.size);
+      for (let [expectedObjectId, expectedLockState] of params.expectedLocks) {
+        const actualLock = actualLocks.find(lock => lock.id === expectedObjectId && lock.state === expectedLockState);
+        expect(actualLock).to.not.be.undefined;
+      }
     }
-  });
+  })
 });


### PR DESCRIPTION
In this PR:
- Fixed an issue where locks received from the platform code were not correctly transformed in `PlatformToClientAdapter` class due to incorrect iteration over a map.
- Added integration tests in `@itwin/imodels-access-backend-tests` package. All three lock related methods are used
  - `BackendIModelsAccess.queryAllLocks`
  - `BackendIModelsAccess.releaseAllLocks`
  - `BackendIModelsAccess.acquireLocks`