### PR TITLE
Improve flaky iModels ordering tests

### DIFF
--- a/tests/imodels-clients-tests/src/integration/management/IModelOperations.test.ts
+++ b/tests/imodels-clients-tests/src/integration/management/IModelOperations.test.ts
@@ -101,6 +101,14 @@ describe("[Management] IModelOperations", () => {
 
   it("should return items in ascending order when querying representation collection", async () => {
     // Arrange
+    await iModelsClient.iModels.createEmpty({
+      authorization,
+      iModelProperties: {
+        iTwinId,
+        name: testIModelGroup.getFirstIModelNameForOrderingTests()
+      }
+    });
+
     const getIModelListParams: GetIModelListParams = {
       authorization,
       urlParams: {
@@ -115,14 +123,21 @@ describe("[Management] IModelOperations", () => {
     const iModels = iModelsClient.iModels.getRepresentationList(getIModelListParams);
 
     // Assert
-    const iModelNames = (await toArray(iModels)).map((iModel) => iModel.name);
-    expect(iModelNames.length).to.be.greaterThan(1);
-    for (let i = 0; i < iModelNames.length - 1; i++)
-      expect(iModelNames[i] < iModelNames[i + 1]).to.be.true;
+    const iModelArray = await toArray(iModels);
+    expect(iModelArray.length).to.be.greaterThanOrEqual(2);
+    expect(iModelArray[0].name.startsWith(testIModelGroup.firstNamePrefix)).to.be.true;
   });
 
   it("should return items in descending order when querying representation collection", async () => {
     // Arrange
+    await iModelsClient.iModels.createEmpty({
+      authorization,
+      iModelProperties: {
+        iTwinId,
+        name: testIModelGroup.getLastIModelNameForOrderingTests()
+      }
+    });
+
     const getIModelListParams: GetIModelListParams = {
       authorization,
       urlParams: {
@@ -138,10 +153,9 @@ describe("[Management] IModelOperations", () => {
     const iModels = iModelsClient.iModels.getRepresentationList(getIModelListParams);
 
     // Assert
-    const iModelNames = (await toArray(iModels)).map((iModel) => iModel.name);
-    expect(iModelNames.length).to.be.greaterThan(1);
-    for (let i = 0; i < iModelNames.length - 1; i++)
-      expect(iModelNames[i] > iModelNames[i + 1]).to.be.true;
+    const iModelArray = await toArray(iModels);
+    expect(iModelArray.length).to.be.greaterThanOrEqual(2);
+    expect(iModelArray[0].name.startsWith(testIModelGroup.lastNamePrefix)).to.be.true;
   });
 
   it("should return iModels that match the name filter when querying representation collection", async () => {

--- a/tests/imodels-clients-tests/src/integration/management/IModelOperations.test.ts
+++ b/tests/imodels-clients-tests/src/integration/management/IModelOperations.test.ts
@@ -157,9 +157,9 @@ describe("[Management] IModelOperations", () => {
   });
 
   function assertAscendingiModelArray(iModelArray: IModel[]): { firstIModelIndex: number, lastIModelIndex: number } {
-    const firstIModelIndex = iModelArray.findIndex(iModel => iModel.name.startsWith(testIModelGroup.firstNamePrefix));
+    const firstIModelIndex = iModelArray.findIndex((iModel) => iModel.name.startsWith(testIModelGroup.firstNamePrefix));
     expect(firstIModelIndex).to.not.be.equal(-1);
-    const lastIModelIndex = iModelArray.findIndex(iModel => iModel.name.startsWith(testIModelGroup.lastNamePrefix));
+    const lastIModelIndex = iModelArray.findIndex((iModel) => iModel.name.startsWith(testIModelGroup.lastNamePrefix));
     expect(lastIModelIndex).to.not.be.equal(-1);
     return { firstIModelIndex, lastIModelIndex };
   }

--- a/utils/imodels-client-test-utils/src/test-imodel-group/TestIModelGroup.ts
+++ b/utils/imodels-client-test-utils/src/test-imodel-group/TestIModelGroup.ts
@@ -11,7 +11,7 @@ export interface TestRunContext {
 }
 
 export class TestIModelGroup {
-  public readonly firstNamePrefix = "***";
+  public readonly firstNamePrefix = "AAA";
   public readonly lastNamePrefix = "YYY";
   private _iModelNamePrefix: string;
 

--- a/utils/imodels-client-test-utils/src/test-imodel-group/TestIModelGroup.ts
+++ b/utils/imodels-client-test-utils/src/test-imodel-group/TestIModelGroup.ts
@@ -55,6 +55,8 @@ export class TestIModelGroup {
   }
 
   private doesIModelBelongToGroup(iModelName: string): boolean {
-    return iModelName.startsWith(this._iModelNamePrefix) || iModelName.startsWith(this.firstNamePrefix) || iModelName.startsWith(this.lastNamePrefix);
+    return iModelName.startsWith(this._iModelNamePrefix) ||
+      iModelName.startsWith(this.firstNamePrefix) ||
+      iModelName.startsWith(this.lastNamePrefix);
   }
 }

--- a/utils/imodels-client-test-utils/src/test-imodel-group/TestIModelGroup.ts
+++ b/utils/imodels-client-test-utils/src/test-imodel-group/TestIModelGroup.ts
@@ -56,7 +56,7 @@ export class TestIModelGroup {
 
   private doesIModelBelongToGroup(iModelName: string): boolean {
     return iModelName.startsWith(this._iModelNamePrefix) ||
-      iModelName.startsWith(this.firstNamePrefix) ||
-      iModelName.startsWith(this.lastNamePrefix);
+      iModelName === this.getFirstIModelNameForOrderingTests() ||
+      iModelName === this.getLastIModelNameForOrderingTests();
   }
 }

--- a/utils/imodels-client-test-utils/src/test-imodel-group/TestIModelGroup.ts
+++ b/utils/imodels-client-test-utils/src/test-imodel-group/TestIModelGroup.ts
@@ -11,6 +11,8 @@ export interface TestRunContext {
 }
 
 export class TestIModelGroup {
+  public readonly firstNamePrefix = "***";
+  public readonly lastNamePrefix = "YYY";
   private _iModelNamePrefix: string;
 
   constructor(
@@ -28,6 +30,14 @@ export class TestIModelGroup {
     return `${this._iModelNamePrefix} ${iModelName}`;
   }
 
+  public getFirstIModelNameForOrderingTests(): string {
+    return `${this.firstNamePrefix}${this._iModelNamePrefix} Ordering tests`;
+  }
+
+  public getLastIModelNameForOrderingTests(): string {
+    return `${this.lastNamePrefix}${this._iModelNamePrefix} Ordering tests`;
+  }
+
   public async cleanupIModels(): Promise<void> {
     const iTwinId = await this._testITwinProvider.getOrCreate();
     const iModels = this._iModelsClient.iModels.getMinimalList({
@@ -37,14 +47,14 @@ export class TestIModelGroup {
       }
     });
     for await (const iModel of iModels)
-      if (this.doesIModelBelongToContext(iModel.displayName))
+      if (this.doesIModelBelongToGroup(iModel.displayName))
         await this._iModelsClient.iModels.delete({
           authorization: this._testAuthorizationProvider.getAdmin1Authorization(),
           iModelId: iModel.id
         });
   }
 
-  private doesIModelBelongToContext(iModelName: string): boolean {
-    return iModelName.startsWith(this._iModelNamePrefix);
+  private doesIModelBelongToGroup(iModelName: string): boolean {
+    return iModelName.startsWith(this._iModelNamePrefix) || iModelName.startsWith(this.firstNamePrefix) || iModelName.startsWith(this.lastNamePrefix);
   }
 }


### PR DESCRIPTION
In this PR:
- Simplified the iModels collection ordering tests so that parallel runs would not interfere with each other and so that the JS ordering rules would not be used.