### PR TITLE
Removing unused interface

### DIFF
--- a/clients/imodels-client-authoring/src/base/internal/ApiResponseInterfaces.ts
+++ b/clients/imodels-client-authoring/src/base/internal/ApiResponseInterfaces.ts
@@ -4,17 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 import { BaselineFile, Lock } from "../public";
 
-/** DTO to hold Lock list API response. */
 export interface LocksResponse {
   locks: Lock[];
 }
 
-/** DTO to hold a single Lock API response. */
 export interface LockResponse {
   lock: Lock;
 }
 
-/** DTO to hold a single Baseline file API response. */
 export interface BaselineFileResponse {
   baselineFile: BaselineFile;
 }

--- a/clients/imodels-client-authoring/src/operations/lock/LockOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/lock/LockOperations.ts
@@ -6,7 +6,7 @@ import { EntityListIteratorImpl, OperationsBase } from "@itwin/imodels-client-ma
 
 import { EntityListIterator } from "@itwin/imodels-client-management";
 
-import {LockResponse, LocksResponse} from "../../base/internal";
+import { LockResponse, LocksResponse } from "../../base/internal";
 import { Lock } from "../../base/public";
 import { OperationOptions } from "../OperationOptions";
 

--- a/clients/imodels-client-management/src/base/internal/ApiResponseInterfaces.ts
+++ b/clients/imodels-client-management/src/base/internal/ApiResponseInterfaces.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { Briefcase, Changeset, Checkpoint, IModel, IModelLinks, Link, MinimalBriefcase, MinimalChangeset, MinimalIModel, MinimalNamedVersion, MinimalUser, NamedVersion, User } from "../public";
+import { Briefcase, Changeset, Checkpoint, IModel, Link, MinimalBriefcase, MinimalChangeset, MinimalIModel, MinimalNamedVersion, MinimalUser, NamedVersion, User } from "../public";
 
 /**
  * Links that are included in all entity list page responses. They simplify pagination implementation because users
@@ -48,22 +48,6 @@ export interface BriefcaseResponse {
 
 export interface ChangesetResponse {
   changeset: Changeset;
-}
-
-/**
- * Links that belong to iModel entity returned from iModels API.
- * @deprecated
- */
-// eslint-disable-next-line deprecation/deprecation
-export type iModelLinks = IModelLinks;
-
-/**
- * DTO to hold a single iModel API response returned by iModel creation operation.
- * @deprecated
- */
-export interface IModelCreateResponse {
-  // eslint-disable-next-line deprecation/deprecation
-  iModel: IModel & { _links: iModelLinks };
 }
 
 export interface CheckpointResponse {


### PR DESCRIPTION
In this PR:
- Removed unused interface `IModelCreateResponse`
- Minor formatting fixes