### PR TITLE
Fixing the @itwin/imodels-client-test-utils to publish its assets

### DIFF
--- a/utils/imodels-client-test-utils/.npmignore
+++ b/utils/imodels-client-test-utils/.npmignore
@@ -2,3 +2,4 @@
 *
 !lib/**/*.d.ts
 !lib/**/*.js
+!lib/assets/**


### PR DESCRIPTION
In this PR:
- modified the `.npmignore` file in `@itwin/imodels-client-test-utils` to publish its assets that are required for test iModel creation.