### PR TITLE
Added esm output

### DIFF
--- a/clients/imodels-client-management/package.json
+++ b/clients/imodels-client-management/package.json
@@ -23,7 +23,7 @@
   "types": "lib/index.d.ts",
   "module": "lib/esm/index.js",
   "scripts": {
-    "build": "tsc 1>&2",
+    "build": "tsc -p tsconfig.json && tsc -p tsconfig.esm.json 1>&2",
     "clean": "rimraf lib",
     "lint": "eslint ./src/**/*.ts 1>&2",
     "lint-fix": "eslint --fix ./src/**/*.ts 1>&2 && sort-package-json",

--- a/clients/imodels-client-management/package.json
+++ b/clients/imodels-client-management/package.json
@@ -20,7 +20,8 @@
     "url": "http://www.bentley.com"
   },
   "main": "lib/index.js",
-  "typings": "lib/index",
+  "types": "lib/index.d.ts",
+  "module": "lib/esm/index.js",
   "scripts": {
     "build": "tsc 1>&2",
     "clean": "rimraf lib",

--- a/clients/imodels-client-management/tsconfig.esm.json
+++ b/clients/imodels-client-management/tsconfig.esm.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./node_modules/@itwin/imodels-client-common-config/tsconfig.esm.json",
+  "compilerOptions": {
+    "outDir": "./lib/esm",
+  },
+  "include": [
+    "./src/**/*.ts"
+  ],
+  "exclude": [
+    "lib",
+    "node_modules"
+  ]
+}

--- a/itwin-platform-access/imodels-access-frontend/package.json
+++ b/itwin-platform-access/imodels-access-frontend/package.json
@@ -22,7 +22,7 @@
   "types": "lib/index.d.ts",
   "module": "lib/esm/index.js",
   "scripts": {
-    "build": "tsc 1>&2",
+    "build": "tsc -p tsconfig.json && tsc -p tsconfig.esm.json 1>&2",
     "clean": "rimraf lib",
     "lint": "eslint ./src/**/*.ts 1>&2",
     "lint-fix": "eslint --fix ./src/**/*.ts 1>&2 && sort-package-json",

--- a/itwin-platform-access/imodels-access-frontend/package.json
+++ b/itwin-platform-access/imodels-access-frontend/package.json
@@ -19,7 +19,8 @@
     "url": "http://www.bentley.com"
   },
   "main": "lib/index.js",
-  "typings": "lib/index",
+  "types": "lib/index.d.ts",
+  "module": "lib/esm/index.js",
   "scripts": {
     "build": "tsc 1>&2",
     "clean": "rimraf lib",

--- a/itwin-platform-access/imodels-access-frontend/tsconfig.esm.json
+++ b/itwin-platform-access/imodels-access-frontend/tsconfig.esm.json
@@ -1,7 +1,8 @@
 {
   "extends": "./node_modules/@itwin/imodels-client-common-config/tsconfig.esm.json",
   "compilerOptions": {
-    "outDir": "./lib/esm"
+    "outDir": "./lib/esm",
+    "esModuleInterop": true
   },
   "include": [
     "./src/**/*.ts"

--- a/itwin-platform-access/imodels-access-frontend/tsconfig.esm.json
+++ b/itwin-platform-access/imodels-access-frontend/tsconfig.esm.json
@@ -1,8 +1,7 @@
 {
   "extends": "./node_modules/@itwin/imodels-client-common-config/tsconfig.esm.json",
   "compilerOptions": {
-    "outDir": "./lib/esm",
-    "esModuleInterop": true
+    "outDir": "./lib/esm"
   },
   "include": [
     "./src/**/*.ts"

--- a/itwin-platform-access/imodels-access-frontend/tsconfig.esm.json
+++ b/itwin-platform-access/imodels-access-frontend/tsconfig.esm.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./node_modules/@itwin/imodels-client-common-config/tsconfig.esm.json",
+  "compilerOptions": {
+    "outDir": "./lib/esm",
+    "esModuleInterop": true
+  },
+  "include": [
+    "./src/**/*.ts"
+  ],
+  "exclude": [
+    "lib",
+    "node_modules"
+  ]
+}

--- a/itwin-platform-access/imodels-access-frontend/tsconfig.json
+++ b/itwin-platform-access/imodels-access-frontend/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "./node_modules/@itwin/imodels-client-common-config/tsconfig.json",
   "compilerOptions": {
-    "outDir": "./lib",
-    "esModuleInterop": true
+    "outDir": "./lib"
   },
   "include": [
     "./src/**/*.ts"

--- a/itwin-platform-access/imodels-access-frontend/tsconfig.json
+++ b/itwin-platform-access/imodels-access-frontend/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "./node_modules/@itwin/imodels-client-common-config/tsconfig.json",
   "compilerOptions": {
-    "outDir": "./lib"
+    "outDir": "./lib",
+    "esModuleInterop": true
   },
   "include": [
     "./src/**/*.ts"

--- a/tests/imodels-clients-tests-browser/src/ThumbnailOperations.test.ts
+++ b/tests/imodels-clients-tests-browser/src/ThumbnailOperations.test.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { ThumbnailOperations } from "@itwin/imodels-client-management/lib/operations";
+import { ThumbnailOperations } from "@itwin/imodels-client-management/lib/esm/operations";
 import { assertThumbnail } from "@itwin/imodels-client-test-utils/lib/assertions/BrowserFriendlyAssertions";
 
 import { ApiOptions, Authorization, AuthorizationCallback, ContentType, DownloadThumbnailParams, IModelScopedOperationParams, IModelsClient, Thumbnail, ThumbnailSize, UploadThumbnailParams } from "@itwin/imodels-client-management";

--- a/utils/imodels-client-common-config/tsconfig.esm.json
+++ b/utils/imodels-client-common-config/tsconfig.esm.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "sourceMap": true,
+    "moduleResolution": "node",
+  }
+}

--- a/utils/imodels-client-common-config/tsconfig.esm.json
+++ b/utils/imodels-client-common-config/tsconfig.esm.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",
-    "sourceMap": true,
     "moduleResolution": "node",
   }
 }


### PR DESCRIPTION
This is a tradeoff support for ES modules in the output of frontend packages. 
@itwin/imodels-client-management package has many exported modules that are labeled as private, but they can still be imported using full path specifier by the end users. I keep commonjs output the same as before to preserve these import paths, but place ES output to lib/esm. If you consume this package in your ES module using bare specifier, e.g.

import {...} from "@itwin/imodels-client-management"

then only ES modules would be imported. But if you begin mixing imports by full path in the same project, then it would drag in commonjs version too. I think intellisense of vscode would suggest to add import paths to cjs version if object/function/class used is not reexported from the main package barrel file.

To solve this issue "exports" of package.json should be defined, which effectively restricts the public surface. But that would cause breaking changes both for end users and other packages in this monorepo. I'd suggest to plan these changes in the next major version.

@itwin/imodels-access-frontend has only 2 files, everything is reexported from the barrel. It depends on @itwin/imodels-client-management, but there are no full path imports from it. Therefore consuming @itwin/imodels-access-frontend as ESM would yield @itwin/imodels-access-frontend as ESM too with proper tree shaking etc.