### PR TITLE
2.0.0 version bump

### DIFF
--- a/clients/imodels-client-authoring/.npmignore
+++ b/clients/imodels-client-authoring/.npmignore
@@ -1,5 +1,6 @@
 # start off ignoring everything, and then add back only the files we want
 *
+!*.md
 !lib/**/*.d.ts
 !lib/**/*.js
 !lib/**/*.js.map

--- a/clients/imodels-client-authoring/CHANGELOG.md
+++ b/clients/imodels-client-authoring/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Change Log - @itwin/imodels-client-authoring 
+
+## 2.0.0
+
+Breaking changes:
+- Removed `FileHandler` interface and default `AzureFileHandler` implementation. Storage operations now use `@itwin/object-storage-core` and `@itwin/object-storage-azure` packages.
+- Removed internal code exports from the main `index.ts` file that should not be used directly by package users. The following components are no longer part of the public package API:
+  - Operation classes (`IModelOperations`, `ChangesetOperations`, etc.)
+  - Utility types (raw API response interfaces, etc.)
+  - Default IModelsClient option implementations (`AxiosRestClient`)
+  - Default iModels API parser class
+- Changed `_links` property type in entity interfaces from `Link` to `Link | null` as per iModels API definition.
+
+Please see the package documentation for an updated list of supported operations and entities: [link to docs](https://github.com/iTwin/imodels-clients/blob/main/docs/IModelsClientAuthoring.md).

--- a/clients/imodels-client-authoring/package.json
+++ b/clients/imodels-client-authoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-client-authoring",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "iModels API client wrapper for applications that author iModels.",
   "keywords": [
     "Bentley",

--- a/clients/imodels-client-management/.npmignore
+++ b/clients/imodels-client-management/.npmignore
@@ -1,5 +1,6 @@
 # start off ignoring everything, and then add back only the files we want
 *
+!*.md
 !lib/**/*.d.ts
 !lib/**/*.js
 !lib/**/*.js.map

--- a/clients/imodels-client-management/CHANGELOG.md
+++ b/clients/imodels-client-management/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Change Log - @itwin/imodels-client-management 
+
+## 2.0.0
+
+Breaking changes:
+- Removed internal code exports from the main `index.ts` file that should not be used directly by package users. The following components are no longer part of the public package API:
+  - Operation classes (`IModelOperations`, `ChangesetOperations`, etc.)
+  - Utility types (raw API response interfaces, etc.)
+  - Default IModelsClient option implementations (`AxiosRestClient`)
+  - Default iModels API parser class
+- Changed `_links` property type in entity interfaces from `Link` to `Link | null` as per iModels API definition.
+
+Please see the package documentation for an updated list of supported operations and entities: [link to docs](https://github.com/iTwin/imodels-clients/blob/main/docs/IModelsClientManagement.md).

--- a/clients/imodels-client-management/package.json
+++ b/clients/imodels-client-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-client-management",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "iModels API client wrapper for applications that manage iModels.",
   "keywords": [
     "Bentley",

--- a/itwin-platform-access/imodels-access-backend/.npmignore
+++ b/itwin-platform-access/imodels-access-backend/.npmignore
@@ -1,5 +1,6 @@
 # start off ignoring everything, and then add back only the files we want
 *
+!*.md
 !lib/**/*.d.ts
 !lib/**/*.js
 !lib/**/*.js.map

--- a/itwin-platform-access/imodels-access-backend/CHANGELOG.md
+++ b/itwin-platform-access/imodels-access-backend/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log - @itwin/imodels-access-backend
+
+## 2.0.0
+
+Changes:
+- Updated `BackendIModelsAccess` class implementation according to breaking changes in `@itwin/imodels-client-authoring`.
+
+This release contains no breaking changes compared to the previous package version.

--- a/itwin-platform-access/imodels-access-backend/package.json
+++ b/itwin-platform-access/imodels-access-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-access-backend",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Interoperability package between iModels API and iTwin.js library for backend.",
   "keywords": [
     "Bentley",

--- a/itwin-platform-access/imodels-access-frontend/.npmignore
+++ b/itwin-platform-access/imodels-access-frontend/.npmignore
@@ -1,5 +1,6 @@
 # start off ignoring everything, and then add back only the files we want
 *
+!*.md
 !lib/**/*.d.ts
 !lib/**/*.js
 !lib/**/*.js.map

--- a/itwin-platform-access/imodels-access-frontend/CHANGELOG.md
+++ b/itwin-platform-access/imodels-access-frontend/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Change Log - @itwin/imodels-access-frontend
+
+## 2.0.0
+
+This release contains no changes compared to the previous package version.

--- a/itwin-platform-access/imodels-access-frontend/package.json
+++ b/itwin-platform-access/imodels-access-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-access-frontend",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Interoperability package between iModels API and iTwin.js library for frontend.",
   "keywords": [
     "Bentley",

--- a/tests/imodels-access-backend-tests/package.json
+++ b/tests/imodels-access-backend-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-access-backend-tests",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Tests for iTwin platform and iModels API interoperability package - @itwin/imodels-access-backend.",
   "keywords": [
     "Bentley",

--- a/tests/imodels-access-frontend-tests/package.json
+++ b/tests/imodels-access-frontend-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-access-frontend-tests",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Tests for iTwin platform and iModels API interoperability package - @itwin/imodels-access-frontend.",
   "keywords": [
     "Bentley",

--- a/tests/imodels-clients-tests-browser/package.json
+++ b/tests/imodels-clients-tests-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-clients-tests-browser",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Tests for iModels API client wrappers",
   "keywords": [
     "Bentley",

--- a/tests/imodels-clients-tests/package.json
+++ b/tests/imodels-clients-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-clients-tests",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Tests for iModels API client wrappers",
   "keywords": [
     "Bentley",

--- a/utils/imodels-client-common-config/package.json
+++ b/utils/imodels-client-common-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-client-common-config",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Common configuration for iModels API client wrappers.",
   "keywords": [
     "Bentley",

--- a/utils/imodels-client-test-utils/package.json
+++ b/utils/imodels-client-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-client-test-utils",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Common utilities for iModels API client wrappers tests.",
   "keywords": [
     "Bentley",


### PR DESCRIPTION
In this PR:
- Bumped all package versions to 2.0.0
- Added minimal CHANGELOG.md files
- Fixed `.npmignore` files to not ignore license and documentation (*.md) files 