### PR TITLE
Fixing error parsing in case of Lock update conflict

### DIFF
--- a/clients/imodels-client-authoring/src/IModelsClient.ts
+++ b/clients/imodels-client-authoring/src/IModelsClient.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import { AxiosRestClient } from "@itwin/imodels-client-management/lib/base/internal";
 import { AzureClientStorage, BlockBlobClientWrapperFactory } from "@itwin/object-storage-azure";
 import { ClientStorage } from "@itwin/object-storage-core";
 
@@ -12,10 +13,9 @@ import {
 } from "@itwin/imodels-client-management";
 
 import { NodeLocalFileSystem } from "./base/internal";
+import { IModelsErrorParser } from "./base/internal/IModelsErrorParser";
 import { LocalFileSystem } from "./base/public";
 import { BaselineFileOperations, BriefcaseOperations, ChangesetOperations, IModelOperations, IModelsApiUrlFormatter, LockOperations, OperationOptions } from "./operations";
-import { AxiosRestClient } from "@itwin/imodels-client-management/lib/base/internal";
-import { IModelsErrorParser } from "./base/internal/IModelsErrorParser";
 
 /** User-configurable iModels client options. */
 export interface IModelsClientOptions extends ManagementIModelsClientOptions {

--- a/clients/imodels-client-authoring/src/base/internal/IModelsErrorParser.ts
+++ b/clients/imodels-client-authoring/src/base/internal/IModelsErrorParser.ts
@@ -1,0 +1,109 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { IModelsErrorCode } from "@itwin/imodels-client-management";
+import { IModelsErrorParser as ManagementIModelsErrorParser, IModelsErrorImpl, IModelsErrorBaseImpl, IModelsApiError } from "@itwin/imodels-client-management/lib/base/internal";
+import { ConflictingLock, ConflictingLocksError, LocksError } from "../public/apiEntities/LockErrorInterfaces";
+
+interface AuthoringIModelsApiErrorWrapper {
+  error: AuthoringIModelsApiError;
+}
+
+interface AuthoringIModelsApiError extends IModelsApiError {
+  objectIds?: string[];
+  conflictingLocks?: ConflictingLock[];
+}
+
+class LocksErrorImpl extends IModelsErrorBaseImpl implements LocksError {
+  public objectIds?: string[];
+
+  constructor(params: {
+    code: IModelsErrorCode,
+    message: string,
+    objectIds?: string[]
+  }) {
+    super(params);
+    this.objectIds = params.objectIds;
+  }
+}
+class ConflictingLocksErrorImpl extends IModelsErrorBaseImpl implements ConflictingLocksError {
+  public conflictingLocks?: ConflictingLock[];
+
+  constructor(params: {
+    code: IModelsErrorCode,
+    message: string,
+    conflictingLocks?: ConflictingLock[]
+  }) {
+    super(params);
+    this.conflictingLocks = params.conflictingLocks;
+  }
+}
+
+export class IModelsErrorParser extends ManagementIModelsErrorParser {
+
+  public static override parse(response: { body?: unknown }): Error {
+    if (!response.body)
+      return new IModelsErrorImpl(ManagementIModelsErrorParser._unknownErrorProperties);
+
+    const errorFromApi: AuthoringIModelsApiErrorWrapper | undefined =
+      response.body as AuthoringIModelsApiErrorWrapper;
+    const errorCode: IModelsErrorCode = IModelsErrorParser.parseCode(errorFromApi?.error?.code);
+
+    if (errorCode === IModelsErrorCode.NewerChangesExist) {
+      const errorMessage = IModelsErrorParser.parseAndFormatLockErrorMessage(
+        errorFromApi?.error?.message,
+        errorFromApi?.error?.objectIds
+      );
+      return new LocksErrorImpl({
+        code: errorCode,
+        message: errorMessage,
+        objectIds: errorFromApi?.error?.objectIds
+      });
+    }
+
+    if (errorCode === IModelsErrorCode.ConflictWithAnotherUser) {
+      const errorMessage = IModelsErrorParser.parseAndFormatLockConflictErrorMessage(
+        errorFromApi?.error?.message,
+        errorFromApi?.error?.conflictingLocks
+      );
+      return new ConflictingLocksErrorImpl({
+        code: errorCode,
+        message: errorMessage,
+        conflictingLocks: errorFromApi?.error?.conflictingLocks
+      });
+    }
+
+    return ManagementIModelsErrorParser.parse(response);
+  }
+
+  private static parseAndFormatLockErrorMessage(
+    message: string | undefined,
+    objectIds: string[] | undefined
+  ): string {
+    let result = message ?? ManagementIModelsErrorParser._defaultErrorMessage;
+    if (!objectIds || objectIds.length === 0)
+      return result;
+
+    result += ` Object ids: ${objectIds.join(" ,")}`;
+    return result;
+  }
+
+  private static parseAndFormatLockConflictErrorMessage(
+    message: string | undefined,
+    conflictingLocks: ConflictingLock[] | undefined
+  ) {
+    let result = message ?? ManagementIModelsErrorParser._defaultErrorMessage;
+    if (!conflictingLocks || conflictingLocks.length === 0)
+      return result;
+
+    result += " Conflicting locks:\n";
+    for (let i = 0; i < conflictingLocks.length; i++) {
+      result += `${i + 1}. Object id: ${conflictingLocks[i].objectId
+        }, lock level: ${conflictingLocks[i].lockLevel
+        }, briefcase ids: ${conflictingLocks[i].briefcaseIds.join(", ")
+        }\n`;
+    }
+    return result;
+  }
+}

--- a/clients/imodels-client-authoring/src/base/internal/IModelsErrorParser.ts
+++ b/clients/imodels-client-authoring/src/base/internal/IModelsErrorParser.ts
@@ -44,7 +44,6 @@ class ConflictingLocksErrorImpl extends IModelsErrorBaseImpl implements Conflict
 }
 
 export class IModelsErrorParser extends ManagementIModelsErrorParser {
-
   public static override parse(response: { body?: unknown }): Error {
     if (!response.body)
       return new IModelsErrorImpl(ManagementIModelsErrorParser._unknownErrorProperties);

--- a/clients/imodels-client-authoring/src/base/internal/IModelsErrorParser.ts
+++ b/clients/imodels-client-authoring/src/base/internal/IModelsErrorParser.ts
@@ -29,6 +29,7 @@ class LocksErrorImpl extends IModelsErrorBaseImpl implements LocksError {
     this.objectIds = params.objectIds;
   }
 }
+
 class ConflictingLocksErrorImpl extends IModelsErrorBaseImpl implements ConflictingLocksError {
   public conflictingLocks?: ConflictingLock[];
 

--- a/clients/imodels-client-authoring/src/base/internal/IModelsErrorParser.ts
+++ b/clients/imodels-client-authoring/src/base/internal/IModelsErrorParser.ts
@@ -2,8 +2,10 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import { IModelsApiError, IModelsErrorBaseImpl, IModelsErrorImpl, IModelsErrorParser as ManagementIModelsErrorParser } from "@itwin/imodels-client-management/lib/base/internal";
+
 import { IModelsErrorCode } from "@itwin/imodels-client-management";
-import { IModelsErrorParser as ManagementIModelsErrorParser, IModelsErrorImpl, IModelsErrorBaseImpl, IModelsApiError } from "@itwin/imodels-client-management/lib/base/internal";
+
 import { ConflictingLock, ConflictingLocksError, LocksError } from "../public/apiEntities/LockErrorInterfaces";
 
 interface AuthoringIModelsApiErrorWrapper {
@@ -19,9 +21,9 @@ class LocksErrorImpl extends IModelsErrorBaseImpl implements LocksError {
   public objectIds?: string[];
 
   constructor(params: {
-    code: IModelsErrorCode,
-    message: string,
-    objectIds?: string[]
+    code: IModelsErrorCode;
+    message: string;
+    objectIds?: string[];
   }) {
     super(params);
     this.objectIds = params.objectIds;
@@ -31,9 +33,9 @@ class ConflictingLocksErrorImpl extends IModelsErrorBaseImpl implements Conflict
   public conflictingLocks?: ConflictingLock[];
 
   constructor(params: {
-    code: IModelsErrorCode,
-    message: string,
-    conflictingLocks?: ConflictingLock[]
+    code: IModelsErrorCode;
+    message: string;
+    conflictingLocks?: ConflictingLock[];
   }) {
     super(params);
     this.conflictingLocks = params.conflictingLocks;
@@ -100,9 +102,9 @@ export class IModelsErrorParser extends ManagementIModelsErrorParser {
     result += " Conflicting locks:\n";
     for (let i = 0; i < conflictingLocks.length; i++) {
       result += `${i + 1}. Object id: ${conflictingLocks[i].objectId
-        }, lock level: ${conflictingLocks[i].lockLevel
-        }, briefcase ids: ${conflictingLocks[i].briefcaseIds.join(", ")
-        }\n`;
+      }, lock level: ${conflictingLocks[i].lockLevel
+      }, briefcase ids: ${conflictingLocks[i].briefcaseIds.join(", ")
+      }\n`;
     }
     return result;
   }

--- a/clients/imodels-client-authoring/src/base/public/apiEntities/LockErrorInterfaces.ts
+++ b/clients/imodels-client-authoring/src/base/public/apiEntities/LockErrorInterfaces.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { IModelsErrorBase } from "@itwin/imodels-client-management";
+import { LockLevel } from "./LockInterfaces";
+
+/** Error thrown by Lock update operation. */
+export interface LocksError extends IModelsErrorBase {
+  /** Object ids that are causing the Lock update error. */
+  objectIds?: string[];
+}
+
+/**
+ * Error thrown by Lock update operation in case Locks cannot be updated because of conflicts with other Briefcases.
+ */
+export interface ConflictingLocksError extends IModelsErrorBase {
+  /** List of locks that are causing the conflicts. */
+  conflictingLocks?: ConflictingLock[];
+}
+
+/** Detailed information about a particular object Lock that is causing the Lock update conflict. */
+export interface ConflictingLock {
+  /** Id of the object that is causing conflict. */
+  objectId: string;
+  /**
+   * The level of conflicting lock. Possible values are {@link LockLevel.Shared}, {@link LockLevel.Exclusive}.
+   * See {@link LockLevel}.
+   */
+  lockLevel: LockLevel;
+  /** An array of Briefcase ids that hold this lock. */
+  briefcaseIds: number[];
+}

--- a/clients/imodels-client-authoring/src/base/public/apiEntities/LockErrorInterfaces.ts
+++ b/clients/imodels-client-authoring/src/base/public/apiEntities/LockErrorInterfaces.ts
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { IModelsErrorBase } from "@itwin/imodels-client-management";
+
 import { LockLevel } from "./LockInterfaces";
 
 /** Error thrown by Lock update operation. */

--- a/clients/imodels-client-authoring/src/base/public/index.ts
+++ b/clients/imodels-client-authoring/src/base/public/index.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 export * from "./apiEntities/BaselineFileInterfaces";
 export * from "./apiEntities/ChangesetInterfaces";
+export * from "./apiEntities/LockErrorInterfaces";
 export * from "./apiEntities/LockInterfaces";
 export * from "./CommonInterfaces";
 export * from "./LocalFileSystem";

--- a/clients/imodels-client-management/src/base/internal/AxiosRestClient.ts
+++ b/clients/imodels-client-management/src/base/internal/AxiosRestClient.ts
@@ -4,15 +4,19 @@
  *--------------------------------------------------------------------------------------------*/
 import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
 
-import { ContentType, HttpGetRequestParams, HttpRequestParams, HttpRequestWithBinaryBodyParams, HttpRequestWithJsonBodyParams, ParseErrorFunc, RestClient } from "../public/RestClient";
+import { ContentType, HttpGetRequestParams, HttpRequestParams, HttpRequestWithBinaryBodyParams, HttpRequestWithJsonBodyParams, RestClient } from "../public/RestClient";
 
-import { IModelsErrorParser } from "./IModelsErrorParser";
+/**
+ * Function that is called if the HTTP request fails and which returns an error that will be thrown by one of the
+ * methods in {@link RestClient}.
+ */
+export type ParseErrorFunc = (response: { body?: unknown }) => Error;
 
 /** Default implementation for {@link RestClient} interface that uses `axios` library for sending the requests. */
 export class AxiosRestClient implements RestClient {
   private _parseErrorFunc: ParseErrorFunc;
 
-  constructor(parseErrorFunc: ParseErrorFunc = IModelsErrorParser.parse) {
+  constructor(parseErrorFunc: ParseErrorFunc) {
     this._parseErrorFunc = parseErrorFunc;
   }
 
@@ -71,7 +75,7 @@ export class AxiosRestClient implements RestClient {
       return response.data;
     } catch (error: unknown) {
       if (axios.isAxiosError(error)) {
-        const parsedError: Error = this._parseErrorFunc({ statusCode: error.response?.status, body: error.response?.data });
+        const parsedError: Error = this._parseErrorFunc({ body: error.response?.data });
         throw parsedError;
       }
       throw new Error("AxiosRestClient: unknown error occurred.");

--- a/clients/imodels-client-management/src/base/public/IModelsErrorInterfaces.ts
+++ b/clients/imodels-client-management/src/base/public/IModelsErrorInterfaces.ts
@@ -32,7 +32,7 @@ export enum IModelsErrorCode {
   NamedVersionOnChangesetExists = "NamedVersionOnChangesetExists",
   ProjectNotFound = "ProjectNotFound",
   IModelNotFound = "iModelNotFound",
-  NamedVersionNotFound  = "NamedVersionNotFound",
+  NamedVersionNotFound = "NamedVersionNotFound",
   ChangesetNotFound = "ChangesetNotFound",
   UserNotFound = "UserNotFound",
   BriefcaseNotFound = "BriefcaseNotFound",
@@ -59,10 +59,18 @@ export interface IModelsErrorDetail {
   target?: string;
 }
 
-/** Interface for the errors thrown by this library. */
-export interface IModelsError extends Error {
+/** Base interface for all errors returned from iModels API. */
+export interface IModelsErrorBase extends Error {
   /** Error code. See {@link iModelsErrorCode}. */
   code: IModelsErrorCode;
+}
+
+/**
+ * Most common error returned in the majority of error cases by iModels API and the only error returned from iModels
+ * API operations that are surfaced in this library. Other types of errors may be returned from libraries that extend
+ * this one.
+ */
+export interface IModelsError extends IModelsErrorBase {
   /** Data that describes the error in more detail. See {@link iModelsErrorDetail}. */
   details?: IModelsErrorDetail[];
 }

--- a/clients/imodels-client-management/src/base/public/RestClient.ts
+++ b/clients/imodels-client-management/src/base/public/RestClient.ts
@@ -5,12 +5,6 @@
 import { Dictionary } from "./UtilityTypes";
 
 /**
- * Function that is called if the HTTP request fails and which returns an error that will be thrown by one of the
- * methods in {@link RestClient}.
- */
-export type ParseErrorFunc = (response: { statusCode?: number, body?: unknown }) => Error;
-
-/**
  * Content-Type header values that are used with for iModels API.
  */
 export enum ContentType {

--- a/tests/imodels-clients-tests/src/integration/authoring/LockOperations.test.ts
+++ b/tests/imodels-clients-tests/src/integration/authoring/LockOperations.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
 
-import { AuthorizationCallback, GetLockListParams, IModelsClient, IModelsClientOptions, IModelsErrorCode, LockLevel, UpdateLockParams, toArray, ConflictingLocksError, ConflictingLock, LocksError } from "@itwin/imodels-client-authoring";
+import { AuthorizationCallback, ConflictingLock, ConflictingLocksError, GetLockListParams, IModelsClient, IModelsClientOptions, IModelsErrorCode, LockLevel, LocksError, UpdateLockParams, toArray } from "@itwin/imodels-client-authoring";
 import { IModelMetadata, ReusableIModelMetadata, ReusableTestIModelProvider, TestAuthorizationProvider, TestIModelCreator, TestIModelFileProvider, TestIModelGroup, TestIModelGroupFactory, TestUtilTypes, assertCollection, assertError, assertLock } from "@itwin/imodels-client-test-utils";
 
 import { Constants, getTestDIContainer, getTestRunId } from "../common";

--- a/tests/imodels-clients-tests/src/integration/management/IModelOperations.test.ts
+++ b/tests/imodels-clients-tests/src/integration/management/IModelOperations.test.ts
@@ -384,7 +384,7 @@ describe("[Management] IModelOperations", () => {
       objectThrown,
       expectedError: {
         code: IModelsErrorCode.Unauthorized,
-        message: "The user is unauthorized. Please provide valid authentication credentials."
+        message: "IDX12741: JWT: 'invalid token' must have three segments (JWS) or five segments (JWE)."
       }
     });
   });

--- a/tests/imodels-clients-tests/src/unit/management/IModelsErrorParser.test.ts
+++ b/tests/imodels-clients-tests/src/unit/management/IModelsErrorParser.test.ts
@@ -34,7 +34,7 @@ describe("IModelsErrorParser", () => {
     };
 
     // Act
-    const parsedError: IModelsError = IModelsErrorParser.parse({ statusCode: 400, body: errorResponse }) as IModelsError;
+    const parsedError: IModelsError = IModelsErrorParser.parse({ body: errorResponse }) as IModelsError;
 
     // Assert
     const expectedErrorMessage = "Cannot create iModel. Details:\n" +


### PR DESCRIPTION
In this PR:
- Added two different error types - `LocksError` and `ConflictingLocksError` to represent errors thrown by lock update operation in case of a conflict ([link to API](https://developer.bentley.com/apis/imodels/operations/update-imodel-locks/#response-409-conflict))
- Added `IModelsErrorParser` in `@itwin/imodels-client-authoring` package to handle those specific scenarios and construct a class instance with appropriate properties.
- Removed `ParseErrorFunc` from exported interfaces and removed `statusCode` property from error parsing (since now the API returns correctly formed unauthorized error)
- Added more assertions to existing tests to verify error properties.