### PR TITLE
Include source maps in published packages

### DIFF
--- a/clients/imodels-client-authoring/.npmignore
+++ b/clients/imodels-client-authoring/.npmignore
@@ -2,3 +2,4 @@
 *
 !lib/**/*.d.ts
 !lib/**/*.js
+!lib/**/*.js.map

--- a/clients/imodels-client-management/.npmignore
+++ b/clients/imodels-client-management/.npmignore
@@ -2,3 +2,4 @@
 *
 !lib/**/*.d.ts
 !lib/**/*.js
+!lib/**/*.js.map

--- a/itwin-platform-access/imodels-access-backend/.npmignore
+++ b/itwin-platform-access/imodels-access-backend/.npmignore
@@ -2,3 +2,4 @@
 *
 !lib/**/*.d.ts
 !lib/**/*.js
+!lib/**/*.js.map

--- a/itwin-platform-access/imodels-access-frontend/.npmignore
+++ b/itwin-platform-access/imodels-access-frontend/.npmignore
@@ -2,3 +2,4 @@
 *
 !lib/**/*.d.ts
 !lib/**/*.js
+!lib/**/*.js.map

--- a/tests/imodels-access-backend-tests/.npmignore
+++ b/tests/imodels-access-backend-tests/.npmignore
@@ -2,3 +2,4 @@
 *
 !lib/**/*.d.ts
 !lib/**/*.js
+!lib/**/*.js.map

--- a/tests/imodels-access-frontend-tests/.npmignore
+++ b/tests/imodels-access-frontend-tests/.npmignore
@@ -2,3 +2,4 @@
 *
 !lib/**/*.d.ts
 !lib/**/*.js
+!lib/**/*.js.map

--- a/tests/imodels-clients-tests/.npmignore
+++ b/tests/imodels-clients-tests/.npmignore
@@ -2,3 +2,4 @@
 *
 !lib/**/*.d.ts
 !lib/**/*.js
+!lib/**/*.js.map

--- a/utils/imodels-client-common-config/tsconfig.json
+++ b/utils/imodels-client-common-config/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es2018",
     "module": "commonjs",
     "sourceMap": true,
+    "inlineSources": true,
     "lib": [
       "es2018",
       "esnext.asynciterable",

--- a/utils/imodels-client-test-utils/.npmignore
+++ b/utils/imodels-client-test-utils/.npmignore
@@ -2,3 +2,4 @@
 *
 !lib/**/*.d.ts
 !lib/**/*.js
+!lib/**/*.js.map


### PR DESCRIPTION
All JavaScript files that are published to npmjs from this repository declare that they have accompanying source maps when in reality they are missing. This results in tools like [source-map-loader](https://github.com/webpack-contrib/source-map-loader) issuing runtime errors when a dev server encounters missing source map references.

Made changes:
* Edit `.npmignore` files to allow generated `.js.map` files to be included in all published packages.
* Change TypeScript configuration to include the original source code within source map files.