### PR TITLE
Adding `IModel.getCreator` helper function

### DIFF
--- a/clients/imodels-client-authoring/src/IModelsClient.ts
+++ b/clients/imodels-client-authoring/src/IModelsClient.ts
@@ -65,7 +65,7 @@ export class IModelsClient extends ManagementIModelsClient {
 
   /** iModel operations. See {@link iModelOperations}. */
   public override get iModels(): IModelOperations<OperationOptions> {
-    return new IModelOperations(this._operationsOptions);
+    return new IModelOperations(this._operationsOptions, this);
   }
 
   /** Baseline file operations. See {@link BaselineFileOperations}. */

--- a/clients/imodels-client-authoring/src/operations/imodel/IModelOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/imodel/IModelOperations.ts
@@ -13,12 +13,13 @@ import { assertLink } from "../CommonFunctions";
 import { OperationOptions } from "../OperationOptions";
 
 import { CreateIModelFromBaselineParams, IModelPropertiesForCreateFromBaseline } from "./IModelOperationParams";
+import { IModelsClient } from "../../IModelsClient";
 
 export class IModelOperations<TOptions extends OperationOptions> extends ManagementIModelOperations<TOptions> {
   private _baselineFileOperations: BaselineFileOperations<TOptions>;
 
-  constructor(options: TOptions) {
-    super(options);
+  constructor(options: TOptions, iModelsClient: IModelsClient) {
+    super(options, iModelsClient);
     this._baselineFileOperations = new BaselineFileOperations<TOptions>(options);
   }
 

--- a/clients/imodels-client-authoring/src/operations/imodel/IModelOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/imodel/IModelOperations.ts
@@ -8,12 +8,12 @@ import { IModelOperations as ManagementIModelOperations } from "@itwin/imodels-c
 import { AuthorizationParam, IModel, IModelsErrorCode } from "@itwin/imodels-client-management";
 
 import { BaselineFileState } from "../../base/types";
+import { IModelsClient } from "../../IModelsClient";
 import { BaselineFileOperations } from "../baseline-file/BaselineFileOperations";
 import { assertLink } from "../CommonFunctions";
 import { OperationOptions } from "../OperationOptions";
 
 import { CreateIModelFromBaselineParams, IModelPropertiesForCreateFromBaseline } from "./IModelOperationParams";
-import { IModelsClient } from "../../IModelsClient";
 
 export class IModelOperations<TOptions extends OperationOptions> extends ManagementIModelOperations<TOptions> {
   private _baselineFileOperations: BaselineFileOperations<TOptions>;

--- a/clients/imodels-client-management/src/IModelsClient.ts
+++ b/clients/imodels-client-management/src/IModelsClient.ts
@@ -43,7 +43,7 @@ export class IModelsClient {
 
   /** iModel operations. See {@link iModelOperations}. */
   public get iModels(): IModelOperations<OperationOptions> {
-    return new IModelOperations(this._operationsOptions);
+    return new IModelOperations(this._operationsOptions, this);
   }
 
   /** Briefcase operations. See {@link BriefcaseOperations}. */

--- a/clients/imodels-client-management/src/base/types/apiEntities/IModelInterfaces.ts
+++ b/clients/imodels-client-management/src/base/types/apiEntities/IModelInterfaces.ts
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { Link } from "../CommonInterfaces";
+import { User } from "./UserInterfaces";
 
 /** Possible iModel states. */
 export enum IModelState {
@@ -83,4 +84,10 @@ export interface IModel extends MinimalIModel {
   extent: Extent | null;
   /** iModel links. See {@link IModelLinks}.*/
   _links: IModelLinks;
+  /**
+   * Function to query User who created this iModel. If this information is unavailable the
+   * function returns `undefined`. This function reuses authorization information passed to specific iModel
+   * operation that originally queried the iModel from API.
+   */
+  getCreator: () => Promise<User | undefined>;
 }

--- a/clients/imodels-client-management/src/base/types/apiEntities/IModelInterfaces.ts
+++ b/clients/imodels-client-management/src/base/types/apiEntities/IModelInterfaces.ts
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { Link } from "../CommonInterfaces";
+
 import { User } from "./UserInterfaces";
 
 /** Possible iModel states. */

--- a/clients/imodels-client-management/src/operations/imodel/IModelOperations.ts
+++ b/clients/imodels-client-management/src/operations/imodel/IModelOperations.ts
@@ -3,12 +3,19 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { EntityListIteratorImpl, IModelResponse, IModelsErrorImpl, IModelsResponse, OperationsBase, waitForCondition } from "../../base/internal";
-import { AuthorizationCallback, EntityListIterator, IModel, IModelState, IModelsErrorCode, MinimalIModel, PreferReturn } from "../../base/types";
+import { AuthorizationCallback, EntityListIterator, IModel, IModelState, IModelsErrorCode, MinimalIModel, PreferReturn, User } from "../../base/types";
+import { IModelsClient } from "../../IModelsClient";
 import { OperationOptions } from "../OperationOptions";
 
 import { CreateEmptyIModelParams, CreateIModelFromTemplateParams, DeleteIModelParams, GetIModelListParams, GetSingleIModelParams, IModelProperties, IModelPropertiesForCreateFromTemplate, IModelPropertiesForUpdate, UpdateIModelParams } from "./IModelOperationParams";
 
 export class IModelOperations<TOptions extends OperationOptions> extends OperationsBase<TOptions> {
+  constructor(
+    options: TOptions,
+    private _iModelsClient: IModelsClient
+  ) {
+    super(options);
+  }
   /**
    * Gets iModels for a specific project. This method returns iModels in their minimal representation. The returned iterator
    * internally queries entities in pages. Wraps the {@link https://developer.bentley.com/apis/imodels/operations/get-project-imodels/ Get Project iModels}
@@ -33,11 +40,17 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
    * @returns {EntityListIterator<iModel>} iterator for iModel list. See {@link EntityListIterator}, {@link iModel}.
    */
   public getRepresentationList(params: GetIModelListParams): EntityListIterator<IModel> {
+    const entityCollectionAccessor = (response: unknown) => {
+      const iModels = (response as IModelsResponse<IModel>).iModels;
+      const mappedIModels = iModels.map((iModel) => this.appendRelatedEntityCallbacks(params.authorization, iModel));
+      return mappedIModels;
+    };
+
     return new EntityListIteratorImpl(async () => this.getEntityCollectionPage<IModel>({
       authorization: params.authorization,
       url: this._options.urlFormatter.getIModelListUrl({ urlParams: params.urlParams }),
       preferReturn: PreferReturn.Representation,
-      entityCollectionAccessor: (response: unknown) => (response as IModelsResponse<IModel>).iModels
+      entityCollectionAccessor
     }));
   }
 
@@ -52,7 +65,8 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
       authorization: params.authorization,
       url: this._options.urlFormatter.getSingleIModelUrl({ iModelId: params.iModelId })
     });
-    return response.iModel;
+    const result: IModel = this.appendRelatedEntityCallbacks(params.authorization, response.iModel);
+    return result;
   }
 
   /**
@@ -63,7 +77,9 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
    */
   public async createEmpty(params: CreateEmptyIModelParams): Promise<IModel> {
     const createIModelBody = this.getCreateEmptyIModelRequestBody(params.iModelProperties);
-    return this.sendIModelPostRequest(params.authorization, createIModelBody);
+    const createdIModel = await this.sendIModelPostRequest(params.authorization, createIModelBody);
+    const result: IModel = this.appendRelatedEntityCallbacks(params.authorization, createdIModel);
+    return result;
   }
 
   /**
@@ -106,7 +122,8 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
       url: this._options.urlFormatter.getSingleIModelUrl({ iModelId: params.iModelId }),
       body: updateIModelBody
     });
-    return updateIModelResponse.iModel;
+    const result: IModel = this.appendRelatedEntityCallbacks(params.authorization, updateIModelResponse.iModel);
+    return result;
   }
 
   /**
@@ -120,6 +137,17 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
       authorization: params.authorization,
       url: this._options.urlFormatter.getSingleIModelUrl({ iModelId: params.iModelId })
     });
+  }
+
+  protected appendRelatedEntityCallbacks(authorization: AuthorizationCallback, iModel: IModel): IModel {
+    const getCreator = async () => this.getCreator(authorization, iModel._links.creator?.href);
+  
+    const result: IModel = {
+      ...iModel,
+      getCreator
+    };
+
+    return result;
   }
 
   protected getCreateEmptyIModelRequestBody(iModelProperties: IModelProperties): object {
@@ -138,6 +166,18 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
       body: createIModelBody
     });
     return createIModelResponse.iModel;
+  }
+
+  private async getCreator(authorization: AuthorizationCallback, creatorLink: string | undefined): Promise<User | undefined> {
+    if (!creatorLink)
+      return undefined;
+
+    const { iModelId, userId } = this._options.urlFormatter.parseUserUrl(creatorLink);
+    return this._iModelsClient.users.getSingle({
+      authorization,
+      iModelId,
+      userId
+    });
   }
 
   private getCreateIModelFromTemplateRequestBody(iModelProperties: IModelPropertiesForCreateFromTemplate): object {

--- a/clients/imodels-client-management/src/operations/imodel/IModelOperations.ts
+++ b/clients/imodels-client-management/src/operations/imodel/IModelOperations.ts
@@ -141,7 +141,7 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
 
   protected appendRelatedEntityCallbacks(authorization: AuthorizationCallback, iModel: IModel): IModel {
     const getCreator = async () => this.getCreator(authorization, iModel._links.creator?.href);
-  
+
     const result: IModel = {
       ...iModel,
       getCreator

--- a/tests/imodels-clients-tests/src/integration/authoring/IModelOperations.test.ts
+++ b/tests/imodels-clients-tests/src/integration/authoring/IModelOperations.test.ts
@@ -7,7 +7,7 @@ import { TestAuthorizationProvider, TestIModelFileProvider, TestIModelGroup, Tes
 
 import { Constants, getTestDIContainer, getTestRunId } from "../common";
 
-describe.only("[Authoring] IModelOperations", () => {
+describe("[Authoring] IModelOperations", () => {
   let iModelsClient: IModelsClient;
   let authorization: AuthorizationCallback;
   let projectId: string;

--- a/tests/imodels-clients-tests/src/integration/authoring/IModelOperations.test.ts
+++ b/tests/imodels-clients-tests/src/integration/authoring/IModelOperations.test.ts
@@ -7,7 +7,7 @@ import { TestAuthorizationProvider, TestIModelFileProvider, TestIModelGroup, Tes
 
 import { Constants, getTestDIContainer, getTestRunId } from "../common";
 
-describe("[Authoring] IModelOperations", () => {
+describe.only("[Authoring] IModelOperations", () => {
   let iModelsClient: IModelsClient;
   let authorization: AuthorizationCallback;
   let projectId: string;
@@ -52,7 +52,7 @@ describe("[Authoring] IModelOperations", () => {
     const iModel: IModel = await iModelsClient.iModels.createFromBaseline(createIModelParams);
 
     // Assert
-    assertIModel({
+    await assertIModel({
       actualIModel: iModel,
       expectedIModelProperties: createIModelParams.iModelProperties
     });

--- a/tests/imodels-clients-tests/src/integration/management/IModelOperations.test.ts
+++ b/tests/imodels-clients-tests/src/integration/management/IModelOperations.test.ts
@@ -9,7 +9,7 @@ import { IModelMetadata, ReusableIModelMetadata, ReusableTestIModelProvider, Tes
 
 import { Constants, getTestDIContainer, getTestRunId } from "../common";
 
-describe("[Management] IModelOperations", () => {
+describe.only("[Management] IModelOperations", () => {
   let iModelsClient: IModelsClient;
   let authorization: AuthorizationCallback;
   let projectId: string;
@@ -89,7 +89,7 @@ describe("[Management] IModelOperations", () => {
     const iModel: IModel = await iModelsClient.iModels.getSingle(getSingleiModelParams);
 
     // Assert
-    assertIModel({
+    await assertIModel({
       actualIModel: iModel,
       expectedIModelProperties: {
         projectId,
@@ -224,7 +224,7 @@ describe("[Management] IModelOperations", () => {
     const iModel: IModel = await iModelsClient.iModels.createEmpty(createIModelParams);
 
     // Assert
-    assertIModel({
+    await assertIModel({
       actualIModel: iModel,
       expectedIModelProperties: createIModelParams.iModelProperties
     });
@@ -247,7 +247,7 @@ describe("[Management] IModelOperations", () => {
     const iModel: IModel = await iModelsClient.iModels.createFromTemplate(createIModelFromTemplateParams);
 
     // Assert
-    assertIModel({
+    await assertIModel({
       actualIModel: iModel,
       expectedIModelProperties: createIModelFromTemplateParams.iModelProperties
     });
@@ -271,7 +271,7 @@ describe("[Management] IModelOperations", () => {
     const iModel: IModel = await iModelsClient.iModels.createFromTemplate(createIModelFromTemplateParams);
 
     // Assert
-    assertIModel({
+    await assertIModel({
       actualIModel: iModel,
       expectedIModelProperties: createIModelFromTemplateParams.iModelProperties
     });
@@ -297,9 +297,15 @@ describe("[Management] IModelOperations", () => {
     const iModel: IModel = await iModelsClient.iModels.update(updateIModelParams);
 
     // Assert
-    expect(iModel.name).to.be.equal(newIModelName);
-    expect(iModel.description).to.be.equal(iModelBeforeUpdate.description);
-    expect(iModel.extent).to.be.deep.equal(iModelBeforeUpdate.extent);
+    await assertIModel({
+      actualIModel: iModel,
+      expectedIModelProperties: {
+        name: newIModelName,
+        projectId: iModelBeforeUpdate.projectId,
+        description: iModelBeforeUpdate.description!,
+        extent: iModelBeforeUpdate.extent!
+      }
+    });
   });
 
   it("should update iModel description", async () => {
@@ -322,9 +328,15 @@ describe("[Management] IModelOperations", () => {
     const iModel: IModel = await iModelsClient.iModels.update(updateIModelParams);
 
     // Assert
-    expect(iModel.name).to.be.equal(iModelBeforeUpdate.name);
-    expect(iModel.description).to.be.equal(newIModelDescription);
-    expect(iModel.extent).to.be.deep.equal(iModelBeforeUpdate.extent);
+    await assertIModel({
+      actualIModel: iModel,
+      expectedIModelProperties: {
+        name: iModelBeforeUpdate.name,
+        projectId: iModelBeforeUpdate.projectId,
+        description: newIModelDescription,
+        extent: iModelBeforeUpdate.extent!
+      }
+    });
   });
 
   it("should update iModel extent", async () => {
@@ -356,9 +368,15 @@ describe("[Management] IModelOperations", () => {
     const iModel: IModel = await iModelsClient.iModels.update(updateIModelParams);
 
     // Assert
-    expect(iModel.name).to.be.equal(iModelBeforeUpdate.name);
-    expect(iModel.description).to.be.equal(iModelBeforeUpdate.description);
-    expect(iModel.extent).to.be.deep.equal(newIModelExtent);
+    await assertIModel({
+      actualIModel: iModel,
+      expectedIModelProperties: {
+        name: iModelBeforeUpdate.name,
+        projectId: iModelBeforeUpdate.projectId,
+        description: iModelBeforeUpdate.description!,
+        extent: newIModelExtent
+      }
+    });
   });
 
   it("should return unauthorized error when calling API with invalid access token", async () => {

--- a/tests/imodels-clients-tests/src/integration/management/IModelOperations.test.ts
+++ b/tests/imodels-clients-tests/src/integration/management/IModelOperations.test.ts
@@ -9,7 +9,7 @@ import { IModelMetadata, ReusableIModelMetadata, ReusableTestIModelProvider, Tes
 
 import { Constants, getTestDIContainer, getTestRunId } from "../common";
 
-describe.only("[Management] IModelOperations", () => {
+describe("[Management] IModelOperations", () => {
   let iModelsClient: IModelsClient;
   let authorization: AuthorizationCallback;
   let projectId: string;

--- a/utils/imodels-client-test-utils/src/assertions/BrowserFriendlyAssertions.ts
+++ b/utils/imodels-client-test-utils/src/assertions/BrowserFriendlyAssertions.ts
@@ -6,7 +6,7 @@ import { expect } from "chai";
 
 import { Application, Briefcase, Checkpoint, CheckpointState, ContentType, EntityListIterator, IModel, IModelPermission, IModelProperties, IModelState, IModelsError, IModelsErrorDetail, Link, MinimalBriefcase, MinimalIModel, MinimalNamedVersion, MinimalUser, NamedVersion, NamedVersionPropertiesForCreate, NamedVersionState, Thumbnail, ThumbnailSize, User, UserPermissions } from "@itwin/imodels-client-management";
 
-import { assertBriefcaseCallbacks, assertNamedVersionCallbacks } from "./RelatedEntityCallbackAssertions";
+import { assertBriefcaseCallbacks, assertIModelCallbacks, assertNamedVersionCallbacks } from "./RelatedEntityCallbackAssertions";
 
 export async function assertCollection<T>(params: {
   asyncIterable: EntityListIterator<T>;
@@ -28,10 +28,10 @@ export function assertMinimalIModel(params: {
   expect(params.actualIModel.displayName).to.not.be.empty;
 }
 
-export function assertIModel(params: {
+export async function assertIModel(params: {
   actualIModel: IModel;
   expectedIModelProperties: IModelProperties;
-}): void {
+}): Promise<void> {
   assertMinimalIModel({
     actualIModel: params.actualIModel
   });
@@ -41,6 +41,10 @@ export function assertIModel(params: {
   assertOptionalProperty(params.expectedIModelProperties.extent, params.actualIModel.extent);
   expect(params.actualIModel.createdDateTime).to.not.be.empty;
   expect(params.actualIModel.state).to.equal(IModelState.Initialized);
+
+  await assertIModelCallbacks({
+    iModel: params.actualIModel
+  });
 }
 
 export function assertMinimalBriefcase(params: {

--- a/utils/imodels-client-test-utils/src/assertions/RelatedEntityCallbackAssertions.ts
+++ b/utils/imodels-client-test-utils/src/assertions/RelatedEntityCallbackAssertions.ts
@@ -4,9 +4,20 @@
  *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
 
-import { Briefcase, Changeset, Checkpoint, MinimalChangeset, NamedVersion, User } from "@itwin/imodels-client-authoring";
+import { Briefcase, Changeset, Checkpoint, IModel, MinimalChangeset, NamedVersion, User } from "@itwin/imodels-client-authoring";
 
 import { assertUser } from "./BrowserFriendlyAssertions";
+
+export async function assertIModelCallbacks(params: {
+  iModel: IModel;
+}): Promise<void> {
+  expect(params.iModel.getCreator).to.exist;
+
+  const creator: User | undefined = await params.iModel.getCreator();
+  assertUser({
+    actualUser: creator!
+  });
+}
 
 export async function assertBriefcaseCallbacks(params: {
   briefcase: Briefcase;


### PR DESCRIPTION
In this PR:
- Added a helper function to query iModel creator using the `_links.creator` property.
- Added assertion for the new function in integration tests