### PR TITLE
Minimal docs for `IModelsClient`s

### DIFF
--- a/docs/IModelsClientAuthoring.md
+++ b/docs/IModelsClientAuthoring.md
@@ -1,25 +1,25 @@
 # `@itwin/imodels-client-authoring`
 
-`IModelsClient` exposed by `@itwin/imodels-client-authoring` package extends `IModelsClient` exposed by `@itwin/imodels-client-management` package so this documentation references sections from [`@itwin/imodels-client-management` documentation](IModelsClientManagement.md). All types mentioned there are also exported from `@itwin/imodels-client-authoring` package.
+`@itwin/imodels-client-authoring` package extends `IModelsClient` exposed by `@itwin/imodels-client-management` package thus this documentation references sections from [`@itwin/imodels-client-management` documentation](./IModelsClientManagement.md).
 
 ## Key types
 - [`IModelsClient`](../clients/imodels-client-authoring/src/IModelsClient.ts#L31)
 - [`IModelsClientOptions`](../clients/imodels-client-authoring/src/IModelsClient.ts#L18)
 
 ### Parameter and response types
-Please see [parameter and response types for `@itwin/imodels-client-management`](./IModelsClientManagement.md#parameter-and-response-types).
+Please see [documentation](./IModelsClientManagement.md#parameter-and-response-types) of parameter and response types for `@itwin/imodels-client-management`.
 
 Additional types:
 - [`TargetDirectoryParam`](../clients/imodels-client-authoring/src/base/interfaces/CommonInterfaces.ts#L13)
 
 ### Entities
-Please see [entities for `@itwin/imodels-client-management`](./IModelsClientManagement.md#entities).
+Please see [documentation](./IModelsClientManagement.md#entities) of entities for `@itwin/imodels-client-management`.
 
 Additional types:
 - [`Lock`](../clients/imodels-client-authoring/src/base/interfaces/apiEntities/LockInterfaces.ts#L25)
 
 ## Key methods
-Please see [key methods for `@itwin/imodels-client-management`](./IModelsClientManagement.md#key-methods).
+Please see [documentation](./IModelsClientManagement.md#key-methods) of key methods for `@itwin/imodels-client-management`.
 
 Additional methods:
 - [`IModelsClient.iModels`](../clients/imodels-client-authoring/src/IModelsClient.ts#L56)

--- a/docs/IModelsClientAuthoring.md
+++ b/docs/IModelsClientAuthoring.md
@@ -10,7 +10,7 @@
 Please see [parameter and response types for `@itwin/imodels-client-management`](./IModelsClientManagement.md#parameter-and-response-types).
 
 Additional types:
-- [`TargetDirectoryParam`](../clients/imodels-client-authoring/src/base/interfaces/CommonInterfaces.ts#13)
+- [`TargetDirectoryParam`](../clients/imodels-client-authoring/src/base/interfaces/CommonInterfaces.ts#L13)
 
 ### Entities
 Please see [entities for `@itwin/imodels-client-management`](./IModelsClientManagement.md#entities).
@@ -22,16 +22,16 @@ Additional types:
 Please see [key methods for `@itwin/imodels-client-management`](./IModelsClientManagement.md#key-methods).
 
 Additional methods:
-- [`IModelsClient.iModels`](../clients/imodels-client-authoring/src/IModelsClient.ts#L)
+- [`IModelsClient.iModels`](../clients/imodels-client-authoring/src/IModelsClient.ts#L56)
   - [`createFromBaseline(params: CreateIModelFromBaselineParams): Promise<IModel>`](../clients/imodels-client-authoring/src/operations/imodel/IModelOperations.ts#L33) ([sample](#create-imodel-from-baseline-file))
-- [`IModelsClient.briefcases`](../clients/imodels-client-authoring/src/IModelsClient.ts#L)
+- [`IModelsClient.briefcases`](../clients/imodels-client-authoring/src/IModelsClient.ts#L61)
   - [`acquire(params: AcquireBriefcaseParams): Promise<Briefcase>`](../clients/imodels-client-authoring/src/operations/briefcase/BriefcaseOperations.ts#L17)
   - [`release(params: ReleaseBriefcaseParams): Promise<void>`](../clients/imodels-client-authoring/src/operations/briefcase/BriefcaseOperations.ts#L34)
-- [`IModelsClient.changesets`](../clients/imodels-client-authoring/src/IModelsClient.ts#L)
+- [`IModelsClient.changesets`](../clients/imodels-client-authoring/src/IModelsClient.ts#L66)
   - [`create(params: CreateChangesetParams): Promise<Changeset>`](../clients/imodels-client-authoring/src/operations/changeset/ChangesetOperations.ts#L20)
   - [`downloadSingle(params: DownloadSingleChangesetParams): Promise<DownloadedChangeset>`](../clients/imodels-client-authoring/src/operations/changeset/ChangesetOperations.ts#L49)
   - [`downloadList(params: DownloadChangesetListParams): Promise<DownloadedChangeset[]>`](../clients/imodels-client-authoring/src/operations/changeset/ChangesetOperations.ts#L65)
-- [`IModelsClient.locks`](../clients/imodels-client-authoring/src/IModelsClient.ts#L)
+- [`IModelsClient.locks`](../clients/imodels-client-authoring/src/IModelsClient.ts#L81)
   - [`getList(params: GetLockListParams): EntityListIterator<Lock>`](../clients/imodels-client-authoring/src/operations/lock/LockOperations.ts#L19)
   - [`update(params: UpdateLockParams): Promise<Lock>`](../clients/imodels-client-authoring/src/operations/lock/LockOperations.ts#L34)
 
@@ -41,7 +41,7 @@ Since the `@itwin/imodels-client-authoring` package extends the `@itwin/imodels-
 
 ### Authorization
 
-`IModelsClient` expects the authorization info to be passed in a form of an asynchronous callback that returns authorization info. It is a common use case to consume `IModelsClient` in iTwin.js platform based applications which use `IModelApp.getAccessToken` or `IModelHost.getAccessToken` to get the authorization header value returned as a string. The authorization header value specifies the schema and access token e.g. `Bearer ey...`. To convert this value into the format that `IModelsClients` expect users can use `AccessTokenAdapter` class which is exported by both [`@itwin/imodels-access-frontend`](../../itwin-platform-access/imodels-access-frontend/src/interface-adapters/AccessTokenAdapter.ts) and [`@itwin/imodels-access-backend`](../../itwin-platform-access/imodels-access-backend/src/interface-adapters/AccessTokenAdapter.ts) packages.
+`IModelsClient` expects the authorization info to be passed in a form of an asynchronous callback that returns authorization info. It is a common use case to consume `IModelsClient` in iTwin.js platform based applications which use `IModelApp.getAccessToken` or `IModelHost.getAccessToken` to get the authorization header value returned as a string. The authorization header value specifies the schema and access token e.g. `Bearer ey...`. To convert this value into the format that `IModelsClients` expect users can use `AccessTokenAdapter` class which is exported by both [`@itwin/imodels-access-frontend`](../itwin-platform-access/imodels-access-frontend/src/interface-adapters/AccessTokenAdapter.ts) and [`@itwin/imodels-access-backend`](../itwin-platform-access/imodels-access-backend/src/interface-adapters/AccessTokenAdapter.ts) packages.
 ```typescript
 const iModelIterator: EntityListIterator<MinimalIModel> = iModelsClient.iModels.getMinimalList({
   authorization: AccessTokenAdapter.toAuthorizationCallback(await IModelHost.getAccessToken()),

--- a/docs/IModelsClientAuthoring.md
+++ b/docs/IModelsClientAuthoring.md
@@ -23,7 +23,7 @@ Please see [key methods for `@itwin/imodels-client-management`](./IModelsClientM
 
 Additional methods:
 - [`IModelsClient.iModels`](../clients/imodels-client-authoring/src/IModelsClient.ts#L)
-  - [`createFromBaseline(params: CreateIModelFromBaselineParams): Promise<IModel>`](../clients/imodels-client-authoring/src/operations/imodel/IModelOperations.ts#L33)
+  - [`createFromBaseline(params: CreateIModelFromBaselineParams): Promise<IModel>`](../clients/imodels-client-authoring/src/operations/imodel/IModelOperations.ts#L33) ([sample](#create-imodel-from-baseline-file))
 - [`IModelsClient.briefcases`](../clients/imodels-client-authoring/src/IModelsClient.ts#L)
   - [`acquire(params: AcquireBriefcaseParams): Promise<Briefcase>`](../clients/imodels-client-authoring/src/operations/briefcase/BriefcaseOperations.ts#L17)
   - [`release(params: ReleaseBriefcaseParams): Promise<void>`](../clients/imodels-client-authoring/src/operations/briefcase/BriefcaseOperations.ts#L34)
@@ -34,3 +34,45 @@ Additional methods:
 - [`IModelsClient.locks`](../clients/imodels-client-authoring/src/IModelsClient.ts#L)
   - [`getList(params: GetLockListParams): EntityListIterator<Lock>`](../clients/imodels-client-authoring/src/operations/lock/LockOperations.ts#L19)
   - [`update(params: UpdateLockParams): Promise<Lock>`](../clients/imodels-client-authoring/src/operations/lock/LockOperations.ts#L34)
+
+## Usage examples
+
+Since the `@itwin/imodels-client-authoring` package extends the `@itwin/imodels-client-management` package all [its usage examples](./IModelsClientManagement.md#usage-examples) are valid for the current client as well.
+
+### Authorization
+
+`IModelsClient` expects the authorization info to be passed in a form of an asynchronous callback that returns authorization info. It is a common use case to consume `IModelsClient` in iTwin.js platform based applications which use `IModelApp.getAccessToken` or `IModelHost.getAccessToken` to get the authorization header value returned as a string. The authorization header value specifies the schema and access token e.g. `Bearer ey...`. To convert this value into the format that `IModelsClients` expect users can use `AccessTokenAdapter` class which is exported by both [`@itwin/imodels-access-frontend`](../../itwin-platform-access/imodels-access-frontend/src/interface-adapters/AccessTokenAdapter.ts) and [`@itwin/imodels-access-backend`](../../itwin-platform-access/imodels-access-backend/src/interface-adapters/AccessTokenAdapter.ts) packages.
+```typescript
+const iModelIterator: EntityListIterator<MinimalIModel> = iModelsClient.iModels.getMinimalList({
+  authorization: AccessTokenAdapter.toAuthorizationCallback(await IModelHost.getAccessToken()),
+  urlParams: {
+    projectId: "8a1fcd73-8c23-460d-a392-8b4afc00affc"
+  }
+});
+```
+
+### Create iModel from Baseline File
+```typescript
+import { Authorization, IModel, IModelsClient } from "@itwin/imodels-client-authoring";
+
+/** Function that creates a new iModel from Baseline file and prints its id to the console. */
+async function createIModelFromBaselineFile(): Promise<void> {
+  const iModelsClient: IModelsClient = new IModelsClient();
+  const iModel: IModel = await iModelsClient.iModels.createFromBaseline({
+    authorization: () => getAuthorization(),
+    iModelProperties: {
+      projectId: "8a1fcd73-8c23-460d-a392-8b4afc00affc",
+      name: "Sun City Renewable-energy Plant",
+      description: "Overall model of wind and solar farms in Sun City",
+      filePath: "D:\\imodels\\sun-city.bim"
+    }
+  });
+
+  console.log(iModel.id);
+}
+
+/** Function that returns valid authorization information. */
+async function getAuthorization(): Promise<Authorization> {
+  return { scheme: "Bearer", token: "ey..." };
+}
+```

--- a/docs/IModelsClientAuthoring.md
+++ b/docs/IModelsClientAuthoring.md
@@ -7,19 +7,19 @@
 - [`IModelsClientOptions`](../clients/imodels-client-authoring/src/IModelsClient.ts#L18)
 
 ### Parameter and response types
-Please see [parameter and response types for `@itwin/imodels-client-management`](./IModelsClientManagement.md#parameter-and-response-types)
+Please see [parameter and response types for `@itwin/imodels-client-management`](./IModelsClientManagement.md#parameter-and-response-types).
 
 Additional types:
 - [`TargetDirectoryParam`](../clients/imodels-client-authoring/src/base/interfaces/CommonInterfaces.ts#13)
 
 ### Entities
-Please see [entities for `@itwin/imodels-client-management`](./IModelsClientManagement.md#entities)
+Please see [entities for `@itwin/imodels-client-management`](./IModelsClientManagement.md#entities).
 
 Additional types:
 - [`Lock`](../clients/imodels-client-authoring/src/base/interfaces/apiEntities/LockInterfaces.ts#L25)
 
 ## Key methods
-Please see [key methods for `@itwin/imodels-client-management`](./IModelsClientManagement.md#key-methods)
+Please see [key methods for `@itwin/imodels-client-management`](./IModelsClientManagement.md#key-methods).
 
 Additional methods:
 - [`IModelsClient.iModels`](../clients/imodels-client-authoring/src/IModelsClient.ts#L)

--- a/docs/IModelsClientAuthoring.md
+++ b/docs/IModelsClientAuthoring.md
@@ -1,0 +1,36 @@
+# `@itwin/imodels-client-authoring`
+
+`IModelsClient` exposed by `@itwin/imodels-client-authoring` package extends `IModelsClient` exposed by `@itwin/imodels-client-management` package so this documentation references sections from [`@itwin/imodels-client-management` documentation](IModelsClientManagement.md). All types mentioned there are also exported from `@itwin/imodels-client-authoring` package.
+
+## Key types
+- [`IModelsClient`](../clients/imodels-client-authoring/src/IModelsClient.ts#L31)
+- [`IModelsClientOptions`](../clients/imodels-client-authoring/src/IModelsClient.ts#L18)
+
+### Parameter and response types
+Please see [parameter and response types for `@itwin/imodels-client-management`](./IModelsClientManagement.md#parameter-and-response-types)
+
+Additional types:
+- [`TargetDirectoryParam`](../clients/imodels-client-authoring/src/base/interfaces/CommonInterfaces.ts#13)
+
+### Entities
+Please see [entities for `@itwin/imodels-client-management`](./IModelsClientManagement.md#entities)
+
+Additional types:
+- [`Lock`](../clients/imodels-client-authoring/src/base/interfaces/apiEntities/LockInterfaces.ts#L25)
+
+## Key methods
+Please see [key methods for `@itwin/imodels-client-management`](./IModelsClientManagement.md#key-methods)
+
+Additional methods:
+- [`IModelsClient.iModels`](../clients/imodels-client-authoring/src/IModelsClient.ts#L)
+  - [`createFromBaseline(params: CreateIModelFromBaselineParams): Promise<IModel>`](../clients/imodels-client-authoring/src/operations/imodel/IModelOperations.ts#L33)
+- [`IModelsClient.briefcases`](../clients/imodels-client-authoring/src/IModelsClient.ts#L)
+  - [`acquire(params: AcquireBriefcaseParams): Promise<Briefcase>`](../clients/imodels-client-authoring/src/operations/briefcase/BriefcaseOperations.ts#L17)
+  - [`release(params: ReleaseBriefcaseParams): Promise<void>`](../clients/imodels-client-authoring/src/operations/briefcase/BriefcaseOperations.ts#L34)
+- [`IModelsClient.changesets`](../clients/imodels-client-authoring/src/IModelsClient.ts#L)
+  - [`create(params: CreateChangesetParams): Promise<Changeset>`](../clients/imodels-client-authoring/src/operations/changeset/ChangesetOperations.ts#L20)
+  - [`downloadSingle(params: DownloadSingleChangesetParams): Promise<DownloadedChangeset>`](../clients/imodels-client-authoring/src/operations/changeset/ChangesetOperations.ts#L49)
+  - [`downloadList(params: DownloadChangesetListParams): Promise<DownloadedChangeset[]>`](../clients/imodels-client-authoring/src/operations/changeset/ChangesetOperations.ts#L65)
+- [`IModelsClient.locks`](../clients/imodels-client-authoring/src/IModelsClient.ts#L)
+  - [`getList(params: GetLockListParams): EntityListIterator<Lock>`](../clients/imodels-client-authoring/src/operations/lock/LockOperations.ts#L19)
+  - [`update(params: UpdateLockParams): Promise<Lock>`](../clients/imodels-client-authoring/src/operations/lock/LockOperations.ts#L34)

--- a/docs/IModelsClientManagement.md
+++ b/docs/IModelsClientManagement.md
@@ -1,0 +1,40 @@
+# `@itwin/imodels-client-management`
+
+## Key types
+- [`IModelsClient`](../clients/imodels-client-management/src/IModelsClient.ts#L27)
+- [`IModelsClientOptions`](../clients/imodels-client-management/src/IModelsClient.ts#L13)
+
+### Parameter and response types
+- [`AuthorizationParam`](../clients/imodels-client-management/src/base/interfaces/CommonInterfaces.ts#L38)
+- [`EntityListIterator<TEntity>`](../clients/imodels-client-management/src/base/iterators/EntityListIterator.ts#L11)
+
+### Entities
+- [`MinimalIModel`](../clients/imodels-client-management/src/base/interfaces/apiEntities/IModelInterfaces.ts#L39), [`IModel`](../clients/imodels-client-management/src/base/interfaces/apiEntities/IModelInterfaces.ts#L47)
+- [`MinimalBriefcase`](../clients/imodels-client-management/src/base/interfaces/apiEntities/BriefcaseInterfaces.ts#L8), [`Briefcase`](../clients/imodels-client-management/src/base/interfaces/apiEntities/BriefcaseInterfaces.ts#L15)
+- [`MinimalChangeset`](../clients/imodels-client-management/src/base/interfaces/apiEntities/ChangesetInterfaces.ts#L61), [`Changeset`](../clients/imodels-client-management/src/base/interfaces/apiEntities/ChangesetInterfaces.ts#L87)
+- [`MinimalNamedVersion`](../clients/imodels-client-management/src/base/interfaces/apiEntities/NamedVersionInterfaces.ts#L16), [`NamedVersion`](../clients/imodels-client-management/src/base/interfaces/apiEntities/NamedVersionInterfaces.ts#L34)
+- [`Checkpoint`](../clients/imodels-client-management/src/base/interfaces/apiEntities/CheckpointInterfaces.ts#L38)
+
+## Key methods
+- [`IModelsClient.iModels`](../clients/imodels-client-management/src/IModelsClient.ts#L44)
+  - [`getMinimalList(params: GetIModelListParams): EntityListIterator<MinimalIModel>`](../clients/imodels-client-management/src/operations/imodel/IModelOperations.ts#L17)
+  - [`getRepresentationList(params: GetIModelListParams): EntityListIterator<IModel>`](../clients/imodels-client-management/src/operations/imodel/IModelOperations.ts#L33)
+  - [`getSingle(params: GetSingleIModelParams): Promise<IModel>`](../clients/imodels-client-management/src/operations/imodel/IModelOperations.ts#L48)
+  - [`createEmpty(params: CreateEmptyIModelParams): Promise<IModel>`](../clients/imodels-client-management/src/operations/imodel/IModelOperations.ts#L)
+  - [`delete(params: DeleteIModelParams): Promise<void>`](../clients/imodels-client-management/src/operations/imodel/IModelOperations.ts#L)
+- [`IModelsClient.briefcases`](../clients/imodels-client-management/src/IModelsClient.ts#L49)
+  - [`getMinimalList(params: GetBriefcaseListParams): EntityListIterator<MinimalBriefcase> `](../clients/imodels-client-management/src/operations/briefcase/BriefcaseOperations.ts#L19)
+  - [`getRepresentationList(params: GetBriefcaseListParams): EntityListIterator<Briefcase>`](../clients/imodels-client-management/src/operations/briefcase/BriefcaseOperations.ts#L36)
+  - [`getSingle(params: GetSingleBriefcaseParams): Promise<Briefcase>`](../clients/imodels-client-management/src/operations/briefcase/BriefcaseOperations.ts#L52)
+- [`IModelsClient.changesets`](../clients/imodels-client-management/src/IModelsClient.ts#L54)
+  - [`getMinimalList(params: GetChangesetListParams): EntityListIterator<MinimalChangeset>`](../clients/imodels-client-management/src/operations/changeset/ChangesetOperations.ts#L30)
+  - [`getRepresentationList(params: GetChangesetListParams): EntityListIterator<Changeset>`](../clients/imodels-client-management/src/operations/changeset/ChangesetOperations.ts#L48)
+  - [`getSingle(params: GetSingleChangesetParams): Promise<Changeset>`](../clients/imodels-client-management/src/operations/changeset/ChangesetOperations.ts#L70)
+- [`IModelsClient.namedVersions`](../clients/imodels-client-management/src/IModelsClient.ts#L59)
+  - [`getMinimalList(params: GetNamedVersionListParams): EntityListIterator<MinimalNamedVersion>`](../clients/imodels-client-management/src/operations/named-version/NamedVersionOperations.ts#L19)
+  - [`getRepresentationList(params: GetNamedVersionListParams): EntityListIterator<NamedVersion>`](../clients/imodels-client-management/src/operations/named-version/NamedVersionOperations.ts#L37)
+  - [`getSingle(params: GetSingleNamedVersionParams): Promise<NamedVersion>`](../clients/imodels-client-management/src/operations/named-version/NamedVersionOperations.ts#L53)
+  - [`create(params: CreateNamedVersionParams): Promise<NamedVersion>`](../clients/imodels-client-management/src/operations/named-version/NamedVersionOperations.ts#L68)
+  - [`update(params: UpdateNamedVersionParams): Promise<NamedVersion>`](../clients/imodels-client-management/src/operations/named-version/NamedVersionOperations.ts#L85)
+- [`IModelsClient.checkpoints`](../clients/imodels-client-management/src/IModelsClient.ts#L64)
+  - [`getSingle(params: GetSingleCheckpointParams): Promise<Checkpoint>`](../clients/imodels-client-management/src/operations/checkpoint/CheckpointOperations.ts#L19)

--- a/docs/IModelsClientManagement.md
+++ b/docs/IModelsClientManagement.md
@@ -17,7 +17,7 @@
 
 ## Key methods
 - [`IModelsClient.iModels`](../clients/imodels-client-management/src/IModelsClient.ts#L44)
-  - [`getMinimalList(params: GetIModelListParams): EntityListIterator<MinimalIModel>`](../clients/imodels-client-management/src/operations/imodel/IModelOperations.ts#L17)
+  - [`getMinimalList(params: GetIModelListParams): EntityListIterator<MinimalIModel>`](../clients/imodels-client-management/src/operations/imodel/IModelOperations.ts#L17) ([sample](#get-all-project-imodels))
   - [`getRepresentationList(params: GetIModelListParams): EntityListIterator<IModel>`](../clients/imodels-client-management/src/operations/imodel/IModelOperations.ts#L33)
   - [`getSingle(params: GetSingleIModelParams): Promise<IModel>`](../clients/imodels-client-management/src/operations/imodel/IModelOperations.ts#L48)
   - [`createEmpty(params: CreateEmptyIModelParams): Promise<IModel>`](../clients/imodels-client-management/src/operations/imodel/IModelOperations.ts#L)
@@ -27,14 +27,89 @@
   - [`getRepresentationList(params: GetBriefcaseListParams): EntityListIterator<Briefcase>`](../clients/imodels-client-management/src/operations/briefcase/BriefcaseOperations.ts#L36)
   - [`getSingle(params: GetSingleBriefcaseParams): Promise<Briefcase>`](../clients/imodels-client-management/src/operations/briefcase/BriefcaseOperations.ts#L52)
 - [`IModelsClient.changesets`](../clients/imodels-client-management/src/IModelsClient.ts#L54)
-  - [`getMinimalList(params: GetChangesetListParams): EntityListIterator<MinimalChangeset>`](../clients/imodels-client-management/src/operations/changeset/ChangesetOperations.ts#L30)
+  - [`getMinimalList(params: GetChangesetListParams): EntityListIterator<MinimalChangeset>`](../clients/imodels-client-management/src/operations/changeset/ChangesetOperations.ts#L30) ([sample](#get-all-imodel-changesets))
   - [`getRepresentationList(params: GetChangesetListParams): EntityListIterator<Changeset>`](../clients/imodels-client-management/src/operations/changeset/ChangesetOperations.ts#L48)
   - [`getSingle(params: GetSingleChangesetParams): Promise<Changeset>`](../clients/imodels-client-management/src/operations/changeset/ChangesetOperations.ts#L70)
 - [`IModelsClient.namedVersions`](../clients/imodels-client-management/src/IModelsClient.ts#L59)
   - [`getMinimalList(params: GetNamedVersionListParams): EntityListIterator<MinimalNamedVersion>`](../clients/imodels-client-management/src/operations/named-version/NamedVersionOperations.ts#L19)
   - [`getRepresentationList(params: GetNamedVersionListParams): EntityListIterator<NamedVersion>`](../clients/imodels-client-management/src/operations/named-version/NamedVersionOperations.ts#L37)
   - [`getSingle(params: GetSingleNamedVersionParams): Promise<NamedVersion>`](../clients/imodels-client-management/src/operations/named-version/NamedVersionOperations.ts#L53)
-  - [`create(params: CreateNamedVersionParams): Promise<NamedVersion>`](../clients/imodels-client-management/src/operations/named-version/NamedVersionOperations.ts#L68)
+  - [`create(params: CreateNamedVersionParams): Promise<NamedVersion>`](../clients/imodels-client-management/src/operations/named-version/NamedVersionOperations.ts#L68) ([sample](#create-a-named-version-on-a-changeset))
   - [`update(params: UpdateNamedVersionParams): Promise<NamedVersion>`](../clients/imodels-client-management/src/operations/named-version/NamedVersionOperations.ts#L85)
 - [`IModelsClient.checkpoints`](../clients/imodels-client-management/src/IModelsClient.ts#L64)
   - [`getSingle(params: GetSingleCheckpointParams): Promise<Checkpoint>`](../clients/imodels-client-management/src/operations/checkpoint/CheckpointOperations.ts#L19)
+
+## Usage examples
+
+### Authorization
+
+`IModelsClient` expects the authorization info to be passed in a form of an asynchronous callback that returns authorization info. It is a common use case to consume `IModelsClient` in iTwin.js platform based applications which use `IModelApp.getAccessToken` or `IModelHost.getAccessToken` to get the authorization header value returned as a string. The authorization header value specifies the schema and access token e.g. `Bearer ey...`. To convert this value into the format that `IModelsClients` expect users can use `AccessTokenAdapter` class which is exported by both [`@itwin/imodels-access-frontend`](../../itwin-platform-access/imodels-access-frontend/src/interface-adapters/AccessTokenAdapter.ts) and [`@itwin/imodels-access-backend`](../../itwin-platform-access/imodels-access-backend/src/interface-adapters/AccessTokenAdapter.ts) packages.
+```typescript
+const iModelIterator: EntityListIterator<MinimalIModel> = iModelsClient.iModels.getMinimalList({
+  authorization: AccessTokenAdapter.toAuthorizationCallback(await IModelApp.getAccessToken()),
+  urlParams: {
+    projectId: "8a1fcd73-8c23-460d-a392-8b4afc00affc"
+  }
+});
+```
+
+### Get all project iModels
+```typescript
+import { Authorization, EntityListIterator, IModelsClient, MinimalIModel } from "@itwin/imodels-client-management";
+
+/** Function that queries all iModels for a particular project and prints their ids to the console. */
+async function printiModelIds(): Promise<void> {
+  const iModelsClient: IModelsClient = new IModelsClient();
+  const iModelIterator: EntityListIterator<MinimalIModel> = iModelsClient.iModels.getMinimalList({
+    authorization: () => getAuthorization(),
+    urlParams: {
+      projectId: "8a1fcd73-8c23-460d-a392-8b4afc00affc"
+    }
+  });
+
+  for await (const iModel of iModelIterator)
+    console.log(iModel.id);
+}
+
+/** Function that returns valid authorization information. */
+async function getAuthorization(): Promise<Authorization> {
+  return { scheme: "Bearer", token: "ey..." };
+}
+```
+
+### Get all iModel Changesets
+```typescript
+import { Authorization, EntityListIterator, IModelsClient, MinimalChangeset } from "@itwin/imodels-client-management";
+
+/** Function that queries all Changesets for a particular iModel and prints their ids to the console. */
+async function printChangesetIds(): Promise<void> {
+  const iModelsClient: IModelsClient = new IModelsClient();
+  const changesetIterator: EntityListIterator<MinimalChangeset> = iModelsClient.changesets.getMinimalList({
+    authorization: () => getAuthorization(),
+    iModelId: "30c8505e-fa7a-4b53-a13f-e6a193da8ffc"
+  });
+
+  for await (const changeset of changesetIterator)
+    console.log(changeset.id);
+}
+```
+
+### Create a Named Version on a Changeset
+```typescript
+import { Authorization, IModelsClient, NamedVersion } from "@itwin/imodels-client-management";
+
+/** Function that creates a Named Version on a particular changeset and prints its id to the console. */
+async function createNamedVersion(): Promise<void> {
+  const iModelsClient: IModelsClient = new IModelsClient();
+  const namedVersion: NamedVersion = await iModelsClient.namedVersions.create({
+    authorization: () => getAuthorization(),
+    iModelId: "30c8505e-fa7a-4b53-a13f-e6a193da8ffc",
+    namedVersionProperties: {
+      name: "Milestone",
+      changesetId: "bd51c08eb44f40d49fee9a0c7d6fc018c3b5ba3f"
+    }
+  });
+
+  console.log(namedVersion.id);
+}
+```

--- a/docs/IModelsClientManagement.md
+++ b/docs/IModelsClientManagement.md
@@ -20,8 +20,8 @@
   - [`getMinimalList(params: GetIModelListParams): EntityListIterator<MinimalIModel>`](../clients/imodels-client-management/src/operations/imodel/IModelOperations.ts#L17) ([sample](#get-all-project-imodels))
   - [`getRepresentationList(params: GetIModelListParams): EntityListIterator<IModel>`](../clients/imodels-client-management/src/operations/imodel/IModelOperations.ts#L33)
   - [`getSingle(params: GetSingleIModelParams): Promise<IModel>`](../clients/imodels-client-management/src/operations/imodel/IModelOperations.ts#L48)
-  - [`createEmpty(params: CreateEmptyIModelParams): Promise<IModel>`](../clients/imodels-client-management/src/operations/imodel/IModelOperations.ts#L)
-  - [`delete(params: DeleteIModelParams): Promise<void>`](../clients/imodels-client-management/src/operations/imodel/IModelOperations.ts#L)
+  - [`createEmpty(params: CreateEmptyIModelParams): Promise<IModel>`](../clients/imodels-client-management/src/operations/imodel/IModelOperations.ts#L62)
+  - [`delete(params: DeleteIModelParams): Promise<void>`](../clients/imodels-client-management/src/operations/imodel/IModelOperations.ts#L78)
 - [`IModelsClient.briefcases`](../clients/imodels-client-management/src/IModelsClient.ts#L49)
   - [`getMinimalList(params: GetBriefcaseListParams): EntityListIterator<MinimalBriefcase> `](../clients/imodels-client-management/src/operations/briefcase/BriefcaseOperations.ts#L19)
   - [`getRepresentationList(params: GetBriefcaseListParams): EntityListIterator<Briefcase>`](../clients/imodels-client-management/src/operations/briefcase/BriefcaseOperations.ts#L36)
@@ -43,7 +43,7 @@
 
 ### Authorization
 
-`IModelsClient` expects the authorization info to be passed in a form of an asynchronous callback that returns authorization info. It is a common use case to consume `IModelsClient` in iTwin.js platform based applications which use `IModelApp.getAccessToken` or `IModelHost.getAccessToken` to get the authorization header value returned as a string. The authorization header value specifies the schema and access token e.g. `Bearer ey...`. To convert this value into the format that `IModelsClients` expect users can use `AccessTokenAdapter` class which is exported by both [`@itwin/imodels-access-frontend`](../../itwin-platform-access/imodels-access-frontend/src/interface-adapters/AccessTokenAdapter.ts) and [`@itwin/imodels-access-backend`](../../itwin-platform-access/imodels-access-backend/src/interface-adapters/AccessTokenAdapter.ts) packages.
+`IModelsClient` expects the authorization info to be passed in a form of an asynchronous callback that returns authorization info. It is a common use case to consume `IModelsClient` in iTwin.js platform based applications which use `IModelApp.getAccessToken` or `IModelHost.getAccessToken` to get the authorization header value returned as a string. The authorization header value specifies the schema and access token e.g. `Bearer ey...`. To convert this value into the format that `IModelsClients` expect users can use `AccessTokenAdapter` class which is exported by both [`@itwin/imodels-access-frontend`](../itwin-platform-access/imodels-access-frontend/src/interface-adapters/AccessTokenAdapter.ts) and [`@itwin/imodels-access-backend`](../itwin-platform-access/imodels-access-backend/src/interface-adapters/AccessTokenAdapter.ts) packages.
 ```typescript
 const iModelIterator: EntityListIterator<MinimalIModel> = iModelsClient.iModels.getMinimalList({
   authorization: AccessTokenAdapter.toAuthorizationCallback(await IModelApp.getAccessToken()),

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# iModels API clients
+
+<span style="color:red">TODO: what is this</span>. Please visit the [iModels API documentation page](https://developer.bentley.com/apis/imodels/) on iTwin developer portal to learn more about the iModels service and its APIs. API clients contain methods that either act as a thin wrapper for sending a single request to the API or combine several requests to execute a more complex operation.
+
+iModels API is a part of [iTwin Platform](https://developer.bentley.com/). iTwin platform together with an open source [iTwin.js](https://www.itwinjs.org/) library provides capabilities for creating, querying, modifying, and displaying Infrastructure Digital Twins.
+
+Clients:
+- [`@itwin/imodels-client-management`](./IModelsClientManagement.md)
+- [`@itwin/imodels-client-authoring`](./IModelsClientAuthoring.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,9 @@
 # iModels API clients
 
-<span style="color:red">TODO: what is this</span>. Please visit the [iModels API documentation page](https://developer.bentley.com/apis/imodels/) on iTwin developer portal to learn more about the iModels service and its APIs. API clients contain methods that either act as a thin wrapper for sending a single request to the API or combine several requests to execute a more complex operation.
+This is documentation for iModels API clients in `@itwin/imodels-client-management` and `@itwin/imodels-client-authoring` packages. Please visit the [iModels API documentation page](https://developer.bentley.com/apis/imodels/) on iTwin developer portal to learn more about the iModels service and its APIs. API clients contain methods that either act as a thin wrapper for sending a single request to the API or combine several requests to execute a more complex operation.
 
 iModels API is a part of [iTwin Platform](https://developer.bentley.com/). iTwin platform together with an open source [iTwin.js](https://www.itwinjs.org/) library provides capabilities for creating, querying, modifying, and displaying Infrastructure Digital Twins.
 
-Clients:
-- [`@itwin/imodels-client-management`](./IModelsClientManagement.md)
-- [`@itwin/imodels-client-authoring`](./IModelsClientAuthoring.md)
+Users can choose to use either one of the following packages that contain `IModelsClient`:
+- `@itwin/imodels-client-management` ([documentation](./IModelsClientManagement.md)) - client from this package exposes a subset of iModels API operations and is intended to use in iModel management applications. Such applications do not edit the iModel file itself, they allow user to perform administrative tasks - create Named Versions, view Changeset metadata and such. An example of iTwin management application is the [iTwin Demo Portal](https://itwindemo.bentley.com/).
+- `@itwin/imodels-client-authoring` ([documentation](./IModelsClientAuthoring.md)) - client from this package extends the one from `@itwin/imodels-client-management` and exposes additional API operations to facilitate iModel editing workflows. Usually it is not recommended to use the client from this package directly as the additional operations it exposes can only be used meaningfully via [iTwin.js](https://www.itwinjs.org/) library.


### PR DESCRIPTION
In this PR:
- Added some basic documentation to be referenced by other portal that explains the structure and usage of `@itwin/imodels-client-management` and `@itwin/imodels-client-authoring` packages. The documentation contains:
  - A list of key types
  - A list of key methods
  - A few usage examples 