### PR TITLE
Revert "3.1.0 -> 3.2.0 version bump"

### DIFF
--- a/clients/imodels-client-authoring/package.json
+++ b/clients/imodels-client-authoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-client-authoring",
-  "version": "3.2.0",
+  "version": "3.1.0",
   "description": "iModels API client wrapper for applications that author iModels.",
   "keywords": [
     "Bentley",

--- a/clients/imodels-client-management/package.json
+++ b/clients/imodels-client-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-client-management",
-  "version": "3.2.0",
+  "version": "3.1.0",
   "description": "iModels API client wrapper for applications that manage iModels.",
   "keywords": [
     "Bentley",

--- a/itwin-platform-access/imodels-access-backend/package.json
+++ b/itwin-platform-access/imodels-access-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-access-backend",
-  "version": "3.2.0",
+  "version": "3.1.0",
   "description": "Interoperability package between iModels API and iTwin.js library for backend.",
   "keywords": [
     "Bentley",

--- a/itwin-platform-access/imodels-access-frontend/package.json
+++ b/itwin-platform-access/imodels-access-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-access-frontend",
-  "version": "3.2.0",
+  "version": "3.1.0",
   "description": "Interoperability package between iModels API and iTwin.js library for frontend.",
   "keywords": [
     "Bentley",

--- a/tests/imodels-access-backend-tests/package.json
+++ b/tests/imodels-access-backend-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-access-backend-tests",
-  "version": "3.2.0",
+  "version": "3.1.0",
   "description": "Tests for iTwin platform and iModels API interoperability package - @itwin/imodels-access-backend.",
   "keywords": [
     "Bentley",

--- a/tests/imodels-access-frontend-tests/package.json
+++ b/tests/imodels-access-frontend-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-access-frontend-tests",
-  "version": "3.2.0",
+  "version": "3.1.0",
   "description": "Tests for iTwin platform and iModels API interoperability package - @itwin/imodels-access-frontend.",
   "keywords": [
     "Bentley",

--- a/tests/imodels-clients-tests-browser/package.json
+++ b/tests/imodels-clients-tests-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-clients-tests-browser",
-  "version": "3.2.0",
+  "version": "3.1.0",
   "description": "Tests for iModels API client wrappers",
   "keywords": [
     "Bentley",

--- a/tests/imodels-clients-tests/package.json
+++ b/tests/imodels-clients-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-clients-tests",
-  "version": "3.2.0",
+  "version": "3.1.0",
   "description": "Tests for iModels API client wrappers",
   "keywords": [
     "Bentley",

--- a/utils/imodels-client-common-config/package.json
+++ b/utils/imodels-client-common-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-client-common-config",
-  "version": "3.2.0",
+  "version": "3.1.0",
   "description": "Common configuration for iModels API client wrappers.",
   "keywords": [
     "Bentley",

--- a/utils/imodels-client-test-utils/package.json
+++ b/utils/imodels-client-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-client-test-utils",
-  "version": "3.2.0",
+  "version": "3.1.0",
   "description": "Common utilities for iModels API client wrappers tests.",
   "keywords": [
     "Bentley",


### PR DESCRIPTION
Reverts iTwin/imodels-clients#167 - the new iTwin.js 4.0 does not support old versions anymore and neither should we. We should drop support for Node 12, 14, 16 and release a new major version.