### PR TITLE
`rush.json` fix

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -36,8 +36,7 @@
     {
       "packageName": "@itwin/imodels-access-backend",
       "projectFolder": "itwin-platform-access/imodels-access-backend",
-      "shouldPublish": false,
-      "versionPolicyName": "prerelease-monorepo-lockStep"
+      "shouldPublish": false
     },
     {
       "packageName": "@itwin/imodels-client-test-utils",


### PR DESCRIPTION
In this PR:
- Temporarily removed `versionPolicyName` property from `@itwin/imodels-access-backend`
![image](https://user-images.githubusercontent.com/70565417/218138138-22c0e2ff-6322-4840-be0a-b153b7db585e.png)
