### PR TITLE
Support for iModels API V2

### DIFF
--- a/clients/imodels-client-authoring/src/operations/baseline-file/BaselineFileOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/baseline-file/BaselineFileOperations.ts
@@ -13,7 +13,7 @@ import { GetSingleBaselineFileParams } from "./BaselineFileOperationParams";
 export class BaselineFileOperations<TOptions extends OperationOptions> extends OperationsBase<TOptions> {
   /**
    * Gets a single Baseline file by iModel id. This method returns a Baseline file in its full representation. Wraps the
-   * {@link https://developer.bentley.com/apis/imodels/operations/get-imodel-baseline-file-details/
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/get-imodel-baseline-file-details/
    * Get iModel Baseline File Details} operation from iModels API.
    * @param {GetSingleBaselineFileParams} params parameters for this operation. See {@link GetSingleBaselineFileParams}.
    * @returns {Promise<BaselineFile>} a Baseline file for the specified iModel. See {@link BaselineFile}.

--- a/clients/imodels-client-authoring/src/operations/briefcase/BriefcaseOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/briefcase/BriefcaseOperations.ts
@@ -14,7 +14,7 @@ import { AcquireBriefcaseParams, BriefcaseProperties, ReleaseBriefcaseParams } f
 export class BriefcaseOperations<TOptions extends OperationOptions> extends ManagementBriefcaseOperations<TOptions> {
   /**
    * Acquires a new Briefcase with specified properties. Wraps the
-   * {@link https://developer.bentley.com/apis/imodels/operations/acquire-imodel-briefcase/ Acquire iModel Briefcase}
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/acquire-imodel-briefcase/ Acquire iModel Briefcase}
    * operation from iModels API.
    * @param {AcquireBriefcaseParams} params parameters for this operation. See {@link AcquireBriefcaseParams}.
    * @returns {Promise<Briefcase>} newly acquired Briefcase. See {@link Briefcase}.
@@ -32,7 +32,7 @@ export class BriefcaseOperations<TOptions extends OperationOptions> extends Mana
 
   /**
    * Releases the specified Briefcase. Wraps the
-   * {@link https://developer.bentley.com/apis/imodels/operations/release-imodel-briefcase/ Release iModel Briefcase}
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/release-imodel-briefcase/ Release iModel Briefcase}
    * operation from iModels API.
    * @param {ReleaseBriefcaseParams} params parameters for this operation. See {@link ReleaseBriefcaseParams}.
    * @returns {Promise<Briefcase>} a promise that resolves after operation completes.

--- a/clients/imodels-client-authoring/src/operations/changeset/ChangesetOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/changeset/ChangesetOperations.ts
@@ -32,7 +32,7 @@ interface DownloadChangesetFileWithRetryParams extends IModelScopedOperationPara
 
 export class ChangesetOperations<TOptions extends OperationOptions> extends ManagementChangesetOperations<TOptions>{
   /**
-   * Creates a Changeset. Wraps the {@link https://developer.bentley.com/apis/imodels/operations/create-imodel-changeset/
+   * Creates a Changeset. Wraps the {@link https://developer.bentley.com/apis/imodels-v2/operations/create-imodel-changeset/
    * Create iModel Changeset} operation from iModels API. Internally it creates a Changeset instance, uploads the Changeset
    * file and confirms Changeset file upload. The execution of this method depends on the Changeset file size - the larger
    * the file, the longer the upload will take.

--- a/clients/imodels-client-authoring/src/operations/imodel/IModelOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/imodel/IModelOperations.ts
@@ -24,7 +24,7 @@ export class IModelOperations<TOptions extends OperationOptions> extends Managem
 
   /**
   * Creates an iModel from Baseline file with specified properties. Wraps the
-  * {@link https://developer.bentley.com/apis/imodels/operations/create-imodel/ Create iModel} operation from iModels API.
+  * {@link https://developer.bentley.com/apis/imodels-v2/operations/create-imodel/ Create iModel} operation from iModels API.
   * Internally it creates an iModel instance, uploads the Baseline file, confirms Baseline
   * file upload and then repeatedly queries the Baseline file state until the iModel is initialized. The execution of
   * this method can take up to several minutes due to waiting for initialization to complete. It also depends on the

--- a/clients/imodels-client-authoring/src/operations/lock/LockOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/lock/LockOperations.ts
@@ -16,7 +16,7 @@ export class LockOperations<TOptions extends OperationOptions> extends Operation
   /**
    * Gets Locks for a specific iModel. This method returns Locks in their full representation. The returned iterator
    * internally queries entities in pages. Wraps the
-   * {@link https://developer.bentley.com/apis/imodels/operations/get-imodel-locks/ Get iModel Locks} operation from
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/get-imodel-locks/ Get iModel Locks} operation from
    * iModels API.
    * @param {GetLockListParams} params parameters for this operation. See {@link GetLockListParams}.
    * @returns {EntityListIterator<Lock>} iterator for Lock list. See {@link EntityListIterator}, {@link Lock}.
@@ -31,7 +31,7 @@ export class LockOperations<TOptions extends OperationOptions> extends Operation
 
   /**
    * Updates Lock for a specific Briefcase. This operation is used to acquire new locks and change the lock level for
-   * already existing ones. Wraps the {@link https://developer.bentley.com/apis/imodels/operations/update-imodel-locks/
+   * already existing ones. Wraps the {@link https://developer.bentley.com/apis/imodels-v2/operations/update-imodel-locks/
    * Update iModel Locks} operation from iModels API.
    * @param {UpdateLockParams} params parameters for this operation. See {@link UpdateLockParams}.
    * @returns {Promise<Lock>} updated Lock. See {@link Lock}.

--- a/clients/imodels-client-management/src/Constants.ts
+++ b/clients/imodels-client-management/src/Constants.ts
@@ -5,7 +5,7 @@
 export class Constants {
   public static api = {
     baseUrl: "https://api.bentley.com/imodels",
-    version: "itwin-platform.v1"
+    version: "itwin-platform.v2"
   };
 
   public static headers = {

--- a/clients/imodels-client-management/src/base/types/CommonInterfaces.ts
+++ b/clients/imodels-client-management/src/base/types/CommonInterfaces.ts
@@ -42,7 +42,7 @@ export interface AuthorizationParam {
 
 /**
  * Common parameters for iModel scoped operations. All operations exposed in this client are iModel scoped
- * except for {@link https://developer.bentley.com/apis/imodels/operations/get-project-imodels/ Get Project iModels}.
+ * except for {@link https://developer.bentley.com/apis/imodels-v2/operations/get-itwin-imodels/ Get iTwin iModels}.
  */
 export interface IModelScopedOperationParams extends AuthorizationParam {
   /** iModel id. */

--- a/clients/imodels-client-management/src/base/types/CommonInterfaces.ts
+++ b/clients/imodels-client-management/src/base/types/CommonInterfaces.ts
@@ -18,7 +18,7 @@ export interface ApiOptions {
 export interface Authorization {
   /**
    * Authentication scheme. For information on supported authentication schemes see
-   * {@link https://developer.bentley.com/apis/imodels/operations/get-imodel-details/#authentication iModels API documenation}.
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/get-imodel-details/#authentication iModels API documenation}.
    */
   scheme: string;
   /** Access token. */

--- a/clients/imodels-client-management/src/base/types/IModelsErrorInterfaces.ts
+++ b/clients/imodels-client-management/src/base/types/IModelsErrorInterfaces.ts
@@ -30,7 +30,7 @@ export enum IModelsErrorCode {
   VersionExists = "NamedVersionExists",
   ChangesetExists = "ChangesetExists",
   NamedVersionOnChangesetExists = "NamedVersionOnChangesetExists",
-  ProjectNotFound = "ProjectNotFound",
+  ITwinNotFound = "iTwinNotFound",
   IModelNotFound = "iModelNotFound",
   NamedVersionNotFound = "NamedVersionNotFound",
   ChangesetNotFound = "ChangesetNotFound",

--- a/clients/imodels-client-management/src/base/types/apiEntities/IModelInterfaces.ts
+++ b/clients/imodels-client-management/src/base/types/apiEntities/IModelInterfaces.ts
@@ -77,8 +77,8 @@ export interface IModel extends MinimalIModel {
   state: IModelState;
   /** Datetime string of when the iModel was created. */
   createdDateTime: string;
-  /** Id of the Project that the iModel belongs to. */
-  projectId: string;
+  /** Id of the iTwin that the iModel belongs to. */
+  iTwinId: string;
   /** iModel extent. See {@link Extent}. */
   extent: Extent | null;
   /** iModel links. See {@link IModelLinks}.*/

--- a/clients/imodels-client-management/src/base/types/apiEntities/UserPermissionInterfaces.ts
+++ b/clients/imodels-client-management/src/base/types/apiEntities/UserPermissionInterfaces.ts
@@ -16,16 +16,16 @@ export enum IModelPermission {
   Write = "imodels_write",
   /**
    * Allows to create an iModel. Allows to configure access per iModel. Allows to manage Locks or local copies
-   * for the entire iModel. This Permission is both iModel and Project level Permission, but Create iModel operation
-   * requires that user has `imodels_manage` Permission on the Project level. Use
-   * {@link https://developer.bentley.com/apis/projects/ Projects API} to check if user can create an iModel on a
-   * given Project.
+   * for the entire iModel. This Permission is both iModel and iTwin level Permission, but Create iModel operation
+   * requires that user has `imodels_manage` Permission on the iTwin level. Use
+   * {@link https://developer.bentley.com/apis/access-control/operations/get-itwin-permissions/ Access Control API}
+   * to check if user can create an iModel on a given iTwin.
    */
   Manage = "imodels_manage",
   /**
-   * Allows to delete an iModel. This Permission is only available on the Project level. Use
-   * {@link https://developer.bentley.com/apis/projects/ Projects API} to check if user can delete iModels on a given
-   * Project. */
+   * Allows to delete an iModel. This Permission is only available on the iTwin level. Use
+   * {@link https://developer.bentley.com/apis/access-control/operations/get-itwin-permissions/ Access Control API}
+   * to check if user can delete iModels on a given iTwin. */
   Delete = "imodels-delete"
 }
 

--- a/clients/imodels-client-management/src/operations/briefcase/BriefcaseOperations.ts
+++ b/clients/imodels-client-management/src/operations/briefcase/BriefcaseOperations.ts
@@ -21,7 +21,7 @@ export class BriefcaseOperations<TOptions extends OperationOptions> extends Oper
   /**
    * Gets Briefcases of a specific iModel. This method returns Briefcases in their minimal representation. The returned iterator
    * internally queries entities in pages. Wraps the
-   * {@link https://developer.bentley.com/apis/imodels/operations/get-imodel-briefcases/ Get iModel Briefcases}
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/get-imodel-briefcases/ Get iModel Briefcases}
    * operation from iModels API.
    * @param {GetBriefcaseListParams} params parameters for this operation. See {@link GetBriefcaseListParams}.
    * @returns {EntityListIterator<MinimalBriefcase>} iterator for Briefcase list. See {@link EntityListIterator},
@@ -39,7 +39,7 @@ export class BriefcaseOperations<TOptions extends OperationOptions> extends Oper
   /**
    * Gets Briefcases of a specific iModel. This method returns Briefcases in their full representation. The returned iterator
    * internally queries entities in pages. Wraps the
-   * {@link https://developer.bentley.com/apis/imodels/operations/get-imodel-briefcases/ Get iModel Briefcases}
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/get-imodel-briefcases/ Get iModel Briefcases}
    * operation from iModels API.
    * @param {GetBriefcaseListParams} params parameters for this operation. See {@link GetBriefcaseListParams}.
    * @returns {EntityListIterator<Briefcase>} iterator for Briefcase list. See {@link EntityListIterator}, {@link Briefcase}.
@@ -61,7 +61,7 @@ export class BriefcaseOperations<TOptions extends OperationOptions> extends Oper
 
   /**
    * Gets a single Briefcase by its id. This method returns a Briefcase in its full representation. Wraps the
-   * {@link https://developer.bentley.com/apis/imodels/operations/get-imodel-briefcase-details/ Get iModel Briefcase}
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/get-imodel-briefcase-details/ Get iModel Briefcase}
    * operation from iModels API.
    * @param {GetSingleBriefcaseParams} params parameters for this operation. See {@link GetSingleBriefcaseParams}.
    * @returns {Promise<Briefcase>} an Briefcase with specified id. See {@link iModel}.

--- a/clients/imodels-client-management/src/operations/changeset/ChangesetOperations.ts
+++ b/clients/imodels-client-management/src/operations/changeset/ChangesetOperations.ts
@@ -21,7 +21,7 @@ export class ChangesetOperations<TOptions extends OperationOptions> extends Oper
   /**
    * Gets Changesets for a specific iModel. This method returns Changesets in their minimal representation. The
    * returned iterator internally queries entities in pages. Wraps the
-   * {@link https://developer.bentley.com/apis/imodels/operations/get-imodel-changesets/ Get iModel Changesets}
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/get-imodel-changesets/ Get iModel Changesets}
    * operation from iModels API.
    * @param {GetChangesetListParams} params parameters for this operation. See {@link GetChangesetListParams}.
    * @returns {EntityListIterator<MinimalChangeset>} iterator for Changeset list. See {@link EntityListIterator},
@@ -45,7 +45,7 @@ export class ChangesetOperations<TOptions extends OperationOptions> extends Oper
   /**
    * Gets Changesets for a specific iModel. This method returns Changesets in their full representation. The returned
    * iterator internally queries entities in pages. Wraps the
-   * {@link https://developer.bentley.com/apis/imodels/operations/get-imodel-changesets/ Get iModel Changesets}
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/get-imodel-changesets/ Get iModel Changesets}
    * operation from iModels API.
    * @param {GetChangesetListParams} params parameters for this operation. See {@link GetChangesetListParams}.
    * @returns {EntityListIterator<Changeset>} iterator for Changeset list. See {@link EntityListIterator},
@@ -68,7 +68,7 @@ export class ChangesetOperations<TOptions extends OperationOptions> extends Oper
 
   /**
    * Gets a single Changeset identified by either index or id. This method returns a Changeset in its full
-   * representation. Wraps the {@link https://developer.bentley.com/apis/imodels/operations/get-imodel-changeset-details/
+   * representation. Wraps the {@link https://developer.bentley.com/apis/imodels-v2/operations/get-imodel-changeset-details/
    * Get iModel Changeset} operation from iModels API.
    * @param {GetSingleChangesetParams} params parameters for this operation. See {@link GetSingleChangesetParams}.
    * @returns {Promise<Changeset>} a Changeset with specified id or index. See {@link Changeset}.

--- a/clients/imodels-client-management/src/operations/checkpoint/CheckpointOperations.ts
+++ b/clients/imodels-client-management/src/operations/checkpoint/CheckpointOperations.ts
@@ -12,8 +12,8 @@ export class CheckpointOperations<TOptions extends OperationOptions> extends Ope
   /**
    * Gets a single Checkpoint generated either on a specific Changeset or for a specific Named Version. This method
    * returns a Checkpoint in its full representation. Wraps
-   * {@link https://developer.bentley.com/apis/imodels/operations/get-changeset-checkpoint/ Get Changeset Checkpoint}
-   * and {@link https://developer.bentley.com/apis/imodels/operations/get-named-version-checkpoint/
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/get-changeset-checkpoint/ Get Changeset Checkpoint}
+   * and {@link https://developer.bentley.com/apis/imodels-v2/operations/get-named-version-checkpoint/
    * Get Named Version Checkpoint} operations from iModels API.
    * @param {GetSingleCheckpointParams} params parameters for this operation. See {@link GetSingleCheckpointParams}.
    * @returns {Promise<Checkpoint>} a Checkpoint for the specified parent entity. See {@link Checkpoint}.

--- a/clients/imodels-client-management/src/operations/imodel/IModelOperationParams.ts
+++ b/clients/imodels-client-management/src/operations/imodel/IModelOperationParams.ts
@@ -16,8 +16,8 @@ export enum IModelOrderByProperty {
 export interface GetIModelListUrlParams extends CollectionRequestParams {
   /** Specifies in what order should entities be returned. See {@link OrderBy}. */
   $orderBy?: OrderBy<IModel, IModelOrderByProperty>;
-  /** Filters iModels for a specific project. */
-  projectId: string;
+  /** Filters iModels for a specific iTwin. */
+  iTwinId: string;
   /** Filters iModels with a specific name. */
   name?: string;
 }
@@ -33,10 +33,10 @@ export type GetSingleIModelParams = IModelScopedOperationParams;
 
 /** Properties that should be specified when creating a new iModel. */
 export interface IModelProperties {
-  /** Project which will own the iModel. Project id must not be an empty or whitespace string. */
-  projectId: string;
+  /** iTwin to which iModel will belong to. iTwinId id must not be an empty or whitespace string. */
+  iTwinId: string;
   /**
-   * iModel name. iModel name must be unique within the project, not exceed allowed 255 characters and not be an
+   * iModel name. iModel name must be unique within the iTwin, not exceed allowed 255 characters and not be an
    * empty or whitespace string.
    */
   name: string;
@@ -80,7 +80,7 @@ export interface CreateIModelFromTemplateParams extends AuthorizationParam {
 
 export interface EditableIModelProperties {
   /**
-   * iModel name. iModel name must be unique within the project, not exceed allowed 255 characters and not be an
+   * iModel name. iModel name must be unique within the iTwin, not exceed allowed 255 characters and not be an
    * empty or whitespace string.
    */
   name: string;

--- a/clients/imodels-client-management/src/operations/imodel/IModelOperations.ts
+++ b/clients/imodels-client-management/src/operations/imodel/IModelOperations.ts
@@ -10,8 +10,8 @@ import { CreateEmptyIModelParams, CreateIModelFromTemplateParams, DeleteIModelPa
 
 export class IModelOperations<TOptions extends OperationOptions> extends OperationsBase<TOptions> {
   /**
-   * Gets iModels for a specific project. This method returns iModels in their minimal representation. The returned iterator
-   * internally queries entities in pages. Wraps the {@link https://developer.bentley.com/apis/imodels/operations/get-project-imodels/ Get Project iModels}
+   * Gets iModels for a specific iTwin. This method returns iModels in their minimal representation. The returned iterator
+   * internally queries entities in pages. Wraps the {@link https://developer.bentley.com/apis/imodels-v2/operations/get-itwin-imodels/ Get iTwin iModels}
    * operation from iModels API.
    * @param {GetiModelListParams} params parameters for this operation. See {@link GetiModelListParams}.
    * @returns {EntityListIterator<MinimaliModel>} iterator for iModel list. See {@link EntityListIterator}, {@link MinimaliModel}.
@@ -26,8 +26,8 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
   }
 
   /**
-   * Gets iModels for a specific project. This method returns iModels in their full representation. The returned iterator
-   * internally queries entities in pages. Wraps the {@link https://developer.bentley.com/apis/imodels/operations/get-project-imodels/ Get Project iModels}
+   * Gets iModels for a specific iTwin. This method returns iModels in their full representation. The returned iterator
+   * internally queries entities in pages. Wraps the {@link https://developer.bentley.com/apis/imodels-v2/operations/get-itwin-imodels/ Get iTwin iModels}
    * operation from iModels API.
    * @param {GetiModelListParams} params parameters for this operation. See {@link GetiModelListParams}.
    * @returns {EntityListIterator<iModel>} iterator for iModel list. See {@link EntityListIterator}, {@link iModel}.
@@ -124,7 +124,7 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
 
   protected getCreateEmptyIModelRequestBody(iModelProperties: IModelProperties): object {
     return {
-      projectId: iModelProperties.projectId,
+      iTwinId: iModelProperties.iTwinId,
       name: iModelProperties.name,
       description: iModelProperties.description,
       extent: iModelProperties.extent

--- a/clients/imodels-client-management/src/operations/imodel/IModelOperations.ts
+++ b/clients/imodels-client-management/src/operations/imodel/IModelOperations.ts
@@ -43,7 +43,7 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
 
   /**
    * Gets a single iModel by its id. This method returns an iModel in its full representation. Wraps the
-   * {@link https://developer.bentley.com/apis/imodels/operations/get-imodel-details/ Get iModel} operation from iModels API.
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/get-imodel-details/ Get iModel} operation from iModels API.
    * @param {GetSingleiModelParams} params parameters for this operation. See {@link GetSingleiModelParams}.
    * @returns {Promise<iModel>} an iModel with specified id. See {@link iModel}.
    */
@@ -57,7 +57,7 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
 
   /**
    * Creates an empty iModel with specified properties. Wraps the
-   * {@link https://developer.bentley.com/apis/imodels/operations/create-imodel/ Create iModel} operation from iModels API.
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/create-imodel/ Create iModel} operation from iModels API.
    * @param {CreateEmptyiModelParams} params parameters for this operation. See {@link CreateEmptyiModelParams}.
    * @returns {Promise<iModel>} newly created iModel. See {@link iModel}.
    */
@@ -68,7 +68,7 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
 
   /**
    * Creates an iModel from a template. Wraps the
-   * {@link https://developer.bentley.com/apis/imodels/operations/create-imodel/ Create iModel} operation from iModels API.
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/create-imodel/ Create iModel} operation from iModels API.
    * It uses the `template` request body property to specify the source iModel which will be used as a template. Internally
    * this method creates the iModel instance and then repeatedly queries the iModel state until the iModel is initialized.
    * The execution of this method can take up to several minutes due to waiting for initialization to complete.
@@ -95,7 +95,7 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
 
   /**
    * Updates iModel properties. Wraps the
-   * {@link https://developer.bentley.com/apis/imodels/operations/update-imodel/ Update iModel} operation from iModels API.
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/update-imodel/ Update iModel} operation from iModels API.
    * @param {UpdateIModelParams} params parameters for this operation. See {@link UpdateIModelParams}.
    * @returns {Promise<IModel>} updated iModel. See {@link IModel}.
    */
@@ -110,7 +110,7 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
   }
 
   /**
-   * Deletes an iModel with specified id. Wraps the {@link https://developer.bentley.com/apis/imodels/operations/delete-imodel/ Delete iModel}
+   * Deletes an iModel with specified id. Wraps the {@link https://developer.bentley.com/apis/imodels-v2/operations/delete-imodel/ Delete iModel}
    * operation from iModels API.
    * @param {DeleteiModelParams} params parameters for this operation. See {@link DeleteiModelParams}.
    * @returns {Promise<void>} a promise that resolves after operation completes.

--- a/clients/imodels-client-management/src/operations/named-version/NamedVersionOperations.ts
+++ b/clients/imodels-client-management/src/operations/named-version/NamedVersionOperations.ts
@@ -21,7 +21,7 @@ export class NamedVersionOperations<TOptions extends OperationOptions> extends O
   /**
    * Gets Named Versions of a specific iModel. This method returns Named Versions in their minimal representation. The
    * returned iterator internally queries entities in pages. Wraps the
-   * {@link https://developer.bentley.com/apis/imodels/operations/get-imodel-named-versions/ Get iModel Named Versions}
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/get-imodel-named-versions/ Get iModel Named Versions}
    * operation from iModels API.
    * @param {GetNamedVersionListParams} params parameters for this operation. See {@link GetNamedVersionListParams}.
    * @returns {EntityListIterator<MinimalNamedVersion>} iterator for Named Version list. See {@link EntityListIterator},
@@ -39,7 +39,7 @@ export class NamedVersionOperations<TOptions extends OperationOptions> extends O
   /**
    * Gets Named Versions of a specific iModel. This method returns Named Versions in their full representation. The
    * returned iterator internally queries entities in pages. Wraps the
-   * {@link https://developer.bentley.com/apis/imodels/operations/get-imodel-named-versions/
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/get-imodel-named-versions/
    * Get iModel Named Versions} operation from iModels API.
    * @param {GetNamedVersionListParams} params parameters for this operation. See {@link GetNamedVersionListParams}.
    * @returns {EntityListIterator<NamedVersion>} iterator for Named Version list. See {@link EntityListIterator},
@@ -62,7 +62,7 @@ export class NamedVersionOperations<TOptions extends OperationOptions> extends O
 
   /**
    * Gets a single Named Version by its id. This method returns a Named Version in its full representation. Wraps the
-   * {@link https://developer.bentley.com/apis/imodels/operations/get-imodel-named-version-details/
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/get-imodel-named-version-details/
    * Get iModel Named Version} operation from iModels API.
    * @param {GetSingleNamedVersionParams} params parameters for this operation. See {@link GetSingleNamedVersionParams}.
    * @returns {Promise<NamedVersion>} a Named Version with specified id. See {@link NamedVersion}.
@@ -78,7 +78,7 @@ export class NamedVersionOperations<TOptions extends OperationOptions> extends O
 
   /**
    * Creates a Named Version with specified properties. Wraps the
-   * {@link https://developer.bentley.com/apis/imodels/operations/create-imodel-named-version/
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/create-imodel-named-version/
    * Create iModel Named Version} operation from iModels API.
    * @param {CreateNamedVersionParams} params parameters for this operation. See {@link CreateNamedVersionParams}.
    * @returns {Promise<NamedVersion>} newly created Named Version. See {@link NamedVersion}.
@@ -96,7 +96,7 @@ export class NamedVersionOperations<TOptions extends OperationOptions> extends O
 
   /**
    * Updates Named Version with specified properties. Wraps the
-   * {@link https://developer.bentley.com/apis/imodels/operations/update-imodel-named-version/
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/update-imodel-named-version/
    * Update iModel Named Version} operation from iModels API.
    * @param {UpdateNamedVersionParams} params parameters for this operation. See {@link UpdateNamedVersionParams}.
    * @returns {Promise<NamedVersion>} updated Named Version. See {@link NamedVersion}.

--- a/clients/imodels-client-management/src/operations/thumbnail/ThumbnailOperations.ts
+++ b/clients/imodels-client-management/src/operations/thumbnail/ThumbnailOperations.ts
@@ -12,7 +12,7 @@ export class ThumbnailOperations<TOptions extends OperationOptions> extends Oper
   /**
    * Downloads a thumbnail for a specific iModel. The Thumbnail returned is either a default one or a custom
    * uploaded one. Wraps the
-   * {@link https://developer.bentley.com/apis/imodels/operations/get-imodel-thumbnail/ Download iModel Thumbnail}
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/get-imodel-thumbnail/ Download iModel Thumbnail}
    * operation from iModels API.
    * @param {DownloadThumbnailParams} params parameters for this operation. See {@link DownloadThumbnailParams}.
    * @returns {Promise<Thumbnail>} downloaded Thumbnail. See {@link Thumbnail}. The method returns the data in binary
@@ -47,7 +47,7 @@ export class ThumbnailOperations<TOptions extends OperationOptions> extends Oper
 
   /**
    * Uploads a custom iModel Thumbnail. Wraps the
-   * {@link https://developer.bentley.com/apis/imodels/operations/upload-imodel-thumbnail/ Upload iModel Thumbnail}
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/upload-imodel-thumbnail/ Upload iModel Thumbnail}
    * operation from iModels API.
    * @param {UploadThumbnailParams} params parameters for this operation. See {@link UploadThumbnailParams}.
    * @returns {Promise<void>} a promise that resolves after operation completes.

--- a/clients/imodels-client-management/src/operations/user-permission/UserPermissionOperations.ts
+++ b/clients/imodels-client-management/src/operations/user-permission/UserPermissionOperations.ts
@@ -13,8 +13,8 @@ export class UserPermissionOperations<TOptions extends OperationOptions> extends
    * Retrieves Permissions the current user has for the specified iModel. The current user is determined based on
    * passed authorization information. Wraps the
    * {@link https://developer.bentley.com/apis/imodels/operations/get-imodel-user-permissions/ Get iModel User Permissions}
-   * operation from iModels API. iModels Permissions may be configured on a Project level or an iModel level.
-   * This operation will return Permissions configured for this specific iModel or Project Permissions if iModel
+   * operation from iModels API. iModels Permissions may be configured on a iTwin level or an iModel level.
+   * This operation will return Permissions configured for this specific iModel or iTwin Permissions if iModel
    * Permissions are not configured.
    * @param {GetUserPermissionsParams} params parameters for this operation. See {@link GetUserPermissionsParams}.
    * @returns {Promise<UserPermissions>} User Permissions. See {@link UserPermissions}.

--- a/clients/imodels-client-management/src/operations/user-permission/UserPermissionOperations.ts
+++ b/clients/imodels-client-management/src/operations/user-permission/UserPermissionOperations.ts
@@ -12,7 +12,7 @@ export class UserPermissionOperations<TOptions extends OperationOptions> extends
   /**
    * Retrieves Permissions the current user has for the specified iModel. The current user is determined based on
    * passed authorization information. Wraps the
-   * {@link https://developer.bentley.com/apis/imodels/operations/get-imodel-user-permissions/ Get iModel User Permissions}
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/get-imodel-user-permissions/ Get iModel User Permissions}
    * operation from iModels API. iModels Permissions may be configured on a iTwin level or an iModel level.
    * This operation will return Permissions configured for this specific iModel or iTwin Permissions if iModel
    * Permissions are not configured.

--- a/clients/imodels-client-management/src/operations/user/UserOperations.ts
+++ b/clients/imodels-client-management/src/operations/user/UserOperations.ts
@@ -11,7 +11,7 @@ import { GetSingleUserParams, GetUserListParams } from "./UserOperationParams";
 export class UserOperations<TOptions extends OperationOptions> extends OperationsBase<TOptions> {
   /** Gets Users who have ever been connected to the iModel specified by the iModel id. This method returns Users in
    * their minimal representation. The returned iterator internally queries entities in pages. Wraps the
-   * {@link https://developer.bentley.com/apis/imodels/operations/get-imodel-users/ Get iModel Users}
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/get-imodel-users/ Get iModel Users}
    * operation from iModels API.
    * @param {GetUserListParams} params parameters for this operation. See {@link GetUserListParams}.
    * @returns {EntityListIterator<MinimalUser>} iterator for User list. See {@link EntityListIterator}, {@link MinimalUser}.
@@ -28,7 +28,7 @@ export class UserOperations<TOptions extends OperationOptions> extends Operation
   /**
    * Gets Users who have ever been connected to the iModel specified by the iModel id. This method returns Users in their
    * full representation. The returned iterator internally queries entities in pages. Wraps the
-   * {@link https://developer.bentley.com/apis/imodels/operations/get-imodel-users/ Get iModel Users}
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/get-imodel-users/ Get iModel Users}
    * operation from iModels API.
    * @param {GetUserListParams} params parameters for this operation. See {@link GetUserListParams}.
    * @returns {EntityListIterator<User>} iterator for User list. See {@link EntityListIterator}, {@link User}.
@@ -44,7 +44,7 @@ export class UserOperations<TOptions extends OperationOptions> extends Operation
 
   /**
    * Gets a single User by its id. This method returns a User in its full representation. Wraps the
-   * {@link https://developer.bentley.com/apis/imodels/operations/get-imodel-user-details/ Get iModel User}
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/get-imodel-user-details/ Get iModel User}
    * operation from iModels API.
    * @param {GetSingleUserParams} params parameters for this operation. See {@link GetSingleUserParams}.
    * @returns {Promise<User>} a User with specified id. See {@link User}.

--- a/common/config/azure-pipelines/build-test-publish.yml
+++ b/common/config/azure-pipelines/build-test-publish.yml
@@ -31,7 +31,7 @@ jobs:
     pool:
         vmImage: $(imageName)
     variables:
-      - group: iModels Clients - Integration Tests - DEV
+      - group: iModels Clients V3 - Integration Tests - DEV
     workspace:
       clean: all
 

--- a/common/config/azure-pipelines/build-test-publish.yml
+++ b/common/config/azure-pipelines/build-test-publish.yml
@@ -31,7 +31,7 @@ jobs:
     pool:
         vmImage: $(imageName)
     variables:
-      - group: iModels Clients V3 - Integration Tests - DEV
+      - group: iModels Clients 3.0 - Integration Tests - DEV
     workspace:
       clean: all
 

--- a/common/config/azure-pipelines/build-test.yml
+++ b/common/config/azure-pipelines/build-test.yml
@@ -27,7 +27,7 @@ jobs:
     pool:
         vmImage: $(imageName)
     variables:
-      - group: iModels Clients V3 - Integration Tests - DEV
+      - group: iModels Clients 3.0 - Integration Tests - DEV
     workspace:
       clean: all
 

--- a/common/config/azure-pipelines/build-test.yml
+++ b/common/config/azure-pipelines/build-test.yml
@@ -27,7 +27,7 @@ jobs:
     pool:
         vmImage: $(imageName)
     variables:
-      - group: iModels Clients - Integration Tests - DEV
+      - group: iModels Clients V3 - Integration Tests - DEV
     workspace:
       clean: all
 

--- a/common/config/azure-pipelines/templates/build-test.yml
+++ b/common/config/azure-pipelines/templates/build-test.yml
@@ -34,44 +34,32 @@ steps:
     displayName: npm run test:integration (@itwin/imodels-client-management and @itwin/imodels-client-authoring tests)
     workingDirectory: tests/imodels-clients-tests
     env:
-      AUTH_CLIENT_ID: $(AUTH_CLIENT_ID)
       AUTH_CLIENT_SECRET: $(AUTH_CLIENT_SECRET)
-      TEST_USERS_ADMIN1_EMAIL: $(TEST_USERS_ADMIN1_EMAIL)
       TEST_USERS_ADMIN1_PASSWORD: $(TEST_USERS_ADMIN1_PASSWORD)
-      TEST_USERS_ADMIN2_FULLY_FEATURED_EMAIL: $(TEST_USERS_ADMIN2_FULLY_FEATURED_EMAIL)
       TEST_USERS_ADMIN2_FULLY_FEATURED_PASSWORD: $(TEST_USERS_ADMIN2_FULLY_FEATURED_PASSWORD)
 
   - script: npm run test:integration
     displayName: npm run test:integration (@itwin/imodels-client-management and @itwin/imodels-client-authoring browser tests)
     workingDirectory: tests/imodels-clients-tests-browser
     env:
-      AUTH_CLIENT_ID: $(AUTH_CLIENT_ID)
       AUTH_CLIENT_SECRET: $(AUTH_CLIENT_SECRET)
-      TEST_USERS_ADMIN1_EMAIL: $(TEST_USERS_ADMIN1_EMAIL)
       TEST_USERS_ADMIN1_PASSWORD: $(TEST_USERS_ADMIN1_PASSWORD)
-      TEST_USERS_ADMIN2_FULLY_FEATURED_EMAIL: $(TEST_USERS_ADMIN2_FULLY_FEATURED_EMAIL)
       TEST_USERS_ADMIN2_FULLY_FEATURED_PASSWORD: $(TEST_USERS_ADMIN2_FULLY_FEATURED_PASSWORD)
 
   - script: npm run test:integration
     displayName: npm run test:integration (@itwin/imodels-access-frontend tests)
     workingDirectory: tests/imodels-access-frontend-tests
     env:
-      AUTH_CLIENT_ID: $(AUTH_CLIENT_ID)
       AUTH_CLIENT_SECRET: $(AUTH_CLIENT_SECRET)
-      TEST_USERS_ADMIN1_EMAIL: $(TEST_USERS_ADMIN1_EMAIL)
       TEST_USERS_ADMIN1_PASSWORD: $(TEST_USERS_ADMIN1_PASSWORD)
-      TEST_USERS_ADMIN2_FULLY_FEATURED_EMAIL: $(TEST_USERS_ADMIN2_FULLY_FEATURED_EMAIL)
       TEST_USERS_ADMIN2_FULLY_FEATURED_PASSWORD: $(TEST_USERS_ADMIN2_FULLY_FEATURED_PASSWORD)
 
   - script: npm run test:integration
     displayName: npm run test:integration (@itwin/imodels-access-backend tests)
     workingDirectory: tests/imodels-access-backend-tests
     env:
-      AUTH_CLIENT_ID: $(AUTH_CLIENT_ID)
       AUTH_CLIENT_SECRET: $(AUTH_CLIENT_SECRET)
-      TEST_USERS_ADMIN1_EMAIL: $(TEST_USERS_ADMIN1_EMAIL)
       TEST_USERS_ADMIN1_PASSWORD: $(TEST_USERS_ADMIN1_PASSWORD)
-      TEST_USERS_ADMIN2_FULLY_FEATURED_EMAIL: $(TEST_USERS_ADMIN2_FULLY_FEATURED_EMAIL)
       TEST_USERS_ADMIN2_FULLY_FEATURED_PASSWORD: $(TEST_USERS_ADMIN2_FULLY_FEATURED_PASSWORD)
 
   - script: node common/scripts/install-run-rush.js publish --pack --include-all --publish

--- a/docs/IModelsClientAuthoring.md
+++ b/docs/IModelsClientAuthoring.md
@@ -49,7 +49,7 @@ Since the `@itwin/imodels-client-authoring` package extends the `@itwin/imodels-
 const iModelIterator: EntityListIterator<MinimalIModel> = iModelsClient.iModels.getMinimalList({
   authorization: AccessTokenAdapter.toAuthorizationCallback(await IModelHost.getAccessToken()),
   urlParams: {
-    projectId: "8a1fcd73-8c23-460d-a392-8b4afc00affc"
+    iTwinId: "8a1fcd73-8c23-460d-a392-8b4afc00affc"
   }
 });
 ```
@@ -64,7 +64,7 @@ async function createIModelFromBaselineFile(): Promise<void> {
   const iModel: IModel = await iModelsClient.iModels.createFromBaseline({
     authorization: () => getAuthorization(),
     iModelProperties: {
-      projectId: "8a1fcd73-8c23-460d-a392-8b4afc00affc",
+      iTwinId: "8a1fcd73-8c23-460d-a392-8b4afc00affc",
       name: "Sun City Renewable-energy Plant",
       description: "Overall model of wind and solar farms in Sun City",
       filePath: "D:\\imodels\\sun-city.bim"

--- a/docs/IModelsClientManagement.md
+++ b/docs/IModelsClientManagement.md
@@ -20,7 +20,7 @@
 
 ## Key methods
 - [`IModelsClient.iModels`](../clients/imodels-client-management/src/IModelsClient.ts#L45)
-  - [`getMinimalList(params: GetIModelListParams): EntityListIterator<MinimalIModel>`](../clients/imodels-client-management/src/operations/imodel/IModelOperations.ts#L19) ([sample](#get-all-project-imodels))
+  - [`getMinimalList(params: GetIModelListParams): EntityListIterator<MinimalIModel>`](../clients/imodels-client-management/src/operations/imodel/IModelOperations.ts#L19) ([sample](#get-all-iTwin-imodels))
   - [`getRepresentationList(params: GetIModelListParams): EntityListIterator<IModel>`](../clients/imodels-client-management/src/operations/imodel/IModelOperations.ts#L35)
   - [`getSingle(params: GetSingleIModelParams): Promise<IModel>`](../clients/imodels-client-management/src/operations/imodel/IModelOperations.ts#L50)
   - [`createEmpty(params: CreateEmptyIModelParams): Promise<IModel>`](../clients/imodels-client-management/src/operations/imodel/IModelOperations.ts#L64)
@@ -60,22 +60,22 @@
 const iModelIterator: EntityListIterator<MinimalIModel> = iModelsClient.iModels.getMinimalList({
   authorization: AccessTokenAdapter.toAuthorizationCallback(await IModelApp.getAccessToken()),
   urlParams: {
-    projectId: "8a1fcd73-8c23-460d-a392-8b4afc00affc"
+    iTwinId: "8a1fcd73-8c23-460d-a392-8b4afc00affc"
   }
 });
 ```
 
-### Get all project iModels
+### Get all iTwin iModels
 ```typescript
 import { Authorization, EntityListIterator, IModelsClient, MinimalIModel } from "@itwin/imodels-client-management";
 
-/** Function that queries all iModels for a particular project and prints their ids to the console. */
+/** Function that queries all iModels for a particular iTwinId and prints their ids to the console. */
 async function printiModelIds(): Promise<void> {
   const iModelsClient: IModelsClient = new IModelsClient();
   const iModelIterator: EntityListIterator<MinimalIModel> = iModelsClient.iModels.getMinimalList({
     authorization: () => getAuthorization(),
     urlParams: {
-      projectId: "8a1fcd73-8c23-460d-a392-8b4afc00affc"
+      iTwinId: "8a1fcd73-8c23-460d-a392-8b4afc00affc"
     }
   });
 
@@ -99,7 +99,7 @@ async function getiModel(): Promise<IModel | undefined> {
   const iModelIterator: EntityListIterator<IModel> = iModelsClient.iModels.getRepresentationList({
     authorization: () => getAuthorization(),
     urlParams: {
-      projectId: "8a1fcd73-8c23-460d-a392-8b4afc00affc",
+      iTwinId: "8a1fcd73-8c23-460d-a392-8b4afc00affc",
       name: "Sun City Renewable-energy Plant",
     }
   });

--- a/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
@@ -337,7 +337,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
     const getIModelListParams: GetIModelListParams = {
       ...this.getAuthorizationParam(arg),
       urlParams: {
-        projectId: arg.iTwinId,
+        iTwinId: arg.iTwinId,
         name: arg.iModelName
       }
     };

--- a/itwin-platform-access/imodels-access-backend/src/interface-adapters/PlatformToClientAdapter.ts
+++ b/itwin-platform-access/imodels-access-backend/src/interface-adapters/PlatformToClientAdapter.ts
@@ -26,7 +26,7 @@ export class PlatformToClientAdapter {
 
   public static toIModelProperties(createNewIModelProps: CreateNewIModelProps): IModelProperties {
     return {
-      projectId: createNewIModelProps.iTwinId,
+      iTwinId: createNewIModelProps.iTwinId,
       name: createNewIModelProps.iModelName,
       description: createNewIModelProps.description
     };

--- a/tests/imodels-access-backend-tests/README.md
+++ b/tests/imodels-access-backend-tests/README.md
@@ -11,7 +11,7 @@ This package contains tests for various classes in the [`@itwin/imodels-access-b
 ## Running tests
 
 - Create `.env` file in the current directory (`./tests/imodels-access-backend-tests`). The following variables should be configured:
-  - `TEST_PROJECT_NAME`
+  - `TEST_ITWIN_NAME`
   - `TEST_IMODEL_NAME`
   - `AUTH_AUTHORITY`
   - `AUTH_CLIENT_ID`
@@ -20,8 +20,8 @@ This package contains tests for various classes in the [`@itwin/imodels-access-b
   - `APIS_IMODELS_BASE_URL`
   - `APIS_IMODELS_VERSION`
   - `APIS_IMODELS_SCOPES`
-  - `APIS_PROJECTS_BASE_URL`
-  - `APIS_PROJECTS_SCOPES`
+  - `APIS_ITWINS_BASE_URL`
+  - `APIS_ITWINS_SCOPES`
   - `TEST_USERS_ADMIN1_EMAIL`
   - `TEST_USERS_ADMIN1_PASSWORD`
   - `TEST_USERS_ADMIN2_FULLY_FEATURED_EMAIL`

--- a/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
+++ b/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
@@ -12,7 +12,7 @@ import { BackendIModelsAccess } from "@itwin/imodels-access-backend";
 import { expect } from "chai";
 
 import { ContainingChanges, IModelsClient, IModelsClientOptions } from "@itwin/imodels-client-authoring";
-import { IModelMetadata, ProgressReport, ReusableIModelMetadata, ReusableTestIModelProvider, TestAuthorizationProvider, TestIModelCreator, TestIModelFileProvider, TestIModelGroup, TestIModelGroupFactory, TestProjectProvider, TestUtilTypes, assertAbortError, assertProgressReports, cleanupDirectory, createGuidValue } from "@itwin/imodels-client-test-utils";
+import { IModelMetadata, ProgressReport, ReusableIModelMetadata, ReusableTestIModelProvider, TestAuthorizationProvider, TestIModelCreator, TestIModelFileProvider, TestIModelGroup, TestIModelGroupFactory, TestITwinProvider, TestUtilTypes, assertAbortError, assertProgressReports, cleanupDirectory, createGuidValue } from "@itwin/imodels-client-test-utils";
 
 import { getTestDIContainer } from "./TestDiContainerProvider";
 
@@ -51,8 +51,8 @@ describe("BackendIModelsAccess", () => {
     accessToken = `${authorization.scheme} ${authorization.token}`;
     IModelHost.authorizationClient = new TestAuthorizationClient(accessToken);
 
-    const testProjectProvider = container.get(TestProjectProvider);
-    iTwinId = await testProjectProvider.getOrCreate();
+    const testITwinProvider = container.get(TestITwinProvider);
+    iTwinId = await testITwinProvider.getOrCreate();
 
     testIModelFileProvider = container.get(TestIModelFileProvider);
 

--- a/tests/imodels-access-frontend-tests/README.md
+++ b/tests/imodels-access-frontend-tests/README.md
@@ -11,7 +11,7 @@ This package contains tests for various classes in the [`@itwin/imodels-access-f
 ## Running tests
 
 - Create `.env` file in the current directory (`./tests/imodels-access-frontend-tests`). The following variables should be configured:
-  - `TEST_PROJECT_NAME`
+  - `TEST_ITWIN_NAME`
   - `TEST_IMODEL_NAME`
   - `AUTH_AUTHORITY`
   - `AUTH_CLIENT_ID`
@@ -20,8 +20,8 @@ This package contains tests for various classes in the [`@itwin/imodels-access-f
   - `APIS_IMODELS_BASE_URL`
   - `APIS_IMODELS_VERSION`
   - `APIS_IMODELS_SCOPES`
-  - `APIS_PROJECTS_BASE_URL`
-  - `APIS_PROJECTS_SCOPES`
+  - `APIS_ITWINS_BASE_URL`
+  - `APIS_ITWINS_SCOPES`
   - `TEST_USERS_ADMIN1_EMAIL`
   - `TEST_USERS_ADMIN1_PASSWORD`
   - `TEST_USERS_ADMIN2_FULLY_FEATURED_EMAIL`

--- a/tests/imodels-clients-tests-browser/src/ThumbnailOperations.test.ts
+++ b/tests/imodels-clients-tests-browser/src/ThumbnailOperations.test.ts
@@ -27,11 +27,11 @@ describe(`[Management] ${ThumbnailOperations.name}`, () => {
 
     testIModelForReadId = Cypress.env(FrontendTestEnvVariableKeys.testIModelForReadId);
 
-    const projectId: string = Cypress.env(FrontendTestEnvVariableKeys.testProjectId);
+    const iTwinId: string = Cypress.env(FrontendTestEnvVariableKeys.testITwinId);
     const testIModelForWrite = await iModelsClient.iModels.createEmpty({
       authorization,
       iModelProperties: {
-        projectId,
+        iTwinId,
         name: "Thumbnail browser tests"
       }
     });

--- a/tests/imodels-clients-tests-browser/src/setup/CypressSetup.ts
+++ b/tests/imodels-clients-tests-browser/src/setup/CypressSetup.ts
@@ -7,7 +7,7 @@ import * as path from "path";
 import { Container } from "inversify";
 
 import { IModelsClientOptions } from "@itwin/imodels-client-management";
-import { ReusableTestIModelProvider, TestAuthorizationProvider, TestProjectProvider, TestUtilBootstrapper, TestUtilTypes } from "@itwin/imodels-client-test-utils";
+import { ReusableTestIModelProvider, TestAuthorizationProvider, TestITwinProvider, TestUtilBootstrapper, TestUtilTypes } from "@itwin/imodels-client-test-utils";
 
 import { FrontendTestEnvVariableKeys } from "./FrontendTestEnvVariableKeys";
 
@@ -23,9 +23,9 @@ export async function setupIntegrationTests(_on: unknown, config: { env: any }):
   const authorizationInfo = await authorizationCallback();
   config.env[FrontendTestEnvVariableKeys.admin1AuthorizationInfo] = JSON.stringify(authorizationInfo);
 
-  const testProjectProvider = container.get(TestProjectProvider);
-  const projectId = await testProjectProvider.getOrCreate();
-  config.env[FrontendTestEnvVariableKeys.testProjectId] = projectId;
+  const testITwinProvider = container.get(TestITwinProvider);
+  const iTwinId = await testITwinProvider.getOrCreate();
+  config.env[FrontendTestEnvVariableKeys.testITwinId] = iTwinId;
 
   const reusableTestIModelProvider = container.get(ReusableTestIModelProvider);
   const testIModelForRead = await reusableTestIModelProvider.getOrCreate();

--- a/tests/imodels-clients-tests-browser/src/setup/FrontendTestEnvVariableKeys.ts
+++ b/tests/imodels-clients-tests-browser/src/setup/FrontendTestEnvVariableKeys.ts
@@ -6,7 +6,7 @@ const frontendTestEnvVariableKeys = {
   iModelsClientApiOptions: "iModelsClientApiOptions",
   admin1AuthorizationInfo: "admin1AuthorizationInfo",
 
-  testProjectId: "testProjectId",
+  testITwinId: "testITwinId",
   testIModelForReadId: "testIModelForReadId",
 
   testPngFilePath: "testPngFilePath"

--- a/tests/imodels-clients-tests/README.md
+++ b/tests/imodels-clients-tests/README.md
@@ -11,7 +11,7 @@ This package contains tests for various classes in the [`@itwin/imodels-client-m
 ## Running tests
 
 - Create `.env` file in the current directory (`./tests/imodels-clients-tests`). The following variables should be configured:
-  - `TEST_PROJECT_NAME`
+  - `TEST_ITWIN_NAME`
   - `TEST_IMODEL_NAME`
   - `AUTH_AUTHORITY`
   - `AUTH_CLIENT_ID`
@@ -20,8 +20,8 @@ This package contains tests for various classes in the [`@itwin/imodels-client-m
   - `APIS_IMODELS_BASE_URL`
   - `APIS_IMODELS_VERSION`
   - `APIS_IMODELS_SCOPES`
-  - `APIS_PROJECTS_BASE_URL`
-  - `APIS_PROJECTS_SCOPES`
+  - `APIS_ITWINS_BASE_URL`
+  - `APIS_ITWINS_SCOPES`
   - `TEST_USERS_ADMIN1_EMAIL`
   - `TEST_USERS_ADMIN1_PASSWORD`
   - `TEST_USERS_ADMIN2_FULLY_FEATURED_EMAIL`

--- a/tests/imodels-clients-tests/src/integration/authoring/IModelOperations.test.ts
+++ b/tests/imodels-clients-tests/src/integration/authoring/IModelOperations.test.ts
@@ -3,14 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { AuthorizationCallback, CreateIModelFromBaselineParams, IModel, IModelsClient, IModelsClientOptions } from "@itwin/imodels-client-authoring";
-import { TestAuthorizationProvider, TestIModelFileProvider, TestIModelGroup, TestIModelGroupFactory, TestProjectProvider, TestUtilTypes, assertIModel } from "@itwin/imodels-client-test-utils";
+import { TestAuthorizationProvider, TestIModelFileProvider, TestIModelGroup, TestIModelGroupFactory, TestITwinProvider, TestUtilTypes, assertIModel } from "@itwin/imodels-client-test-utils";
 
 import { Constants, getTestDIContainer, getTestRunId } from "../common";
 
 describe("[Authoring] IModelOperations", () => {
   let iModelsClient: IModelsClient;
   let authorization: AuthorizationCallback;
-  let projectId: string;
+  let iTwinId: string;
 
   let testIModelFileProvider: TestIModelFileProvider;
   let testIModelGroup: TestIModelGroup;
@@ -24,8 +24,8 @@ describe("[Authoring] IModelOperations", () => {
     const authorizationProvider = container.get(TestAuthorizationProvider);
     authorization = authorizationProvider.getAdmin1Authorization();
 
-    const testProjectProvider = container.get(TestProjectProvider);
-    projectId = await testProjectProvider.getOrCreate();
+    const testITwinProvider = container.get(TestITwinProvider);
+    iTwinId = await testITwinProvider.getOrCreate();
 
     testIModelFileProvider = container.get(TestIModelFileProvider);
 
@@ -42,7 +42,7 @@ describe("[Authoring] IModelOperations", () => {
     const createIModelParams: CreateIModelFromBaselineParams = {
       authorization,
       iModelProperties: {
-        projectId,
+        iTwinId,
         name: testIModelGroup.getPrefixedUniqueIModelName("Sample iModel from baseline"),
         filePath: testIModelFileProvider.iModel.filePath
       }

--- a/tests/imodels-clients-tests/src/integration/common/GlobalSetup.test.ts
+++ b/tests/imodels-clients-tests/src/integration/common/GlobalSetup.test.ts
@@ -15,17 +15,17 @@ export function getTestRunId(): string {
 }
 
 before(async () => {
-  await cleanupIModelsInTestProject();
+  await cleanupTestRuniModels();
   createDirectory(Constants.TestDownloadDirectoryPath);
   await cleanupDirectory(Constants.TestDownloadDirectoryPath);
 });
 
 after(async () => {
-  await cleanupIModelsInTestProject();
+  await cleanupTestRuniModels();
   await cleanupDirectory(Constants.TestDownloadDirectoryPath);
 });
 
-async function cleanupIModelsInTestProject(): Promise<void> {
+async function cleanupTestRuniModels(): Promise<void> {
   const container = getTestDIContainer();
   const testIModelGroupFactory = container.get(TestIModelGroupFactory);
   const testIModelGroup = testIModelGroupFactory.create({ testRunId: getTestRunId(), packageName: Constants.PackagePrefix });

--- a/tests/imodels-clients-tests/src/integration/management/IModelOperations.test.ts
+++ b/tests/imodels-clients-tests/src/integration/management/IModelOperations.test.ts
@@ -5,14 +5,14 @@
 import { expect } from "chai";
 
 import { AuthorizationCallback, CreateEmptyIModelParams, CreateIModelFromTemplateParams, EntityListIterator, Extent, GetIModelListParams, GetSingleIModelParams, IModel, IModelOrderByProperty, IModelsClient, IModelsClientOptions, IModelsErrorCode, MinimalIModel, OrderByOperator, UpdateIModelParams, take, toArray } from "@itwin/imodels-client-management";
-import { IModelMetadata, ReusableIModelMetadata, ReusableTestIModelProvider, TestAuthorizationProvider, TestIModelCreator, TestIModelFileProvider, TestIModelGroup, TestIModelGroupFactory, TestProjectProvider, TestUtilTypes, assertCollection, assertError, assertIModel, assertMinimalIModel } from "@itwin/imodels-client-test-utils";
+import { IModelMetadata, ReusableIModelMetadata, ReusableTestIModelProvider, TestAuthorizationProvider, TestIModelCreator, TestIModelFileProvider, TestIModelGroup, TestIModelGroupFactory, TestITwinProvider, TestUtilTypes, assertCollection, assertError, assertIModel, assertMinimalIModel } from "@itwin/imodels-client-test-utils";
 
 import { Constants, getTestDIContainer, getTestRunId } from "../common";
 
 describe("[Management] IModelOperations", () => {
   let iModelsClient: IModelsClient;
   let authorization: AuthorizationCallback;
-  let projectId: string;
+  let iTwinId: string;
 
   let testIModelFileProvider: TestIModelFileProvider;
   let testIModelGroup: TestIModelGroup;
@@ -28,8 +28,8 @@ describe("[Management] IModelOperations", () => {
     const authorizationProvider = container.get(TestAuthorizationProvider);
     authorization = authorizationProvider.getAdmin1Authorization();
 
-    const testProjectProvider = container.get(TestProjectProvider);
-    projectId = await testProjectProvider.getOrCreate();
+    const testITwinProvider = container.get(TestITwinProvider);
+    iTwinId = await testITwinProvider.getOrCreate();
 
     testIModelFileProvider = container.get(TestIModelFileProvider);
 
@@ -62,7 +62,7 @@ describe("[Management] IModelOperations", () => {
       const getIModelListParams: GetIModelListParams = {
         authorization,
         urlParams: {
-          projectId,
+          iTwinId,
           $top: 5
         }
       };
@@ -92,7 +92,7 @@ describe("[Management] IModelOperations", () => {
     assertIModel({
       actualIModel: iModel,
       expectedIModelProperties: {
-        projectId,
+        iTwinId,
         name: testIModelForRead.name,
         description: testIModelForRead.description
       }
@@ -104,7 +104,7 @@ describe("[Management] IModelOperations", () => {
     const getIModelListParams: GetIModelListParams = {
       authorization,
       urlParams: {
-        projectId,
+        iTwinId,
         $orderBy: {
           property: IModelOrderByProperty.Name
         }
@@ -126,7 +126,7 @@ describe("[Management] IModelOperations", () => {
     const getIModelListParams: GetIModelListParams = {
       authorization,
       urlParams: {
-        projectId,
+        iTwinId,
         $orderBy: {
           property: IModelOrderByProperty.Name,
           operator: OrderByOperator.Descending
@@ -149,7 +149,7 @@ describe("[Management] IModelOperations", () => {
     const getIModelListParams: GetIModelListParams = {
       authorization,
       urlParams: {
-        projectId,
+        iTwinId,
         name: testIModelForRead.name
       }
     };
@@ -170,7 +170,7 @@ describe("[Management] IModelOperations", () => {
     const getIModelListParams: GetIModelListParams = {
       authorization,
       urlParams: {
-        projectId,
+        iTwinId,
         $top: 1
       }
     };
@@ -192,7 +192,7 @@ describe("[Management] IModelOperations", () => {
     const getIModelListParams: GetIModelListParams = {
       authorization,
       urlParams: {
-        projectId,
+        iTwinId,
         name: "Non existent name"
       }
     };
@@ -210,7 +210,7 @@ describe("[Management] IModelOperations", () => {
     const createIModelParams: CreateEmptyIModelParams = {
       authorization,
       iModelProperties: {
-        projectId,
+        iTwinId,
         name: testIModelGroup.getPrefixedUniqueIModelName("Empty Test IModel"),
         description: "Sample iModel description",
         extent: {
@@ -235,7 +235,7 @@ describe("[Management] IModelOperations", () => {
     const createIModelFromTemplateParams: CreateIModelFromTemplateParams = {
       authorization,
       iModelProperties: {
-        projectId,
+        iTwinId,
         name: testIModelGroup.getPrefixedUniqueIModelName("iModel from template (without changeset)"),
         template: {
           iModelId: testIModelForRead.id
@@ -258,7 +258,7 @@ describe("[Management] IModelOperations", () => {
     const createIModelFromTemplateParams: CreateIModelFromTemplateParams = {
       authorization,
       iModelProperties: {
-        projectId,
+        iTwinId,
         name: testIModelGroup.getPrefixedUniqueIModelName("iModel from template (with changeset)"),
         template: {
           iModelId: testIModelForRead.id,
@@ -366,7 +366,7 @@ describe("[Management] IModelOperations", () => {
     const createIModelParams: CreateEmptyIModelParams = {
       authorization: async () => ({ scheme: "Bearer", token: "invalid token" }),
       iModelProperties: {
-        projectId,
+        iTwinId,
         name: testIModelGroup.getPrefixedUniqueIModelName("Sample iModel (unauthorized)")
       }
     };
@@ -394,7 +394,7 @@ describe("[Management] IModelOperations", () => {
     const createIModelParams: CreateEmptyIModelParams = {
       authorization,
       iModelProperties: {
-        projectId,
+        iTwinId,
         name: testIModelGroup.getPrefixedUniqueIModelName("Sample iModel (invalid)"),
         description: "x".repeat(256)
       }

--- a/tests/imodels-clients-tests/src/unit/management/IModelsApiUrlFormatter.test.ts
+++ b/tests/imodels-clients-tests/src/unit/management/IModelsApiUrlFormatter.test.ts
@@ -38,13 +38,13 @@ describe("[Management] IModelsApiUrlFormatter", () => {
 
     it("should format iModel list url", () => {
       // Arrange
-      const getIModelListUrlParams = { iModelId: "IMODEL_ID", urlParams: { projectId: "PROJECT_ID" } };
+      const getIModelListUrlParams = { iModelId: "IMODEL_ID", urlParams: { iTwinId: "ITWIN_ID" } };
 
       // Act
       const iModelListUrl = iModelsApiUrlFormatter.getIModelListUrl(getIModelListUrlParams);
 
       // Assert
-      expect(iModelListUrl).to.equal("https://api.bentley.com/imodels?projectId=PROJECT_ID");
+      expect(iModelListUrl).to.equal("https://api.bentley.com/imodels?iTwinId=ITWIN_ID");
     });
   });
 
@@ -320,7 +320,7 @@ describe("[Management] IModelsApiUrlFormatter", () => {
       // Arrange
       const getIModelListUrlParams = {
         urlParams: {
-          projectId: "PROJECT_ID",
+          iTwinId: "ITWIN_ID",
           name: "IMODEL_NAME",
           $skip: 1,
           $top: 2,
@@ -337,7 +337,7 @@ describe("[Management] IModelsApiUrlFormatter", () => {
       const iModelListUrl = iModelsApiUrlFormatter.getIModelListUrl(getIModelListUrlParams);
 
       // Assert
-      expect(iModelListUrl).to.be.equal("https://api.bentley.com/imodels?projectId=PROJECT_ID&name=IMODEL_NAME&$skip=1&$top=2&$orderBy=name asc&testParam1=1&testParam2=param2");
+      expect(iModelListUrl).to.be.equal("https://api.bentley.com/imodels?iTwinId=ITWIN_ID&name=IMODEL_NAME&$skip=1&$top=2&$orderBy=name asc&testParam1=1&testParam2=param2");
     });
 
     [
@@ -362,7 +362,7 @@ describe("[Management] IModelsApiUrlFormatter", () => {
         // Arrange
         const getIModelListUrlParams = {
           urlParams: {
-            projectId: "PROJECT_ID",
+            iTwinId: "ITWIN_ID",
             testValue: testCase.valueUnderTest
           }
         };
@@ -371,7 +371,7 @@ describe("[Management] IModelsApiUrlFormatter", () => {
         const iModelListUrl = iModelsApiUrlFormatter.getIModelListUrl(getIModelListUrlParams);
 
         // Assert
-        expect(iModelListUrl).to.be.equal("https://api.bentley.com/imodels?projectId=PROJECT_ID");
+        expect(iModelListUrl).to.be.equal("https://api.bentley.com/imodels?iTwinId=ITWIN_ID");
       });
     });
 
@@ -379,7 +379,7 @@ describe("[Management] IModelsApiUrlFormatter", () => {
       // Arrange
       const getIModelListUrlParams = {
         urlParams: {
-          projectId: "PROJECT_ID",
+          iTwinId: "ITWIN_ID",
           testValue: 0
         }
       };
@@ -388,7 +388,7 @@ describe("[Management] IModelsApiUrlFormatter", () => {
       const iModelListUrl = iModelsApiUrlFormatter.getIModelListUrl(getIModelListUrlParams);
 
       // Assert
-      expect(iModelListUrl).to.be.equal("https://api.bentley.com/imodels?projectId=PROJECT_ID&testValue=0");
+      expect(iModelListUrl).to.be.equal("https://api.bentley.com/imodels?iTwinId=ITWIN_ID&testValue=0");
     });
   });
 });

--- a/utils/imodels-client-common-config/cspell.json
+++ b/utils/imodels-client-common-config/cspell.json
@@ -17,7 +17,8 @@
     "namedversions",
     "datetime",
     "inversify",
-    "bootstrapper"
+    "bootstrapper",
+    "ITWINS"
   ],
   "ignoreRegExpList": [
     "/imodel.*/i"

--- a/utils/imodels-client-test-utils/src/IModelsClientsTestsConfig.ts
+++ b/utils/imodels-client-test-utils/src/IModelsClientsTestsConfig.ts
@@ -21,7 +21,7 @@ export interface ApiConfigValues {
 }
 
 export interface ApisConfigValues {
-  projects: ApiConfigValues;
+  iTwins: ApiConfigValues;
   iModels: ApiConfigValues;
 }
 
@@ -45,7 +45,7 @@ export interface BehaviorOptions {
 
 @injectable()
 export class IModelsClientsTestsConfig {
-  public readonly testProjectName: string;
+  public readonly testITwinName: string;
   public readonly testIModelName: string;
   public readonly auth: AuthConfigValues;
   public readonly apis: ApisConfigValues;
@@ -56,7 +56,7 @@ export class IModelsClientsTestsConfig {
     dotenv.config({ path: envFilePath });
     this.validateAllValuesPresent();
 
-    this.testProjectName = process.env.TEST_PROJECT_NAME!;
+    this.testITwinName = process.env.TEST_ITWIN_NAME!;
     this.testIModelName = process.env.TEST_IMODEL_NAME!;
 
     this.auth = {
@@ -72,9 +72,9 @@ export class IModelsClientsTestsConfig {
         version: process.env.APIS_IMODELS_VERSION!,
         scopes: process.env.APIS_IMODELS_SCOPES!
       },
-      projects: {
-        baseUrl: process.env.APIS_PROJECTS_BASE_URL!,
-        scopes: process.env.APIS_PROJECTS_SCOPES!
+      iTwins: {
+        baseUrl: process.env.APIS_ITWINS_BASE_URL!,
+        scopes: process.env.APIS_ITWINS_SCOPES!
       }
     };
 
@@ -95,7 +95,7 @@ export class IModelsClientsTestsConfig {
   }
 
   private validateAllValuesPresent(): void {
-    this.validateConfigValue("TEST_PROJECT_NAME");
+    this.validateConfigValue("TEST_ITWIN_NAME");
     this.validateConfigValue("TEST_IMODEL_NAME");
 
     this.validateConfigValue("AUTH_AUTHORITY");
@@ -107,8 +107,8 @@ export class IModelsClientsTestsConfig {
     this.validateConfigValue("APIS_IMODELS_VERSION");
     this.validateConfigValue("APIS_IMODELS_SCOPES");
 
-    this.validateConfigValue("APIS_PROJECTS_BASE_URL");
-    this.validateConfigValue("APIS_PROJECTS_SCOPES");
+    this.validateConfigValue("APIS_ITWINS_BASE_URL");
+    this.validateConfigValue("APIS_ITWINS_SCOPES");
 
     this.validateConfigValue("TEST_USERS_ADMIN1_EMAIL");
     this.validateConfigValue("TEST_USERS_ADMIN1_PASSWORD");

--- a/utils/imodels-client-test-utils/src/TestUtilBootstrapper.ts
+++ b/utils/imodels-client-test-utils/src/TestUtilBootstrapper.ts
@@ -7,7 +7,7 @@ import { Container } from "inversify";
 import { IModelsClientOptions } from "@itwin/imodels-client-authoring";
 
 import { IModelsClientsTestsConfig } from "./IModelsClientsTestsConfig";
-import { ProjectsClient, ProjectsClientConfig, ReusableTestIModelProvider, ReusableTestIModelProviderConfig, TestAuthorizationClient, TestAuthorizationClientConfig, TestAuthorizationProvider, TestIModelCreator, TestIModelFileProvider, TestIModelRetriever, TestIModelsClient, TestIModelsClientOptions, TestProjectProvider, TestProjectProviderConfig } from "./test-context-providers";
+import { ITwinsClient, ITwinsClientConfig, ReusableTestIModelProvider, ReusableTestIModelProviderConfig, TestAuthorizationClient, TestAuthorizationClientConfig, TestAuthorizationProvider, TestIModelCreator, TestIModelFileProvider, TestIModelRetriever, TestIModelsClient, TestIModelsClientOptions, TestITwinProvider, TestITwinProviderConfig } from "./test-context-providers";
 import { TestAuthorizationProviderConfig } from "./test-context-providers/auth/TestAuthorizationProviderConfig";
 import { TestIModelGroupFactory } from "./test-imodel-group/TestIModelGroupFactory";
 import { TestUtilTypes } from "./TestUtilTypes";
@@ -28,10 +28,10 @@ export class TestUtilBootstrapper {
     container.bind(TestAuthorizationProviderConfig).toSelf().inSingletonScope();
     container.bind(TestAuthorizationProvider).toSelf().inSingletonScope();
 
-    container.bind(ProjectsClientConfig).toSelf().inSingletonScope();
-    container.bind(ProjectsClient).toSelf().inSingletonScope();
-    container.bind(TestProjectProviderConfig).toSelf().inSingletonScope();
-    container.bind(TestProjectProvider).toSelf().inSingletonScope();
+    container.bind(ITwinsClientConfig).toSelf().inSingletonScope();
+    container.bind(ITwinsClient).toSelf().inSingletonScope();
+    container.bind(TestITwinProviderConfig).toSelf().inSingletonScope();
+    container.bind(TestITwinProvider).toSelf().inSingletonScope();
 
     container.bind<IModelsClientOptions>(TestUtilTypes.IModelsClientOptions).to(TestIModelsClientOptions).inSingletonScope();
     container.bind(TestIModelsClient).toSelf().inSingletonScope();

--- a/utils/imodels-client-test-utils/src/test-context-providers/auth/TestAuthorizationProvider.ts
+++ b/utils/imodels-client-test-utils/src/test-context-providers/auth/TestAuthorizationProvider.ts
@@ -26,8 +26,8 @@ export class TestAuthorizationProvider {
     return this.getAuthorization({ ...this._config.testUsers.admin2FullyFeatured, scopes: this._config.apiScopes.iModels });
   }
 
-  public getAdmin1AuthorizationForProjects(): AuthorizationCallback {
-    return this.getAuthorization({ ...this._config.testUsers.admin1, scopes: this._config.apiScopes.projects });
+  public getAdmin1AuthorizationForITwins(): AuthorizationCallback {
+    return this.getAuthorization({ ...this._config.testUsers.admin1, scopes: this._config.apiScopes.iTwins });
   }
 
   private getAuthorization(testUser: { email: string, password: string, scopes: string }): AuthorizationCallback {

--- a/utils/imodels-client-test-utils/src/test-context-providers/auth/TestAuthorizationProviderConfig.ts
+++ b/utils/imodels-client-test-utils/src/test-context-providers/auth/TestAuthorizationProviderConfig.ts
@@ -8,7 +8,7 @@ import { IModelsClientsTestsConfig, TestUsersConfigValues } from "../../IModelsC
 
 interface ApiScopes {
   iModels: string;
-  projects: string;
+  iTwins: string;
 }
 
 @injectable()
@@ -22,7 +22,7 @@ export class TestAuthorizationProviderConfig {
     this.testUsers = config.testUsers;
     this.apiScopes = {
       iModels: config.apis.iModels.scopes,
-      projects: config.apis.projects.scopes
+      iTwins: config.apis.iTwins.scopes
     };
   }
 }

--- a/utils/imodels-client-test-utils/src/test-context-providers/imodel/TestIModelCreator.ts
+++ b/utils/imodels-client-test-utils/src/test-context-providers/imodel/TestIModelCreator.ts
@@ -9,7 +9,7 @@ import { CheckpointState, GetSingleCheckpointParams, Lock, LockLevel, LockedObje
 
 import { TestSetupError } from "../../CommonTestUtils";
 import { TestAuthorizationProvider } from "../auth/TestAuthorizationProvider";
-import { TestProjectProvider } from "../project/TestProjectProvider";
+import { TestITwinProvider } from "../itwin/TestITwinProvider";
 
 import { TestIModelFileProvider } from "./TestIModelFileProvider";
 import { BriefcaseMetadata, IModelMetadata, NamedVersionMetadata, ReusableIModelMetadata } from "./TestIModelInterfaces";
@@ -28,16 +28,16 @@ export class TestIModelCreator {
   constructor(
     private readonly _iModelsClient: TestIModelsClient,
     private readonly _testAuthorizationProvider: TestAuthorizationProvider,
-    private readonly _testProjectProvider: TestProjectProvider,
+    private readonly _testITwinProvider: TestITwinProvider,
     private readonly _testIModelFileProvider: TestIModelFileProvider
   ) { }
 
   public async createEmpty(iModelName: string): Promise<IModelMetadata> {
-    const projectId = await this._testProjectProvider.getOrCreate();
+    const iTwinId = await this._testITwinProvider.getOrCreate();
     const iModel = await this._iModelsClient.iModels.createEmpty({
       authorization: this._testAuthorizationProvider.getAdmin1Authorization(),
       iModelProperties: {
-        projectId,
+        iTwinId,
         name: iModelName,
         description: this._iModelDescription
       }

--- a/utils/imodels-client-test-utils/src/test-context-providers/imodel/TestIModelInterfaces.ts
+++ b/utils/imodels-client-test-utils/src/test-context-providers/imodel/TestIModelInterfaces.ts
@@ -33,7 +33,7 @@ export interface TestIModelSetupContext extends AuthorizationParam {
 }
 
 export interface IModelIdentificationByNameParams {
-  projectId: string;
+  iTwinId: string;
   iModelName: string;
 }
 

--- a/utils/imodels-client-test-utils/src/test-context-providers/imodel/TestIModelRetriever.ts
+++ b/utils/imodels-client-test-utils/src/test-context-providers/imodel/TestIModelRetriever.ts
@@ -8,7 +8,7 @@ import { GetBriefcaseListParams, GetLockListParams, GetNamedVersionListParams, I
 
 import { TestSetupError } from "../../CommonTestUtils";
 import { TestAuthorizationProvider } from "../auth/TestAuthorizationProvider";
-import { TestProjectProvider } from "../project/TestProjectProvider";
+import { TestITwinProvider } from "../itwin/TestITwinProvider";
 
 import { TestIModelCreator } from "./TestIModelCreator";
 import { TestIModelFileProvider } from "./TestIModelFileProvider";
@@ -20,16 +20,16 @@ export class TestIModelRetriever {
   constructor(
     private readonly _iModelsClient: TestIModelsClient,
     private readonly _testAuthorizationProvider: TestAuthorizationProvider,
-    private readonly _testProjectProvider: TestProjectProvider,
+    private readonly _testITwinProvider: TestITwinProvider,
     private readonly _testIModelFileProvider: TestIModelFileProvider
   ) { }
 
   public async findIModelByName(iModelName: string): Promise<IModel | undefined> {
-    const projectId = await this._testProjectProvider.getOrCreate();
+    const iTwinId = await this._testITwinProvider.getOrCreate();
     const iModelIterator = this._iModelsClient.iModels.getRepresentationList({
       authorization: this._testAuthorizationProvider.getAdmin1Authorization(),
       urlParams: {
-        projectId,
+        iTwinId,
         name: iModelName
       }
     });

--- a/utils/imodels-client-test-utils/src/test-context-providers/index.ts
+++ b/utils/imodels-client-test-utils/src/test-context-providers/index.ts
@@ -6,10 +6,10 @@ export * from "./auth/TestAuthorizationClient";
 export * from "./auth/TestAuthorizationClientConfigImpl";
 export * from "./auth/TestAuthorizationProvider";
 
-export * from "./project/ProjectsClient";
-export * from "./project/ProjectsClientConfig";
-export * from "./project/TestProjectProvider";
-export * from "./project/TestProjectProviderConfig";
+export * from "./itwin/ITwinsClient";
+export * from "./itwin/ITwinsClientConfig";
+export * from "./itwin/TestITwinProvider";
+export * from "./itwin/TestITwinProviderConfig";
 
 export * from "./imodel/ReusableTestIModelProvider";
 export * from "./imodel/ReusableTestIModelProviderConfig";

--- a/utils/imodels-client-test-utils/src/test-context-providers/itwin/ITwinsClient.ts
+++ b/utils/imodels-client-test-utils/src/test-context-providers/itwin/ITwinsClient.ts
@@ -1,6 +1,6 @@
 /*---------------------------------------------------------------------------------------------
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
- * See LICENSE.md in the project root for license terms and full copyright notice.
+ * See LICENSE.md in the iTwin root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import axios, { AxiosResponse } from "axios";
 import { injectable } from "inversify";
@@ -9,20 +9,22 @@ import { AuthorizationParam } from "@itwin/imodels-client-authoring";
 
 import { ITwinsClientConfig } from "./ITwinsClientConfig";
 
-interface Project {
+interface iTwin {
   id: string;
 }
 
-interface ProjectsResponse {
-  projects: Project[];
+interface ITwinsResponse {
+  iTwins: iTwin[];
 }
 
-interface ProjectResponse {
-  project: Project;
+interface ITwinResponse {
+  iTwin: iTwin;
 }
 
 @injectable()
 export class ITwinsClient {
+  private readonly defaultClass = "Endeavor";
+  private readonly defaultSubClass = "Project";
   constructor(
     private _config: ITwinsClientConfig
   ) { }
@@ -31,21 +33,23 @@ export class ITwinsClient {
     const authorizationInfo = await params.authorization();
     const requestConfig = {
       headers: {
+        Accept: "application/vnd.bentley.itwin-platform.v1+json",
         Authorization: `${authorizationInfo.scheme} ${authorizationInfo.token}`
       }
     };
 
-    const getProjectsWithNameUrl = `${this._config.baseUrl}?displayName=${params.iTwinName}`; // TODOooooooooooooooooooooooooooooooooo
-    const getProjectsWithNameResponse: AxiosResponse<ProjectsResponse> = await axios.get(getProjectsWithNameUrl, requestConfig);
-    if (getProjectsWithNameResponse.data.projects.length > 0)
-      return getProjectsWithNameResponse.data.projects[0].id;
+    const getITwinsWithNameUrl = `${this._config.baseUrl}?subClass=${this.defaultSubClass}&displayName=${params.iTwinName}`;
+    const getITwinsWithNameResponse: AxiosResponse<ITwinsResponse> = await axios.get(getITwinsWithNameUrl, requestConfig);
+    if (getITwinsWithNameResponse.data.iTwins.length > 0)
+      return getITwinsWithNameResponse.data.iTwins[0].id;
 
-    const createProjectUrl = this._config.baseUrl;
-    const createProjectBody = {
-      displayName: params.iTwinName,
-      projectNumber: `${params.iTwinName} ${new Date()}`
+    const createITwinUrl = this._config.baseUrl;
+    const createITwinBody = {
+      class: this.defaultClass,
+      subClass: this.defaultSubClass,
+      displayName: params.iTwinName
     };
-    const createProjectResponse: AxiosResponse<ProjectResponse> = await axios.post(createProjectUrl, createProjectBody, requestConfig);
-    return createProjectResponse.data.project.id;
+    const createITwinResponse: AxiosResponse<ITwinResponse> = await axios.post(createITwinUrl, createITwinBody, requestConfig);
+    return createITwinResponse.data.iTwin.id;
   }
 }

--- a/utils/imodels-client-test-utils/src/test-context-providers/itwin/ITwinsClient.ts
+++ b/utils/imodels-client-test-utils/src/test-context-providers/itwin/ITwinsClient.ts
@@ -7,7 +7,7 @@ import { injectable } from "inversify";
 
 import { AuthorizationParam } from "@itwin/imodels-client-authoring";
 
-import { ProjectsClientConfig } from "./ProjectsClientConfig";
+import { ITwinsClientConfig } from "./ITwinsClientConfig";
 
 interface Project {
   id: string;
@@ -22,12 +22,12 @@ interface ProjectResponse {
 }
 
 @injectable()
-export class ProjectsClient {
+export class ITwinsClient {
   constructor(
-    private _config: ProjectsClientConfig
+    private _config: ITwinsClientConfig
   ) { }
 
-  public async getOrCreateProject(params: AuthorizationParam & { projectName: string }): Promise<string> {
+  public async getOrCreateITwin(params: AuthorizationParam & { iTwinName: string }): Promise<string> {
     const authorizationInfo = await params.authorization();
     const requestConfig = {
       headers: {
@@ -35,15 +35,15 @@ export class ProjectsClient {
       }
     };
 
-    const getProjectsWithNameUrl = `${this._config.baseUrl}?displayName=${params.projectName}`;
+    const getProjectsWithNameUrl = `${this._config.baseUrl}?displayName=${params.iTwinName}`; // TODOooooooooooooooooooooooooooooooooo
     const getProjectsWithNameResponse: AxiosResponse<ProjectsResponse> = await axios.get(getProjectsWithNameUrl, requestConfig);
     if (getProjectsWithNameResponse.data.projects.length > 0)
       return getProjectsWithNameResponse.data.projects[0].id;
 
     const createProjectUrl = this._config.baseUrl;
     const createProjectBody = {
-      displayName: params.projectName,
-      projectNumber: `${params.projectName} ${new Date()}`
+      displayName: params.iTwinName,
+      projectNumber: `${params.iTwinName} ${new Date()}`
     };
     const createProjectResponse: AxiosResponse<ProjectResponse> = await axios.post(createProjectUrl, createProjectBody, requestConfig);
     return createProjectResponse.data.project.id;

--- a/utils/imodels-client-test-utils/src/test-context-providers/itwin/ITwinsClient.ts
+++ b/utils/imodels-client-test-utils/src/test-context-providers/itwin/ITwinsClient.ts
@@ -23,8 +23,9 @@ interface ITwinResponse {
 
 @injectable()
 export class ITwinsClient {
-  private readonly defaultClass = "Endeavor";
-  private readonly defaultSubClass = "Project";
+  private readonly _defaultClass = "Endeavor";
+  private readonly _defaultSubClass = "Project";
+
   constructor(
     private _config: ITwinsClientConfig
   ) { }
@@ -38,15 +39,15 @@ export class ITwinsClient {
       }
     };
 
-    const getITwinsWithNameUrl = `${this._config.baseUrl}?subClass=${this.defaultSubClass}&displayName=${params.iTwinName}`;
+    const getITwinsWithNameUrl = `${this._config.baseUrl}?subClass=${this._defaultSubClass}&displayName=${params.iTwinName}`;
     const getITwinsWithNameResponse: AxiosResponse<ITwinsResponse> = await axios.get(getITwinsWithNameUrl, requestConfig);
     if (getITwinsWithNameResponse.data.iTwins.length > 0)
       return getITwinsWithNameResponse.data.iTwins[0].id;
 
     const createITwinUrl = this._config.baseUrl;
     const createITwinBody = {
-      class: this.defaultClass,
-      subClass: this.defaultSubClass,
+      class: this._defaultClass,
+      subClass: this._defaultSubClass,
       displayName: params.iTwinName
     };
     const createITwinResponse: AxiosResponse<ITwinResponse> = await axios.post(createITwinUrl, createITwinBody, requestConfig);

--- a/utils/imodels-client-test-utils/src/test-context-providers/itwin/ITwinsClientConfig.ts
+++ b/utils/imodels-client-test-utils/src/test-context-providers/itwin/ITwinsClientConfig.ts
@@ -7,12 +7,12 @@ import { injectable } from "inversify";
 import { IModelsClientsTestsConfig } from "../../IModelsClientsTestsConfig";
 
 @injectable()
-export class ProjectsClientConfig {
+export class ITwinsClientConfig {
   public baseUrl: string;
 
   constructor(
     config: IModelsClientsTestsConfig
   ) {
-    this.baseUrl = config.apis.projects.baseUrl;
+    this.baseUrl = config.apis.iTwins.baseUrl;
   }
 }

--- a/utils/imodels-client-test-utils/src/test-context-providers/itwin/TestITwinProvider.ts
+++ b/utils/imodels-client-test-utils/src/test-context-providers/itwin/TestITwinProvider.ts
@@ -6,29 +6,29 @@ import { injectable } from "inversify";
 
 import { TestAuthorizationProvider } from "../auth/TestAuthorizationProvider";
 
-import { ProjectsClient } from "./ProjectsClient";
-import { TestProjectProviderConfig } from "./TestProjectProviderConfig";
+import { ITwinsClient } from "./ITwinsClient";
+import { TestITwinProviderConfig } from "./TestITwinProviderConfig";
 
 @injectable()
-export class TestProjectProvider {
-  private _projectId: string | undefined;
+export class TestITwinProvider {
+  private _iTwinId: string | undefined;
 
   constructor(
-    private readonly _testProjectProviderConfig: TestProjectProviderConfig,
-    private readonly _projectsClient: ProjectsClient,
+    private readonly _testITwinProviderConfig: TestITwinProviderConfig,
+    private readonly _iTwinsClient: ITwinsClient,
     private readonly _testAuthorizationProvider: TestAuthorizationProvider
   ) { }
 
   public async getOrCreate(): Promise<string> {
-    return this._projectId ?? await this.initialize();
+    return this._iTwinId ?? await this.initialize();
   }
 
   private async initialize(): Promise<string> {
-    const authorization = this._testAuthorizationProvider.getAdmin1AuthorizationForProjects();
-    this._projectId = await this._projectsClient.getOrCreateProject({
+    const authorization = this._testAuthorizationProvider.getAdmin1AuthorizationForITwins();
+    this._iTwinId = await this._iTwinsClient.getOrCreateITwin({
       authorization,
-      projectName: this._testProjectProviderConfig.testProjectName
+      iTwinName: this._testITwinProviderConfig.testITwinName
     });
-    return this._projectId;
+    return this._iTwinId;
   }
 }

--- a/utils/imodels-client-test-utils/src/test-context-providers/itwin/TestITwinProviderConfig.ts
+++ b/utils/imodels-client-test-utils/src/test-context-providers/itwin/TestITwinProviderConfig.ts
@@ -7,10 +7,10 @@ import { injectable } from "inversify";
 import { IModelsClientsTestsConfig } from "../../IModelsClientsTestsConfig";
 
 @injectable()
-export class TestProjectProviderConfig {
-  public testProjectName: string;
+export class TestITwinProviderConfig {
+  public testITwinName: string;
 
   constructor(config: IModelsClientsTestsConfig) {
-    this.testProjectName = config.testProjectName;
+    this.testITwinName = config.testITwinName;
   }
 }

--- a/utils/imodels-client-test-utils/src/test-imodel-group/TestIModelGroup.ts
+++ b/utils/imodels-client-test-utils/src/test-imodel-group/TestIModelGroup.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { TestAuthorizationProvider, TestIModelsClient, TestProjectProvider } from "../test-context-providers";
+import { TestAuthorizationProvider, TestIModelsClient, TestITwinProvider } from "../test-context-providers";
 
 export interface TestRunContext {
   testRunId: string;
@@ -16,7 +16,7 @@ export class TestIModelGroup {
   constructor(
     private readonly _iModelsClient: TestIModelsClient,
     private readonly _testAuthorizationProvider: TestAuthorizationProvider,
-    private readonly _testProjectProvider: TestProjectProvider,
+    private readonly _testITwinProvider: TestITwinProvider,
     testRunContext: TestRunContext
   ) {
     this._iModelNamePrefix = `[${testRunContext.testRunId}][${testRunContext.packageName}]`;
@@ -29,11 +29,11 @@ export class TestIModelGroup {
   }
 
   public async cleanupIModels(): Promise<void> {
-    const projectId = await this._testProjectProvider.getOrCreate();
+    const iTwinId = await this._testITwinProvider.getOrCreate();
     const iModels = this._iModelsClient.iModels.getMinimalList({
       authorization: this._testAuthorizationProvider.getAdmin1Authorization(),
       urlParams: {
-        projectId
+        iTwinId
       }
     });
     for await (const iModel of iModels)

--- a/utils/imodels-client-test-utils/src/test-imodel-group/TestIModelGroupFactory.ts
+++ b/utils/imodels-client-test-utils/src/test-imodel-group/TestIModelGroupFactory.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { injectable } from "inversify";
 
-import { TestAuthorizationProvider, TestIModelsClient, TestProjectProvider } from "../test-context-providers";
+import { TestAuthorizationProvider, TestIModelsClient, TestITwinProvider } from "../test-context-providers";
 
 import { TestIModelGroup } from "./TestIModelGroup";
 
@@ -13,7 +13,7 @@ export class TestIModelGroupFactory {
   constructor(
     private readonly _iModelsClient: TestIModelsClient,
     private readonly _testAuthorizationProvider: TestAuthorizationProvider,
-    private readonly _testProjectProvider: TestProjectProvider
+    private readonly _testITwinProvider: TestITwinProvider
   ) { }
 
   public create(testRunContext: {
@@ -21,6 +21,6 @@ export class TestIModelGroupFactory {
     packageName: string;
     testSuiteName?: string;
   }): TestIModelGroup {
-    return new TestIModelGroup(this._iModelsClient, this._testAuthorizationProvider, this._testProjectProvider, testRunContext);
+    return new TestIModelGroup(this._iModelsClient, this._testAuthorizationProvider, this._testITwinProvider, testRunContext);
   }
 }


### PR DESCRIPTION
In this PR:
- Changed the client to target iModels API V2 by default
  - Renamed all references from `project` to `iTwin`
  - Updated links in documentation
- Updated integration tests to use iTwins API instead of Projects for test iTwin creation 