### PR TITLE
Enabled `@typescript-eslint/no-floating-promises` ESLint rule

### DIFF
--- a/utils/imodels-client-common-config/.eslintrc.json
+++ b/utils/imodels-client-common-config/.eslintrc.json
@@ -97,6 +97,9 @@
       "never"
     ],
     "@typescript-eslint/no-non-null-assertion": "off",
+    "@typescript-eslint/no-floating-promises": [
+      "error"
+    ],
     "@typescript-eslint/naming-convention": [
       "error",
       {


### PR DESCRIPTION
In this PR:
- Enabled `@typescript-eslint/no-floating-promises` ESLint rule
