### PR TITLE
Fixing the publish pipeline to consume the correct variable set

### DIFF
--- a/pipelines/build-test-publish.yml
+++ b/pipelines/build-test-publish.yml
@@ -16,7 +16,7 @@ jobs:
     pool:
         vmImage: $(imageName)
     variables:
-      - group: iModels Clients - Integration Tests - SBX
+      - group: iModels Clients - Integration Tests - DEV
     workspace:
       clean: all
 


### PR DESCRIPTION
In this PR:
- Fixed the "Build, Test and Publish" to consume the correct variable set (that points to DEV)