### PR TITLE
Temporary fix: publish only `@itwin/imodels-client-test-utils` package

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -18,31 +18,27 @@
     {
       "packageName": "@itwin/imodels-client-management",
       "projectFolder": "clients/imodels-client-management",
-      "shouldPublish": true,
-      "versionPolicyName": "prerelease-monorepo-lockStep"
+      "shouldPublish": false
     },
     {
       "packageName": "@itwin/imodels-client-authoring",
       "projectFolder": "clients/imodels-client-authoring",
-      "shouldPublish": true,
-      "versionPolicyName": "prerelease-monorepo-lockStep"
+      "shouldPublish": false
     },
     {
       "packageName": "@itwin/imodels-access-frontend",
       "projectFolder": "itwin-platform-access/imodels-access-frontend",
-      "shouldPublish": true,
-      "versionPolicyName": "prerelease-monorepo-lockStep"
+      "shouldPublish": false
     },
     {
       "packageName": "@itwin/imodels-access-backend",
       "projectFolder": "itwin-platform-access/imodels-access-backend",
-      "shouldPublish": true,
-      "versionPolicyName": "prerelease-monorepo-lockStep"
+      "shouldPublish": false
     },
     {
       "packageName": "@itwin/imodels-client-test-utils",
       "projectFolder": "utils/imodels-client-test-utils",
-      "shouldPublish": false
+      "shouldPublish": true
     },
     {
       "packageName": "@itwin/imodels-client-common-config",

--- a/utils/imodels-client-test-utils/LICENSE.md
+++ b/utils/imodels-client-test-utils/LICENSE.md
@@ -1,0 +1,9 @@
+# MIT License
+
+Copyright © Bentley Systems, Incorporated. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
In this PR:
- Temporarily modified rush.json file to only publish `@itwin/imodels-client-test-utils` package. After the release I will restore the client and platform interop package publish flags to true.