### PR TITLE
Adopting iTwin.js 3.3.0

### DIFF
--- a/clients/imodels-client-authoring/CHANGELOG.md
+++ b/clients/imodels-client-authoring/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2.0.0
 
+Non-breaking changes:
+ - Surfaced more iModels API operations. Please see the package documentation for an updated list of supported operations and entities: [link to docs](https://github.com/iTwin/imodels-clients/blob/main/docs/IModelsClientAuthoring.md).
+
 Breaking changes:
 - Removed `FileHandler` interface and default `AzureFileHandler` implementation. Storage operations now use [`@itwin/object-storage-core`](https://www.npmjs.com/package/@itwin/object-storage-core) and [`@itwin/object-storage-azure`](https://www.npmjs.com/package/@itwin/object-storage-azure) packages.
 - Removed internal code exports from the main `index.ts` file that should not be used directly by package users. The following components are no longer part of the public package API:
@@ -10,5 +13,3 @@ Breaking changes:
   - Default IModelsClient option implementations (`AxiosRestClient`)
   - Default iModels API parser class
 - Changed `_links` property type in entity interfaces from `Link` to `Link | null` as per iModels API definition.
-
-Please see the package documentation for an updated list of supported operations and entities: [link to docs](https://github.com/iTwin/imodels-clients/blob/main/docs/IModelsClientAuthoring.md).

--- a/clients/imodels-client-authoring/CHANGELOG.md
+++ b/clients/imodels-client-authoring/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## 2.0.0
 
-Non-breaking changes:
- - Surfaced more iModels API operations. Please see the package documentation for an updated list of supported operations and entities: [link to docs](https://github.com/iTwin/imodels-clients/blob/main/docs/IModelsClientAuthoring.md).
-
 Breaking changes:
 - Removed `FileHandler` interface and default `AzureFileHandler` implementation. Storage operations now use [`@itwin/object-storage-core`](https://www.npmjs.com/package/@itwin/object-storage-core) and [`@itwin/object-storage-azure`](https://www.npmjs.com/package/@itwin/object-storage-azure) packages.
 - Removed internal code exports from the main `index.ts` file that should not be used directly by package users. The following components are no longer part of the public package API:
@@ -13,3 +10,6 @@ Breaking changes:
   - Default IModelsClient option implementations (`AxiosRestClient`)
   - Default iModels API parser class
 - Changed `_links` property type in entity interfaces from `Link` to `Link | null` as per iModels API definition.
+
+Non-breaking changes:
+ - Surfaced more iModels API operations. Please see the package documentation for an updated list of supported operations and entities: [link to docs](https://github.com/iTwin/imodels-clients/blob/main/docs/IModelsClientAuthoring.md).

--- a/clients/imodels-client-management/CHANGELOG.md
+++ b/clients/imodels-client-management/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2.0.0
 
+Non-breaking changes:
+ - Surfaced more iModels API operations. Please see the package documentation for an updated list of supported operations and entities: [link to docs](https://github.com/iTwin/imodels-clients/blob/main/docs/IModelsClientManagement.md).
+
 Breaking changes:
 - Removed internal code exports from the main `index.ts` file that should not be used directly by package users. The following components are no longer part of the public package API:
   - Operation classes (`IModelOperations`, `ChangesetOperations`, etc.)
@@ -9,5 +12,3 @@ Breaking changes:
   - Default IModelsClient option implementations (`AxiosRestClient`)
   - Default iModels API parser class
 - Changed `_links` property type in entity interfaces from `Link` to `Link | null` as per iModels API definition.
-
-Please see the package documentation for an updated list of supported operations and entities: [link to docs](https://github.com/iTwin/imodels-clients/blob/main/docs/IModelsClientManagement.md).

--- a/clients/imodels-client-management/CHANGELOG.md
+++ b/clients/imodels-client-management/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## 2.0.0
 
-Non-breaking changes:
- - Surfaced more iModels API operations. Please see the package documentation for an updated list of supported operations and entities: [link to docs](https://github.com/iTwin/imodels-clients/blob/main/docs/IModelsClientManagement.md).
-
 Breaking changes:
 - Removed internal code exports from the main `index.ts` file that should not be used directly by package users. The following components are no longer part of the public package API:
   - Operation classes (`IModelOperations`, `ChangesetOperations`, etc.)
@@ -12,3 +9,6 @@ Breaking changes:
   - Default IModelsClient option implementations (`AxiosRestClient`)
   - Default iModels API parser class
 - Changed `_links` property type in entity interfaces from `Link` to `Link | null` as per iModels API definition.
+
+Non-breaking changes:
+ - Surfaced more iModels API operations. Please see the package documentation for an updated list of supported operations and entities: [link to docs](https://github.com/iTwin/imodels-clients/blob/main/docs/IModelsClientManagement.md).

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -53,11 +53,11 @@ importers:
 
   ../../itwin-platform-access/imodels-access-backend:
     specifiers:
-      '@itwin/core-backend': ^3.0.0
-      '@itwin/core-bentley': ^3.0.0
-      '@itwin/core-common': ^3.0.0
-      '@itwin/core-geometry': ^3.0.0
-      '@itwin/ecschema-metadata': ^3.0.0
+      '@itwin/core-backend': ^3.3.0
+      '@itwin/core-bentley': ^3.3.0
+      '@itwin/core-common': ^3.3.0
+      '@itwin/core-geometry': ^3.3.0
+      '@itwin/ecschema-metadata': ^3.3.0
       '@itwin/imodels-client-authoring': workspace:*
       '@itwin/imodels-client-common-config': workspace:*
       '@types/node': 14.14.31
@@ -72,11 +72,11 @@ importers:
       '@itwin/imodels-client-authoring': link:../../clients/imodels-client-authoring
       axios: 0.21.4
     devDependencies:
-      '@itwin/core-backend': 3.2.0_6d8ed02b6d58c40967ff078d2d51dd5f
-      '@itwin/core-bentley': 3.2.0
-      '@itwin/core-common': 3.2.0_7cd671bdbf1cf2d2e03262996efd1f64
-      '@itwin/core-geometry': 3.2.0
-      '@itwin/ecschema-metadata': 3.2.0_@itwin+core-bentley@3.2.0
+      '@itwin/core-backend': 3.3.0_6cb52bce383bc4481b1af007b1456cdc
+      '@itwin/core-bentley': 3.3.0
+      '@itwin/core-common': 3.3.0_e1c7120832f97c6cd8e6749fcb0b8f50
+      '@itwin/core-geometry': 3.3.0
+      '@itwin/ecschema-metadata': 3.3.0_@itwin+core-bentley@3.3.0
       '@itwin/imodels-client-common-config': link:../../utils/imodels-client-common-config
       '@types/node': 14.14.31
       '@types/ws': 7.4.7
@@ -88,16 +88,16 @@ importers:
 
   ../../itwin-platform-access/imodels-access-frontend:
     specifiers:
-      '@itwin/appui-abstract': ^3.0.0
-      '@itwin/core-bentley': ^3.0.0
-      '@itwin/core-common': ^3.0.0
-      '@itwin/core-frontend': ^3.0.0
-      '@itwin/core-geometry': ^3.0.0
-      '@itwin/core-orbitgt': ^3.0.0
-      '@itwin/core-quantity': ^3.0.0
+      '@itwin/appui-abstract': ^3.3.0
+      '@itwin/core-bentley': ^3.3.0
+      '@itwin/core-common': ^3.3.0
+      '@itwin/core-frontend': ^3.3.0
+      '@itwin/core-geometry': ^3.3.0
+      '@itwin/core-orbitgt': ^3.3.0
+      '@itwin/core-quantity': ^3.3.0
       '@itwin/imodels-client-common-config': workspace:*
       '@itwin/imodels-client-management': workspace:*
-      '@itwin/webgl-compatibility': ^3.0.0
+      '@itwin/webgl-compatibility': ^3.3.0
       '@types/node': 14.14.31
       cspell: ~5.21.0
       eslint: ~7.31.0
@@ -107,15 +107,15 @@ importers:
     dependencies:
       '@itwin/imodels-client-management': link:../../clients/imodels-client-management
     devDependencies:
-      '@itwin/appui-abstract': 3.2.0_@itwin+core-bentley@3.2.0
-      '@itwin/core-bentley': 3.2.0
-      '@itwin/core-common': 3.2.0_7cd671bdbf1cf2d2e03262996efd1f64
-      '@itwin/core-frontend': 3.2.0_d0ae248df510e2cd9b391084a77a8fb2
-      '@itwin/core-geometry': 3.2.0
-      '@itwin/core-orbitgt': 3.2.0
-      '@itwin/core-quantity': 3.2.0_@itwin+core-bentley@3.2.0
+      '@itwin/appui-abstract': 3.3.0_@itwin+core-bentley@3.3.0
+      '@itwin/core-bentley': 3.3.0
+      '@itwin/core-common': 3.3.0_e1c7120832f97c6cd8e6749fcb0b8f50
+      '@itwin/core-frontend': 3.3.0_65f6b066372fa5f23e11e9cbf1a40c5e
+      '@itwin/core-geometry': 3.3.0
+      '@itwin/core-orbitgt': 3.3.0
+      '@itwin/core-quantity': 3.3.0_@itwin+core-bentley@3.3.0
       '@itwin/imodels-client-common-config': link:../../utils/imodels-client-common-config
-      '@itwin/webgl-compatibility': 3.2.0
+      '@itwin/webgl-compatibility': 3.3.0
       '@types/node': 14.14.31
       cspell: 5.21.2
       eslint: 7.31.0
@@ -125,10 +125,10 @@ importers:
 
   ../../tests/imodels-access-backend-tests:
     specifiers:
-      '@itwin/core-backend': ^3.0.0
-      '@itwin/core-bentley': ^3.0.0
-      '@itwin/core-common': ^3.0.0
-      '@itwin/ecschema-metadata': ^3.0.0
+      '@itwin/core-backend': ^3.3.0
+      '@itwin/core-bentley': ^3.3.0
+      '@itwin/core-common': ^3.3.0
+      '@itwin/ecschema-metadata': ^3.3.0
       '@itwin/imodels-access-backend': workspace:*
       '@itwin/imodels-client-authoring': workspace:*
       '@itwin/imodels-client-common-config': workspace:*
@@ -147,10 +147,10 @@ importers:
       sort-package-json: ~1.53.1
       typescript: ~4.4.0
     dependencies:
-      '@itwin/core-backend': 3.2.0_e12312b15e5055e2f2a8dc698d76e0b1
-      '@itwin/core-bentley': 3.2.0
-      '@itwin/core-common': 3.2.0_@itwin+core-bentley@3.2.0
-      '@itwin/ecschema-metadata': 3.2.0_@itwin+core-bentley@3.2.0
+      '@itwin/core-backend': 3.3.0_9acad095885f5359c2cb2c767d03c7b5
+      '@itwin/core-bentley': 3.3.0
+      '@itwin/core-common': 3.3.0_@itwin+core-bentley@3.3.0
+      '@itwin/ecschema-metadata': 3.3.0_@itwin+core-bentley@3.3.0
       '@itwin/imodels-access-backend': link:../../itwin-platform-access/imodels-access-backend
       '@itwin/imodels-client-authoring': link:../../clients/imodels-client-authoring
       '@itwin/imodels-client-test-utils': link:../../utils/imodels-client-test-utils
@@ -172,8 +172,8 @@ importers:
 
   ../../tests/imodels-access-frontend-tests:
     specifiers:
-      '@itwin/core-common': ^3.0.0
-      '@itwin/core-frontend': ^3.0.0
+      '@itwin/core-common': ^3.3.0
+      '@itwin/core-frontend': ^3.3.0
       '@itwin/imodels-access-frontend': workspace:*
       '@itwin/imodels-client-common-config': workspace:*
       '@itwin/imodels-client-management': workspace:*
@@ -192,8 +192,8 @@ importers:
       sort-package-json: ~1.53.1
       typescript: ~4.4.0
     dependencies:
-      '@itwin/core-common': 3.2.0
-      '@itwin/core-frontend': 3.2.0_@itwin+core-common@3.2.0
+      '@itwin/core-common': 3.3.0
+      '@itwin/core-frontend': 3.3.0_@itwin+core-common@3.3.0
       '@itwin/imodels-access-frontend': link:../../itwin-platform-access/imodels-access-frontend
       '@itwin/imodels-client-management': link:../../clients/imodels-client-management
       '@itwin/imodels-client-test-utils': link:../../utils/imodels-client-test-utils
@@ -307,7 +307,7 @@ importers:
 
   ../../utils/imodels-client-common-config:
     specifiers:
-      '@itwin/eslint-plugin': ^3.0.0
+      '@itwin/eslint-plugin': ^3.3.0
       '@typescript-eslint/eslint-plugin': ~4.28.4
       '@typescript-eslint/parser': ~4.28.4
       eslint: ~7.31.0
@@ -315,7 +315,7 @@ importers:
       eslint-plugin-mocha: ~9.0.0
       sort-package-json: ~1.53.1
     devDependencies:
-      '@itwin/eslint-plugin': 3.2.0_eslint@7.31.0
+      '@itwin/eslint-plugin': 3.3.0_eslint@7.31.0
       '@typescript-eslint/eslint-plugin': 4.28.5_b121c633c473862f790ae30ff0479b86
       '@typescript-eslint/parser': 4.28.5_eslint@7.31.0
       eslint: 7.31.0
@@ -751,8 +751,8 @@ packages:
     resolution: {integrity: sha512-5zZgs+himE2vjf39CVlDXMHCFAwSfcoORqJBk3Vji8QVCF8AIX4IX2DO6HlsIAM7szxMNqhz1kd07Xfppro6MA==}
     dev: true
 
-  /@bentley/imodeljs-native/3.2.8:
-    resolution: {integrity: sha512-7Ycn4cTvDjQtoTQzPGdrZhaEqETgb891yLA3f1K69q7LO2eEhQFanXOITO/zKun+WuQhYbKkjEPlAQtJYkMV5g==}
+  /@bentley/imodeljs-native/3.3.12:
+    resolution: {integrity: sha512-EBCdnjyObiCiJryO39Qwdn8tgQZ8Kl54V9NNILA3wSn0dej6ljz3wITieUjXD3XpReu6xsYqK4K/TQEdXEP95A==}
     requiresBuild: true
 
   /@colors/colors/1.5.0:
@@ -1062,13 +1062,13 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /@itwin/appui-abstract/3.2.0_@itwin+core-bentley@3.2.0:
-    resolution: {integrity: sha512-5Bv/Rgp4y+MXySurovNgkkoBUECgrLyco/ADLGaYy0KIRrtVvPi5bJ1SqT0qg6nTy31J9CQA0xofUdElbCDxIg==}
+  /@itwin/appui-abstract/3.3.0_@itwin+core-bentley@3.3.0:
+    resolution: {integrity: sha512-bGt/m+P3wDqHK4cyOn+fLc7a3aItpdrGLhXlk2sWMrCj07aSBjg+rhKfPf68DkbfNse4QPqwQGK+yYQ6vNsSdw==}
     peerDependencies:
-      '@itwin/core-bentley': ^3.2.0
+      '@itwin/core-bentley': ^3.3.0
     dependencies:
       '@bentley/icons-generic-webfont': 1.0.34
-      '@itwin/core-bentley': 3.2.0
+      '@itwin/core-bentley': 3.3.0
     dev: true
 
   /@itwin/cloud-agnostic-core/1.0.0:
@@ -1079,31 +1079,34 @@ packages:
       reflect-metadata: 0.1.13
     dev: false
 
-  /@itwin/core-backend/3.2.0_6d8ed02b6d58c40967ff078d2d51dd5f:
-    resolution: {integrity: sha512-k2OkaTGjydIZxBVAVi8xnz7NK1UTK91tfMUCXiQ9sAkd/Zl8F/wC7V2L4n/3a/IqGj6yweh+5+KOqCoIMX4Zeg==}
+  /@itwin/core-backend/3.3.0_6cb52bce383bc4481b1af007b1456cdc:
+    resolution: {integrity: sha512-vGKgxMD21nBVTPnG3X70wmYsW5aQdP5IIxuZf8CLDaUPt348+gfA4zUBte5sbUVPfPA4Tkjwyerdlrww+Jcjtg==}
     engines: {node: '>=12.22.0 < 14.0 || >=14.17.0 <17.0'}
     peerDependencies:
-      '@itwin/core-bentley': ^3.2.0
-      '@itwin/core-common': ^3.2.0
-      '@itwin/core-geometry': ^3.2.0
-      '@itwin/ecschema-metadata': ^3.2.0
+      '@itwin/core-bentley': ^3.3.0
+      '@itwin/core-common': ^3.3.0
+      '@itwin/core-geometry': ^3.3.0
+      '@itwin/ecschema-metadata': ^3.3.0
+      '@opentelemetry/api': ^1.0.4
     peerDependenciesMeta:
       '@itwin/ecschema-metadata':
         optional: true
+      '@opentelemetry/api':
+        optional: true
     dependencies:
       '@azure/storage-blob': 12.10.0
-      '@bentley/imodeljs-native': 3.2.8
-      '@itwin/core-bentley': 3.2.0
-      '@itwin/core-common': 3.2.0_7cd671bdbf1cf2d2e03262996efd1f64
-      '@itwin/core-geometry': 3.2.0
-      '@itwin/core-telemetry': 3.2.0_@itwin+core-geometry@3.2.0
-      '@itwin/ecschema-metadata': 3.2.0_@itwin+core-bentley@3.2.0
+      '@bentley/imodeljs-native': 3.3.12
+      '@itwin/core-bentley': 3.3.0
+      '@itwin/core-common': 3.3.0_e1c7120832f97c6cd8e6749fcb0b8f50
+      '@itwin/core-geometry': 3.3.0
+      '@itwin/core-telemetry': 3.3.0_@itwin+core-geometry@3.3.0
+      '@itwin/ecschema-metadata': 3.3.0_@itwin+core-bentley@3.3.0
       form-data: 2.5.1
       fs-extra: 8.1.0
       js-base64: 3.7.2
       json5: 2.2.1
       multiparty: 4.2.3
-      semver: 5.7.1
+      semver: 7.3.7
       ws: 7.5.8
     transitivePeerDependencies:
       - bufferutil
@@ -1111,30 +1114,33 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@itwin/core-backend/3.2.0_e12312b15e5055e2f2a8dc698d76e0b1:
-    resolution: {integrity: sha512-k2OkaTGjydIZxBVAVi8xnz7NK1UTK91tfMUCXiQ9sAkd/Zl8F/wC7V2L4n/3a/IqGj6yweh+5+KOqCoIMX4Zeg==}
+  /@itwin/core-backend/3.3.0_9acad095885f5359c2cb2c767d03c7b5:
+    resolution: {integrity: sha512-vGKgxMD21nBVTPnG3X70wmYsW5aQdP5IIxuZf8CLDaUPt348+gfA4zUBte5sbUVPfPA4Tkjwyerdlrww+Jcjtg==}
     engines: {node: '>=12.22.0 < 14.0 || >=14.17.0 <17.0'}
     peerDependencies:
-      '@itwin/core-bentley': ^3.2.0
-      '@itwin/core-common': ^3.2.0
-      '@itwin/core-geometry': ^3.2.0
-      '@itwin/ecschema-metadata': ^3.2.0
+      '@itwin/core-bentley': ^3.3.0
+      '@itwin/core-common': ^3.3.0
+      '@itwin/core-geometry': ^3.3.0
+      '@itwin/ecschema-metadata': ^3.3.0
+      '@opentelemetry/api': ^1.0.4
     peerDependenciesMeta:
       '@itwin/ecschema-metadata':
         optional: true
+      '@opentelemetry/api':
+        optional: true
     dependencies:
       '@azure/storage-blob': 12.10.0
-      '@bentley/imodeljs-native': 3.2.8
-      '@itwin/core-bentley': 3.2.0
-      '@itwin/core-common': 3.2.0_@itwin+core-bentley@3.2.0
-      '@itwin/core-telemetry': 3.2.0
-      '@itwin/ecschema-metadata': 3.2.0_@itwin+core-bentley@3.2.0
+      '@bentley/imodeljs-native': 3.3.12
+      '@itwin/core-bentley': 3.3.0
+      '@itwin/core-common': 3.3.0_@itwin+core-bentley@3.3.0
+      '@itwin/core-telemetry': 3.3.0
+      '@itwin/ecschema-metadata': 3.3.0_@itwin+core-bentley@3.3.0
       form-data: 2.5.1
       fs-extra: 8.1.0
       js-base64: 3.7.2
       json5: 2.2.1
       multiparty: 4.2.3
-      semver: 5.7.1
+      semver: 7.3.7
       ws: 7.5.8
     transitivePeerDependencies:
       - bufferutil
@@ -1142,108 +1148,79 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@itwin/core-bentley/3.2.0:
-    resolution: {integrity: sha512-VnxqQxwXvJuAE5sbKmhqdqpEWVp9N1uWdAD4LopUCY/B0GHdZ7fKigQ7GH/m2b3XxnmIzCH8OwjgaEO/Ppe5Sw==}
+  /@itwin/core-bentley/3.3.0:
+    resolution: {integrity: sha512-vbDl4ek4OFfNboGDyKAR1GC0lHIJpmp0R0bgFt6USscQKCHQvRSHctf7OkHtIzTlm+Rd2Pl5EI0gCksLPD/VQA==}
 
-  /@itwin/core-common/3.2.0:
-    resolution: {integrity: sha512-Pcz4WYF+LS2glh3LJcLRvezcbdPy8EsFO9oC+pRzx3ZrzEbQqiTzCFk8IX3UK4n8gyYir7VGCPxkkMrIgPH20w==}
+  /@itwin/core-common/3.3.0:
+    resolution: {integrity: sha512-I+QrmenLf+DoCnzVtmOhBR8bmQ9G/8ntd4FYKnHxI7T6MYFDlPjzUBm6SlwIMuYrsyHP7O5MZ4B4tBT7OP84lw==}
     peerDependencies:
-      '@itwin/core-bentley': ^3.2.0
-      '@itwin/core-geometry': ^3.2.0
+      '@itwin/core-bentley': ^3.3.0
+      '@itwin/core-geometry': ^3.3.0
     dependencies:
       buffer: 6.0.3
       flatbuffers: 1.12.0
       js-base64: 3.7.2
-      semver: 5.7.1
+      semver: 7.3.7
       string_decoder: 1.3.0
     dev: false
 
-  /@itwin/core-common/3.2.0_7cd671bdbf1cf2d2e03262996efd1f64:
-    resolution: {integrity: sha512-Pcz4WYF+LS2glh3LJcLRvezcbdPy8EsFO9oC+pRzx3ZrzEbQqiTzCFk8IX3UK4n8gyYir7VGCPxkkMrIgPH20w==}
+  /@itwin/core-common/3.3.0_@itwin+core-bentley@3.3.0:
+    resolution: {integrity: sha512-I+QrmenLf+DoCnzVtmOhBR8bmQ9G/8ntd4FYKnHxI7T6MYFDlPjzUBm6SlwIMuYrsyHP7O5MZ4B4tBT7OP84lw==}
     peerDependencies:
-      '@itwin/core-bentley': ^3.2.0
-      '@itwin/core-geometry': ^3.2.0
+      '@itwin/core-bentley': ^3.3.0
+      '@itwin/core-geometry': ^3.3.0
     dependencies:
-      '@itwin/core-bentley': 3.2.0
-      '@itwin/core-geometry': 3.2.0
+      '@itwin/core-bentley': 3.3.0
       buffer: 6.0.3
       flatbuffers: 1.12.0
       js-base64: 3.7.2
-      semver: 5.7.1
+      semver: 7.3.7
+      string_decoder: 1.3.0
+    dev: false
+
+  /@itwin/core-common/3.3.0_e1c7120832f97c6cd8e6749fcb0b8f50:
+    resolution: {integrity: sha512-I+QrmenLf+DoCnzVtmOhBR8bmQ9G/8ntd4FYKnHxI7T6MYFDlPjzUBm6SlwIMuYrsyHP7O5MZ4B4tBT7OP84lw==}
+    peerDependencies:
+      '@itwin/core-bentley': ^3.3.0
+      '@itwin/core-geometry': ^3.3.0
+    dependencies:
+      '@itwin/core-bentley': 3.3.0
+      '@itwin/core-geometry': 3.3.0
+      buffer: 6.0.3
+      flatbuffers: 1.12.0
+      js-base64: 3.7.2
+      semver: 7.3.7
       string_decoder: 1.3.0
     dev: true
 
-  /@itwin/core-common/3.2.0_@itwin+core-bentley@3.2.0:
-    resolution: {integrity: sha512-Pcz4WYF+LS2glh3LJcLRvezcbdPy8EsFO9oC+pRzx3ZrzEbQqiTzCFk8IX3UK4n8gyYir7VGCPxkkMrIgPH20w==}
+  /@itwin/core-frontend/3.3.0_65f6b066372fa5f23e11e9cbf1a40c5e:
+    resolution: {integrity: sha512-oNYKsAEL+djzyRILZGs9A87JiUeOpe4ES1wBHraygaOB0Pe6WxyBsNtVsKuRlqTNKWsze2bZDdmV4CsfO0ny1A==}
     peerDependencies:
-      '@itwin/core-bentley': ^3.2.0
-      '@itwin/core-geometry': ^3.2.0
+      '@itwin/appui-abstract': ^3.3.0
+      '@itwin/core-bentley': ^3.3.0
+      '@itwin/core-common': ^3.3.0
+      '@itwin/core-geometry': ^3.3.0
+      '@itwin/core-orbitgt': ^3.3.0
+      '@itwin/core-quantity': ^3.3.0
+      '@itwin/webgl-compatibility': ^3.3.0
     dependencies:
-      '@itwin/core-bentley': 3.2.0
-      buffer: 6.0.3
-      flatbuffers: 1.12.0
-      js-base64: 3.7.2
-      semver: 5.7.1
-      string_decoder: 1.3.0
-    dev: false
-
-  /@itwin/core-frontend/3.2.0_@itwin+core-common@3.2.0:
-    resolution: {integrity: sha512-ooKDXAzLDA6D5crtG8AvdsSstooJkryTF4PM6DtUuAX7Qla9jdCiX3+JM9bThWDRhiGWBPTrRJkN2dc2ZP4khQ==}
-    peerDependencies:
-      '@itwin/appui-abstract': ^3.2.0
-      '@itwin/core-bentley': ^3.2.0
-      '@itwin/core-common': ^3.2.0
-      '@itwin/core-geometry': ^3.2.0
-      '@itwin/core-orbitgt': ^3.2.0
-      '@itwin/core-quantity': ^3.2.0
-      '@itwin/webgl-compatibility': ^3.2.0
-    dependencies:
-      '@itwin/core-common': 3.2.0
-      '@itwin/core-i18n': 3.2.0
-      '@itwin/core-telemetry': 3.2.0
+      '@itwin/appui-abstract': 3.3.0_@itwin+core-bentley@3.3.0
+      '@itwin/core-bentley': 3.3.0
+      '@itwin/core-common': 3.3.0_e1c7120832f97c6cd8e6749fcb0b8f50
+      '@itwin/core-geometry': 3.3.0
+      '@itwin/core-i18n': 3.3.0_@itwin+core-bentley@3.3.0
+      '@itwin/core-orbitgt': 3.3.0
+      '@itwin/core-quantity': 3.3.0_@itwin+core-bentley@3.3.0
+      '@itwin/core-telemetry': 3.3.0_@itwin+core-geometry@3.3.0
+      '@itwin/webgl-compatibility': 3.3.0
       '@loaders.gl/core': 3.2.3
       '@loaders.gl/draco': 3.2.3
       deep-assign: 2.0.0
       fuse.js: 3.6.1
       lodash: 4.17.21
       qs: 6.10.3
-      semver: 5.7.1
-      superagent: 7.1.6
-      wms-capabilities: 0.4.0
-      xml-js: 1.6.11
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
-  /@itwin/core-frontend/3.2.0_d0ae248df510e2cd9b391084a77a8fb2:
-    resolution: {integrity: sha512-ooKDXAzLDA6D5crtG8AvdsSstooJkryTF4PM6DtUuAX7Qla9jdCiX3+JM9bThWDRhiGWBPTrRJkN2dc2ZP4khQ==}
-    peerDependencies:
-      '@itwin/appui-abstract': ^3.2.0
-      '@itwin/core-bentley': ^3.2.0
-      '@itwin/core-common': ^3.2.0
-      '@itwin/core-geometry': ^3.2.0
-      '@itwin/core-orbitgt': ^3.2.0
-      '@itwin/core-quantity': ^3.2.0
-      '@itwin/webgl-compatibility': ^3.2.0
-    dependencies:
-      '@itwin/appui-abstract': 3.2.0_@itwin+core-bentley@3.2.0
-      '@itwin/core-bentley': 3.2.0
-      '@itwin/core-common': 3.2.0_7cd671bdbf1cf2d2e03262996efd1f64
-      '@itwin/core-geometry': 3.2.0
-      '@itwin/core-i18n': 3.2.0_@itwin+core-bentley@3.2.0
-      '@itwin/core-orbitgt': 3.2.0
-      '@itwin/core-quantity': 3.2.0_@itwin+core-bentley@3.2.0
-      '@itwin/core-telemetry': 3.2.0_@itwin+core-geometry@3.2.0
-      '@itwin/webgl-compatibility': 3.2.0
-      '@loaders.gl/core': 3.2.3
-      '@loaders.gl/draco': 3.2.3
-      deep-assign: 2.0.0
-      fuse.js: 3.6.1
-      lodash: 4.17.21
-      qs: 6.10.3
-      semver: 5.7.1
-      superagent: 7.1.6
+      semver: 7.3.7
+      superagent: 7.1.3
       wms-capabilities: 0.4.0
       xml-js: 1.6.11
     transitivePeerDependencies:
@@ -1251,17 +1228,46 @@ packages:
       - supports-color
     dev: true
 
-  /@itwin/core-geometry/3.2.0:
-    resolution: {integrity: sha512-CJ01MxXJfmoW0z3iquvCrtnxPvx/N9Hx8Q40RIsU7asWVPT5Lb1JmSBlPkfxSJ15zN8wZZhFM/x7KWemtPng2Q==}
+  /@itwin/core-frontend/3.3.0_@itwin+core-common@3.3.0:
+    resolution: {integrity: sha512-oNYKsAEL+djzyRILZGs9A87JiUeOpe4ES1wBHraygaOB0Pe6WxyBsNtVsKuRlqTNKWsze2bZDdmV4CsfO0ny1A==}
+    peerDependencies:
+      '@itwin/appui-abstract': ^3.3.0
+      '@itwin/core-bentley': ^3.3.0
+      '@itwin/core-common': ^3.3.0
+      '@itwin/core-geometry': ^3.3.0
+      '@itwin/core-orbitgt': ^3.3.0
+      '@itwin/core-quantity': ^3.3.0
+      '@itwin/webgl-compatibility': ^3.3.0
     dependencies:
-      '@itwin/core-bentley': 3.2.0
+      '@itwin/core-common': 3.3.0
+      '@itwin/core-i18n': 3.3.0
+      '@itwin/core-telemetry': 3.3.0
+      '@loaders.gl/core': 3.2.3
+      '@loaders.gl/draco': 3.2.3
+      deep-assign: 2.0.0
+      fuse.js: 3.6.1
+      lodash: 4.17.21
+      qs: 6.10.3
+      semver: 7.3.7
+      superagent: 7.1.3
+      wms-capabilities: 0.4.0
+      xml-js: 1.6.11
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
+  /@itwin/core-geometry/3.3.0:
+    resolution: {integrity: sha512-4bum5Lq2E+9dLO/POcou+gh8pjJVoI9e0f/VTjnUdL0VIm5BDkXsB9SUhAyMsP8Ei/uiwp1WcxIe9z0Emwozyw==}
+    dependencies:
+      '@itwin/core-bentley': 3.3.0
       flatbuffers: 1.12.0
     dev: true
 
-  /@itwin/core-i18n/3.2.0:
-    resolution: {integrity: sha512-AP2LZAdOGylsNoBJ70ak6d3iyxO9RaA+cTQPTAh8eRioF2XOEk0hRpIc9MDgVoaiS642ucR+dlb7P5C9IEk5Zg==}
+  /@itwin/core-i18n/3.3.0:
+    resolution: {integrity: sha512-HSh0kVVmIaUG/y5acShIJCimhqlBmXj2qzR4wMytXMAgankeWfXCoSUy8MotYRMVYzeh2KTrCQrSljLjpZApXA==}
     peerDependencies:
-      '@itwin/core-bentley': ^3.2.0
+      '@itwin/core-bentley': ^3.3.0
     dependencies:
       i18next: 21.8.5
       i18next-browser-languagedetector: 6.1.4
@@ -1271,12 +1277,12 @@ packages:
       - encoding
     dev: false
 
-  /@itwin/core-i18n/3.2.0_@itwin+core-bentley@3.2.0:
-    resolution: {integrity: sha512-AP2LZAdOGylsNoBJ70ak6d3iyxO9RaA+cTQPTAh8eRioF2XOEk0hRpIc9MDgVoaiS642ucR+dlb7P5C9IEk5Zg==}
+  /@itwin/core-i18n/3.3.0_@itwin+core-bentley@3.3.0:
+    resolution: {integrity: sha512-HSh0kVVmIaUG/y5acShIJCimhqlBmXj2qzR4wMytXMAgankeWfXCoSUy8MotYRMVYzeh2KTrCQrSljLjpZApXA==}
     peerDependencies:
-      '@itwin/core-bentley': ^3.2.0
+      '@itwin/core-bentley': ^3.3.0
     dependencies:
-      '@itwin/core-bentley': 3.2.0
+      '@itwin/core-bentley': 3.3.0
       i18next: 21.8.5
       i18next-browser-languagedetector: 6.1.4
       i18next-http-backend: 1.4.1
@@ -1285,47 +1291,47 @@ packages:
       - encoding
     dev: true
 
-  /@itwin/core-orbitgt/3.2.0:
-    resolution: {integrity: sha512-pS31wAWXhF6ijcRFoUFo9BQUhsxh75yuqjx0JR/W7qH1/tApCS15v9ORGKs5MghpyMCE9A9/xPPOP/8SYOfXuw==}
+  /@itwin/core-orbitgt/3.3.0:
+    resolution: {integrity: sha512-2nSFul1fHtt4ipCIbHkxFI4xPRmrlv1IAHrdp03l48rRTPMud7vjLpdv0TSZ8NCs9tbKIG96i+UGabxKw7sAgg==}
     dev: true
 
-  /@itwin/core-quantity/3.2.0_@itwin+core-bentley@3.2.0:
-    resolution: {integrity: sha512-NepMRIlsCn98O1C/STrYgzb46vnlL1Yj7tBQ2p9RufIKN7wr0S+VgjQYrE8dJnRvucdgJwdZBvsu2ADVLvhIaA==}
+  /@itwin/core-quantity/3.3.0_@itwin+core-bentley@3.3.0:
+    resolution: {integrity: sha512-iU/J3U/yeydZRII0pL4NgZohQP8J07Or77g2G0NYiQpwq5zZRPqDByMRyZaC09tJQPLMia/MKgB4e/zLr5igVw==}
     peerDependencies:
-      '@itwin/core-bentley': ^3.2.0
+      '@itwin/core-bentley': ^3.3.0
     dependencies:
-      '@itwin/core-bentley': 3.2.0
+      '@itwin/core-bentley': 3.3.0
     dev: true
 
-  /@itwin/core-telemetry/3.2.0:
-    resolution: {integrity: sha512-v3ebEI0GfkwJETi+dSB9LIb13pN+fmEcNfCEDSQh1JQJs7Gt+sNxnmbkH6PeaZ09SybZlEUiVwqCqnjhjhxSFg==}
+  /@itwin/core-telemetry/3.3.0:
+    resolution: {integrity: sha512-MclnMfBnrmU7LH3Jn87+u76Ir+VrSYGsrBJon5OgvuKCAtf61F4d53AhLQEKdsApv8NXD5buiqP9Vu9ANJOuNw==}
     dependencies:
-      '@itwin/core-bentley': 3.2.0
-      '@itwin/core-common': 3.2.0_@itwin+core-bentley@3.2.0
+      '@itwin/core-bentley': 3.3.0
+      '@itwin/core-common': 3.3.0_@itwin+core-bentley@3.3.0
     transitivePeerDependencies:
       - '@itwin/core-geometry'
     dev: false
 
-  /@itwin/core-telemetry/3.2.0_@itwin+core-geometry@3.2.0:
-    resolution: {integrity: sha512-v3ebEI0GfkwJETi+dSB9LIb13pN+fmEcNfCEDSQh1JQJs7Gt+sNxnmbkH6PeaZ09SybZlEUiVwqCqnjhjhxSFg==}
+  /@itwin/core-telemetry/3.3.0_@itwin+core-geometry@3.3.0:
+    resolution: {integrity: sha512-MclnMfBnrmU7LH3Jn87+u76Ir+VrSYGsrBJon5OgvuKCAtf61F4d53AhLQEKdsApv8NXD5buiqP9Vu9ANJOuNw==}
     dependencies:
-      '@itwin/core-bentley': 3.2.0
-      '@itwin/core-common': 3.2.0_7cd671bdbf1cf2d2e03262996efd1f64
+      '@itwin/core-bentley': 3.3.0
+      '@itwin/core-common': 3.3.0_e1c7120832f97c6cd8e6749fcb0b8f50
     transitivePeerDependencies:
       - '@itwin/core-geometry'
     dev: true
 
-  /@itwin/ecschema-metadata/3.2.0_@itwin+core-bentley@3.2.0:
-    resolution: {integrity: sha512-hESggC1x3MEqZ6w0FUX9G9+U55U9WkGaZc0b5z0IdtVbLy3NV4nnxRZ/ob4a3N4SdfffrxkWYEWzQZ2pGXtPrw==}
+  /@itwin/ecschema-metadata/3.3.0_@itwin+core-bentley@3.3.0:
+    resolution: {integrity: sha512-RyiMDF5fbSakavcnQpRIUi4kmdbhxMfZrpujyb3To6xzaJOoprQowSU+rl7TbawhV8vlag54lCeaM5MPXgH8zQ==}
     peerDependencies:
-      '@itwin/core-bentley': ^3.2.0
-      '@itwin/core-quantity': ^3.2.0
+      '@itwin/core-bentley': ^3.3.0
+      '@itwin/core-quantity': ^3.3.0
     dependencies:
-      '@itwin/core-bentley': 3.2.0
+      '@itwin/core-bentley': 3.3.0
       almost-equal: 1.1.0
 
-  /@itwin/eslint-plugin/3.2.0_eslint@7.31.0:
-    resolution: {integrity: sha512-xgQUovHm7OkcHThWvxMX8TnEtjnUjk/atYLfB8Y5y/8RZQKIIpk99X8XHKepu5TLmh0Q5wVhtCoQmZBLhmmC3w==}
+  /@itwin/eslint-plugin/3.3.0_eslint@7.31.0:
+    resolution: {integrity: sha512-hBpApmPrdB+eQnjF4PNpbpyfbdLKX/z5yhdfy0qZ8WCQgw6oNXNSwWu6uCRT0az8epVfHwOe+8GWXsq/AjC6HA==}
     hasBin: true
     peerDependencies:
       eslint: ^7.0.0
@@ -1375,10 +1381,10 @@ packages:
       - debug
     dev: false
 
-  /@itwin/webgl-compatibility/3.2.0:
-    resolution: {integrity: sha512-4R0pFJgbibOJn0pr/kd63z68MfJZMPL9td7xbPe7TIVt2Pf/deo+lRmCVHtxdgnhHNZ78p1xLTGPSsxbNe5ymg==}
+  /@itwin/webgl-compatibility/3.3.0:
+    resolution: {integrity: sha512-uv4km27mSIYAjprkfwduO4sS7OQRrkC07J9Og6TUBOgVZMH1XqzHt90NNm6qsRHRjlVMq08BpUaMDGAyB7UEGw==}
     dependencies:
-      '@itwin/core-bentley': 3.2.0
+      '@itwin/core-bentley': 3.3.0
     dev: true
 
   /@jridgewell/gen-mapping/0.1.1:
@@ -2471,6 +2477,7 @@ packages:
 
   /core-js-pure/3.22.7:
     resolution: {integrity: sha512-wTriFxiZI+C8msGeh7fJcbC/a0V8fdInN1oS2eK79DMBGs8iIJiXhtFJCiT3rBa8w6zroHWW3p8ArlujZ/Mz+w==}
+    deprecated: core-js-pure@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js-pure.
     requiresBuild: true
     dev: true
 
@@ -4964,7 +4971,7 @@ packages:
     dev: true
 
   /random-bytes/1.0.0:
-    resolution: {integrity: sha1-T2ih3Arli9P7lYSMMDJNt11kNgs=}
+    resolution: {integrity: sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==}
     engines: {node: '>= 0.8'}
 
   /randombytes/2.1.0:
@@ -5047,7 +5054,7 @@ packages:
     dev: true
 
   /repeat-string/1.6.1:
-    resolution: {integrity: sha1-jcrkcOHIirwtYA//Sndihtp15jc=}
+    resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
     engines: {node: '>=0.10'}
 
   /request-progress/3.0.0:
@@ -5073,7 +5080,7 @@ packages:
     dev: true
 
   /requireindex/1.1.0:
-    resolution: {integrity: sha1-5UBLgVV+91225JxacgBIk/4D4WI=}
+    resolution: {integrity: sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==}
     engines: {node: '>=0.10.5'}
     dev: true
 
@@ -5165,6 +5172,7 @@ packages:
   /semver/5.7.1:
     resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
     hasBin: true
+    dev: true
 
   /semver/6.3.0:
     resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
@@ -5311,7 +5319,7 @@ packages:
       tweetnacl: 0.14.5
 
   /statuses/1.5.0:
-    resolution: {integrity: sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=}
+    resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
     engines: {node: '>= 0.6'}
 
   /string-width/4.2.3:
@@ -5386,8 +5394,8 @@ packages:
       minimist: 1.2.6
     dev: true
 
-  /superagent/7.1.6:
-    resolution: {integrity: sha512-gZkVCQR1gy/oUXr+kxJMLDjla434KmSOKbx5iGD30Ql+AkJQ/YlPKECJy2nhqOsHLjGHzoDTXNSjhnvWhzKk7g==}
+  /superagent/7.1.3:
+    resolution: {integrity: sha512-WA6et4nAvgBCS73lJvv1D0ssI5uk5Gh+TGN/kNe+B608EtcVs/yzfl+OLXTzDs7tOBDIpvgh/WUs1K2OK1zTeQ==}
     engines: {node: '>=6.4.0 <13 || >=14'}
     dependencies:
       component-emitter: 1.3.0
@@ -5659,7 +5667,7 @@ packages:
     dev: true
 
   /util-deprecate/1.0.2:
-    resolution: {integrity: sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=}
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   /util.inherits/1.0.3:
     resolution: {integrity: sha1-qcYmoNBtNIKdR7pWyrEnjXRfnOY=}

--- a/itwin-platform-access/imodels-access-backend/CHANGELOG.md
+++ b/itwin-platform-access/imodels-access-backend/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 2.0.0
 
-Changes:
+Non-breaking changes:
 - Updated `BackendIModelsAccess` class implementation according to breaking changes in `@itwin/imodels-client-authoring`.
 
-This release contains no breaking changes compared to the previous package version.
+Breaking changes:
+- Updated iTwin.js platform peer dependencies to version 3.3.0.

--- a/itwin-platform-access/imodels-access-backend/CHANGELOG.md
+++ b/itwin-platform-access/imodels-access-backend/CHANGELOG.md
@@ -6,4 +6,4 @@ Non-breaking changes:
 - Updated `BackendIModelsAccess` class implementation according to breaking changes in `@itwin/imodels-client-authoring`.
 
 Breaking changes:
-- Updated iTwin.js platform peer dependencies to version 3.3.0.
+- Updated iTwin.js peer dependencies to version 3.3.0.

--- a/itwin-platform-access/imodels-access-backend/CHANGELOG.md
+++ b/itwin-platform-access/imodels-access-backend/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 2.0.0
 
-Non-breaking changes:
-- Updated `BackendIModelsAccess` class implementation according to breaking changes in `@itwin/imodels-client-authoring`.
-
 Breaking changes:
 - Updated iTwin.js peer dependencies to version 3.3.0.
+
+Non-breaking changes:
+- Updated `BackendIModelsAccess` class implementation according to breaking changes in `@itwin/imodels-client-authoring`.

--- a/itwin-platform-access/imodels-access-backend/package.json
+++ b/itwin-platform-access/imodels-access-backend/package.json
@@ -35,11 +35,10 @@
     "axios": "~0.21.1"
   },
   "devDependencies": {
-    "@itwin/core-backend": "^3.0.0",
-    "@itwin/core-bentley": "^3.0.0",
-    "@itwin/core-common": "^3.0.0",
-    "@itwin/core-geometry": "^3.0.0",
-    "@itwin/ecschema-metadata": "^3.0.0",
+    "@itwin/core-backend": "^3.3.0",
+    "@itwin/core-bentley": "^3.3.0",
+    "@itwin/core-common": "^3.3.0",
+    "@itwin/core-geometry": "^3.3.0",
     "@itwin/imodels-client-common-config": "workspace:*",
     "@types/node": "14.14.31",
     "@types/ws": "^7.0.0",
@@ -50,8 +49,8 @@
     "typescript": "~4.4.0"
   },
   "peerDependencies": {
-    "@itwin/core-backend": "^3.0.0",
-    "@itwin/core-bentley": "^3.0.0",
-    "@itwin/core-common": "^3.0.0"
+    "@itwin/core-backend": "^3.3.0",
+    "@itwin/core-bentley": "^3.3.0",
+    "@itwin/core-common": "^3.3.0"
   }
 }

--- a/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
@@ -191,6 +191,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
     return briefcaseIds;
   }
 
+  // eslint-disable-next-line deprecation/deprecation
   public async downloadV1Checkpoint(arg: CheckpointArg): Promise<ChangesetIndexAndId> {
     const checkpoint: Checkpoint | undefined = await this.queryCurrentOrPrecedingCheckpoint(arg);
     if (!checkpoint || !checkpoint._links?.download)
@@ -424,6 +425,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
     return tempBaselineFilePath;
   }
 
+  // eslint-disable-next-line deprecation/deprecation
   private async queryCurrentOrPrecedingCheckpoint(arg: CheckpointArg): Promise<Checkpoint | undefined> {
     const changesetIdOrIndex: ChangesetIdOrIndex = PlatformToClientAdapter.toChangesetIdOrIndex(arg.checkpoint.changeset);
     const getCheckpointParams: GetSingleCheckpointParams = {

--- a/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
@@ -276,42 +276,6 @@ export class BackendIModelsAccess implements BackendHubAccess {
     return result;
   }
 
-  public async downloadV2Checkpoint(arg: CheckpointArg): Promise<ChangesetIndexAndId> {
-    const checkpoint: Checkpoint | undefined = await this.queryCurrentOrPrecedingCheckpoint(arg);
-    if (!checkpoint || !checkpoint.containerAccessInfo)
-      throw new IModelError(IModelStatus.NotFound, "V2 checkpoint not found");
-
-    const v2CheckpointAccessProps = ClientToPlatformAdapter.toV2CheckpointAccessProps(checkpoint.containerAccessInfo);
-
-    const transfer = new IModelHost.platform.CloudDbTransfer("download", {
-      ...v2CheckpointAccessProps,
-      writeable: false,
-      localFile: arg.localFile
-    });
-
-    let timer: NodeJS.Timeout | undefined;
-    try {
-      let total = 0;
-      const onProgress = arg.onProgress;
-      if (onProgress) {
-        timer = setInterval(async () => { // set an interval timer to show progress every 250ms
-          const progress = transfer.getProgress();
-          total = progress.total;
-          if (onProgress(progress.loaded, progress.total))
-            transfer.cancelTransfer();
-        }, 250);
-      }
-      await transfer.promise;
-      onProgress?.(total, total); // make sure we call progress func one last time when download completes
-    } catch (err: unknown) {
-      throw ((err as Error)?.message === "cancelled") ? new IModelError(BriefcaseStatus.DownloadCancelled, "download cancelled") : err;
-    } finally {
-      if (timer)
-        clearInterval(timer);
-    }
-    return { index: checkpoint.changesetIndex, id: checkpoint.changesetId };
-  }
-
   public async acquireLocks(arg: BriefcaseDbArg, locks: LockMap): Promise<void> {
     const updateLockParams: UpdateLockParams = {
       ...this.getIModelScopedOperationParams(arg),

--- a/itwin-platform-access/imodels-access-frontend/CHANGELOG.md
+++ b/itwin-platform-access/imodels-access-frontend/CHANGELOG.md
@@ -3,4 +3,4 @@
 ## 2.0.0
 
 Breaking changes:
-- Updated iTwin.js platform peer dependencies to version 3.3.0.
+- Updated iTwin.js peer dependencies to version 3.3.0.

--- a/itwin-platform-access/imodels-access-frontend/CHANGELOG.md
+++ b/itwin-platform-access/imodels-access-frontend/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ## 2.0.0
 
-This release contains no changes compared to the previous package version.
+Breaking changes:
+- Updated iTwin.js platform peer dependencies to version 3.3.0.

--- a/itwin-platform-access/imodels-access-frontend/package.json
+++ b/itwin-platform-access/imodels-access-frontend/package.json
@@ -34,15 +34,15 @@
     "@itwin/imodels-client-management": "workspace:*"
   },
   "devDependencies": {
-    "@itwin/appui-abstract": "^3.0.0",
-    "@itwin/core-bentley": "^3.0.0",
-    "@itwin/core-common": "^3.0.0",
-    "@itwin/core-frontend": "^3.0.0",
-    "@itwin/core-geometry": "^3.0.0",
-    "@itwin/core-orbitgt": "^3.0.0",
-    "@itwin/core-quantity": "^3.0.0",
+    "@itwin/appui-abstract": "^3.3.0",
+    "@itwin/core-bentley": "^3.3.0",
+    "@itwin/core-common": "^3.3.0",
+    "@itwin/core-frontend": "^3.3.0",
+    "@itwin/core-geometry": "^3.3.0",
+    "@itwin/core-orbitgt": "^3.3.0",
+    "@itwin/core-quantity": "^3.3.0",
     "@itwin/imodels-client-common-config": "workspace:*",
-    "@itwin/webgl-compatibility": "^3.0.0",
+    "@itwin/webgl-compatibility": "^3.3.0",
     "@types/node": "14.14.31",
     "cspell": "~5.21.0",
     "eslint": "~7.31.0",
@@ -51,8 +51,8 @@
     "typescript": "~4.4.0"
   },
   "peerDependencies": {
-    "@itwin/core-bentley": "^3.0.0",
-    "@itwin/core-common": "^3.0.0",
-    "@itwin/core-frontend": "^3.0.0"
+    "@itwin/core-bentley": "^3.3.0",
+    "@itwin/core-common": "^3.3.0",
+    "@itwin/core-frontend": "^3.3.0"
   }
 }

--- a/tests/imodels-access-backend-tests/package.json
+++ b/tests/imodels-access-backend-tests/package.json
@@ -32,10 +32,10 @@
     "extends": "./node_modules/@itwin/imodels-client-common-config/.eslintrc.json"
   },
   "dependencies": {
-    "@itwin/core-backend": "^3.0.0",
-    "@itwin/core-bentley": "^3.0.0",
-    "@itwin/core-common": "^3.0.0",
-    "@itwin/ecschema-metadata": "^3.0.0",
+    "@itwin/core-backend": "^3.3.0",
+    "@itwin/core-bentley": "^3.3.0",
+    "@itwin/core-common": "^3.3.0",
+    "@itwin/ecschema-metadata": "^3.3.0",
     "@itwin/imodels-access-backend": "workspace:*",
     "@itwin/imodels-client-authoring": "workspace:*",
     "@itwin/imodels-client-test-utils": "workspace:*",

--- a/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
+++ b/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
@@ -6,7 +6,7 @@ import { assert } from "console";
 import * as fs from "fs";
 import * as path from "path";
 
-import { AcquireNewBriefcaseIdArg, BriefcaseDbArg, ChangesetRangeArg, CheckpointArg, IModelHost, IModelIdArg, LockMap, LockProps, LockState, ProgressFunction } from "@itwin/core-backend";
+import { AcquireNewBriefcaseIdArg, BriefcaseDbArg, ChangesetRangeArg, IModelHost, IModelIdArg, LockMap, LockProps, LockState, ProgressFunction } from "@itwin/core-backend";
 import { BriefcaseId, ChangesetFileProps, ChangesetIndexAndId, ChangesetType, LocalDirName } from "@itwin/core-common";
 import { BackendIModelsAccess } from "@itwin/imodels-access-backend";
 import { expect } from "chai";
@@ -140,7 +140,7 @@ describe("BackendIModelsAccess", () => {
       const lastNamedVersion = testIModelForRead.namedVersions[testIModelForRead.namedVersions.length - 1];
 
       const localCheckpointFilePath = path.join(testDownloadPath, "checkpoint_specific_changeset.bim");
-      const downloadV1CheckpointParams: CheckpointArg = {
+      const downloadV1CheckpointParams = {
         localFile: localCheckpointFilePath,
         checkpoint: {
           accessToken,
@@ -153,6 +153,7 @@ describe("BackendIModelsAccess", () => {
       };
 
       // Act
+      // eslint-disable-next-line deprecation/deprecation
       const downloadedCheckpoint: ChangesetIndexAndId = await backendIModelsAccess.downloadV1Checkpoint(downloadV1CheckpointParams);
 
       // Assert
@@ -170,7 +171,7 @@ describe("BackendIModelsAccess", () => {
       assert(firstNamedVersion.changesetId !== nextChangeset.id, "Unexpected changeset ids");
 
       const localCheckpointFilePath = path.join(testDownloadPath, "checkpoint_preceding_changeset.bim");
-      const downloadV1CheckpointParams: CheckpointArg = {
+      const downloadV1CheckpointParams = {
         localFile: localCheckpointFilePath,
         checkpoint: {
           accessToken,
@@ -183,6 +184,7 @@ describe("BackendIModelsAccess", () => {
       };
 
       // Act
+      // eslint-disable-next-line deprecation/deprecation
       const downloadedCheckpoint: ChangesetIndexAndId = await backendIModelsAccess.downloadV1Checkpoint(downloadV1CheckpointParams);
 
       // Assert
@@ -201,7 +203,7 @@ describe("BackendIModelsAccess", () => {
       };
 
       const localCheckpointFilePath = path.join(testDownloadPath, "checkpoint_progress_test.bim");
-      const downloadV1CheckpointParams: CheckpointArg = {
+      const downloadV1CheckpointParams = {
         localFile: localCheckpointFilePath,
         checkpoint: {
           accessToken,
@@ -215,6 +217,7 @@ describe("BackendIModelsAccess", () => {
       };
 
       // Act
+      // eslint-disable-next-line deprecation/deprecation
       await backendIModelsAccess.downloadV1Checkpoint(downloadV1CheckpointParams);
 
       // Assert

--- a/tests/imodels-access-frontend-tests/package.json
+++ b/tests/imodels-access-frontend-tests/package.json
@@ -32,8 +32,8 @@
     "extends": "./node_modules/@itwin/imodels-client-common-config/.eslintrc.json"
   },
   "dependencies": {
-    "@itwin/core-common": "^3.0.0",
-    "@itwin/core-frontend": "^3.0.0",
+    "@itwin/core-common": "^3.3.0",
+    "@itwin/core-frontend": "^3.3.0",
     "@itwin/imodels-access-frontend": "workspace:*",
     "@itwin/imodels-client-management": "workspace:*",
     "@itwin/imodels-client-test-utils": "workspace:*",

--- a/utils/imodels-client-common-config/package.json
+++ b/utils/imodels-client-common-config/package.json
@@ -26,7 +26,7 @@
     "spell-check": ""
   },
   "devDependencies": {
-    "@itwin/eslint-plugin": "^3.0.0",
+    "@itwin/eslint-plugin": "^3.3.0",
     "@typescript-eslint/eslint-plugin": "~4.28.4",
     "@typescript-eslint/parser": "~4.28.4",
     "eslint": "~7.31.0",


### PR DESCRIPTION
In this PR:
- Update iTwin.js platform peer dependency versions to `^3.3.0`
  - Removed `BackendHubAccess.downloadV2Checkpoint` method
- Updated docs to separate changes into breaking and non-breaking.