### PR TITLE
transpile esm build to same target as cjs, es2018

### DIFF
--- a/clients/imodels-client-authoring/package.json
+++ b/clients/imodels-client-authoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-client-authoring",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "iModels API client wrapper for applications that author iModels.",
   "keywords": [
     "Bentley",

--- a/clients/imodels-client-management/package.json
+++ b/clients/imodels-client-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-client-management",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "iModels API client wrapper for applications that manage iModels.",
   "keywords": [
     "Bentley",

--- a/itwin-platform-access/imodels-access-backend/package.json
+++ b/itwin-platform-access/imodels-access-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-access-backend",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Interoperability package between iModels API and iTwin.js library for backend.",
   "keywords": [
     "Bentley",

--- a/itwin-platform-access/imodels-access-frontend/package.json
+++ b/itwin-platform-access/imodels-access-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-access-frontend",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Interoperability package between iModels API and iTwin.js library for frontend.",
   "keywords": [
     "Bentley",

--- a/tests/imodels-access-backend-tests/package.json
+++ b/tests/imodels-access-backend-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-access-backend-tests",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Tests for iTwin platform and iModels API interoperability package - @itwin/imodels-access-backend.",
   "keywords": [
     "Bentley",

--- a/tests/imodels-access-frontend-tests/package.json
+++ b/tests/imodels-access-frontend-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-access-frontend-tests",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Tests for iTwin platform and iModels API interoperability package - @itwin/imodels-access-frontend.",
   "keywords": [
     "Bentley",

--- a/tests/imodels-clients-tests-browser/package.json
+++ b/tests/imodels-clients-tests-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-clients-tests-browser",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Tests for iModels API client wrappers",
   "keywords": [
     "Bentley",

--- a/tests/imodels-clients-tests/package.json
+++ b/tests/imodels-clients-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-clients-tests",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Tests for iModels API client wrappers",
   "keywords": [
     "Bentley",

--- a/utils/imodels-client-common-config/package.json
+++ b/utils/imodels-client-common-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-client-common-config",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Common configuration for iModels API client wrappers.",
   "keywords": [
     "Bentley",

--- a/utils/imodels-client-common-config/tsconfig.esm.json
+++ b/utils/imodels-client-common-config/tsconfig.esm.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "node",
   }

--- a/utils/imodels-client-test-utils/package.json
+++ b/utils/imodels-client-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-client-test-utils",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Common utilities for iModels API client wrappers tests.",
   "keywords": [
     "Bentley",


### PR DESCRIPTION
targeting esnext causes issues with apps using webpack4 because its unable to understand some of the newer syntax/features