### PR TITLE
Reverted temporary `rush.json` changes

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -36,7 +36,8 @@
     {
       "packageName": "@itwin/imodels-access-backend",
       "projectFolder": "itwin-platform-access/imodels-access-backend",
-      "shouldPublish": false
+      "shouldPublish": true,
+      "versionPolicyName": "prerelease-monorepo-lockStep"
     },
     {
       "packageName": "@itwin/imodels-client-test-utils",


### PR DESCRIPTION
In this PR:
- Reverted temporary `rush.json` changes for `@itwin/imodels-access-backend` package