### PR TITLE
Remove Node 12, iTwin.js ^3.6 support

### DIFF
--- a/clients/imodels-client-management/package.json
+++ b/clients/imodels-client-management/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@itwin/imodels-client-common-config": "workspace:*",
-    "@types/node": "~18.11.18",
+    "@types/node": "^18.11.18",
     "cspell": "~5.21.0",
     "eslint": "~7.31.0",
     "rimraf": "~3.0.2",

--- a/common/config/azure-pipelines/build-test-publish.yml
+++ b/common/config/azure-pipelines/build-test-publish.yml
@@ -9,8 +9,7 @@ parameters:
 trigger: none
 
 variables:
-  node18Version: '18.13.0'
-  node12Version: '12.17.0'
+  node18Version: '18.12.0'
 
 jobs:
   - job: BuildAndTest
@@ -19,9 +18,6 @@ jobs:
         linux-node18:
           imageName: 'ubuntu-latest'
           nodeVersion: $(node18Version)
-        linux-node12:
-          imageName: 'ubuntu-latest'
-          nodeVersion: $(node12Version)
         mac-node18:
           imageName: 'macos-latest'
           nodeVersion: $(node18Version)

--- a/common/config/azure-pipelines/build-test.yml
+++ b/common/config/azure-pipelines/build-test.yml
@@ -9,7 +9,7 @@ parameters:
 trigger: none
 
 variables:
-  node18Version: '18.13.0'
+  node18Version: '18.12.0'
 
 jobs:
   - job: BuildAndTest

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -336,14 +336,16 @@ importers:
       eslint-plugin-import: ~2.23.4
       eslint-plugin-mocha: ~9.0.0
       sort-package-json: ~1.53.1
+      typescript: ~4.4.0
     devDependencies:
-      '@itwin/eslint-plugin': 3.5.6_eslint@7.31.0
-      '@typescript-eslint/eslint-plugin': 4.28.5_b121c633c473862f790ae30ff0479b86
-      '@typescript-eslint/parser': 4.28.5_eslint@7.31.0
+      '@itwin/eslint-plugin': 3.5.6_eslint@7.31.0+typescript@4.4.4
+      '@typescript-eslint/eslint-plugin': 4.28.5_2d27c79b551e458fb3b3f741bd766f57
+      '@typescript-eslint/parser': 4.28.5_eslint@7.31.0+typescript@4.4.4
       eslint: 7.31.0
       eslint-plugin-import: 2.23.4_eslint@7.31.0
       eslint-plugin-mocha: 9.0.0_eslint@7.31.0
       sort-package-json: 1.53.1
+      typescript: 4.4.4
 
   ../../utils/imodels-client-test-utils:
     specifiers:
@@ -1155,19 +1157,19 @@ packages:
       almost-equal: 1.1.0
     dev: false
 
-  /@itwin/eslint-plugin/3.5.6_eslint@7.31.0:
+  /@itwin/eslint-plugin/3.5.6_eslint@7.31.0+typescript@4.4.4:
     resolution: {integrity: sha512-qXvhoqb9BxonCkveqh+cFt0phQvqgkg1mLPwXrZLd13EtMJdgNmFC76R/01VB0gEekOZwCCCqsz1v1LPl0XXdA==}
     hasBin: true
     peerDependencies:
       eslint: ^7.0.0
       typescript: ^3.7.0 || ^4.0.0
     dependencies:
-      '@typescript-eslint/eslint-plugin': 4.31.2_3fd1a1ec83a9a98a06723734fcfa3caa
-      '@typescript-eslint/parser': 4.31.2_eslint@7.31.0
+      '@typescript-eslint/eslint-plugin': 4.31.2_effd6c19eb91d288277d259d1bcca7c5
+      '@typescript-eslint/parser': 4.31.2_eslint@7.31.0+typescript@4.4.4
       eslint: 7.31.0
       eslint-import-resolver-node: 0.3.4
       eslint-import-resolver-typescript: 2.7.1_af3c5ebbf5d724335f85761a63ef0220
-      eslint-plugin-deprecation: 1.2.1_eslint@7.31.0
+      eslint-plugin-deprecation: 1.2.1_eslint@7.31.0+typescript@4.4.4
       eslint-plugin-import: 2.23.4_eslint@7.31.0
       eslint-plugin-jam3: 0.2.3
       eslint-plugin-jsdoc: 35.1.3_eslint@7.31.0
@@ -1176,6 +1178,7 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.31.0
       eslint-plugin-react-hooks: 4.2.0_eslint@7.31.0
       require-dir: 1.2.0
+      typescript: 4.4.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1403,7 +1406,7 @@ packages:
     dev: false
     optional: true
 
-  /@typescript-eslint/eslint-plugin/4.28.5_b121c633c473862f790ae30ff0479b86:
+  /@typescript-eslint/eslint-plugin/4.28.5_2d27c79b551e458fb3b3f741bd766f57:
     resolution: {integrity: sha512-m31cPEnbuCqXtEZQJOXAHsHvtoDi9OVaeL5wZnO2KZTnkvELk+u6J6jHg+NzvWQxk+87Zjbc4lJS4NHmgImz6Q==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -1414,20 +1417,21 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.28.5_eslint@7.31.0
-      '@typescript-eslint/parser': 4.28.5_eslint@7.31.0
+      '@typescript-eslint/experimental-utils': 4.28.5_eslint@7.31.0+typescript@4.4.4
+      '@typescript-eslint/parser': 4.28.5_eslint@7.31.0+typescript@4.4.4
       '@typescript-eslint/scope-manager': 4.28.5
       debug: 4.3.4
       eslint: 7.31.0
       functional-red-black-tree: 1.0.1
       regexpp: 3.2.0
       semver: 7.5.0
-      tsutils: 3.21.0
+      tsutils: 3.21.0_typescript@4.4.4
+      typescript: 4.4.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin/4.31.2_3fd1a1ec83a9a98a06723734fcfa3caa:
+  /@typescript-eslint/eslint-plugin/4.31.2_effd6c19eb91d288277d259d1bcca7c5:
     resolution: {integrity: sha512-w63SCQ4bIwWN/+3FxzpnWrDjQRXVEGiTt9tJTRptRXeFvdZc/wLiz3FQUwNQ2CVoRGI6KUWMNUj/pk63noUfcA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -1438,20 +1442,21 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.31.2_eslint@7.31.0
-      '@typescript-eslint/parser': 4.31.2_eslint@7.31.0
+      '@typescript-eslint/experimental-utils': 4.31.2_eslint@7.31.0+typescript@4.4.4
+      '@typescript-eslint/parser': 4.31.2_eslint@7.31.0+typescript@4.4.4
       '@typescript-eslint/scope-manager': 4.31.2
       debug: 4.3.4
       eslint: 7.31.0
       functional-red-black-tree: 1.0.1
       regexpp: 3.2.0
       semver: 7.5.0
-      tsutils: 3.21.0
+      tsutils: 3.21.0_typescript@4.4.4
+      typescript: 4.4.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils/3.10.1_eslint@7.31.0:
+  /@typescript-eslint/experimental-utils/3.10.1_eslint@7.31.0+typescript@4.4.4:
     resolution: {integrity: sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -1459,7 +1464,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       '@typescript-eslint/types': 3.10.1
-      '@typescript-eslint/typescript-estree': 3.10.1
+      '@typescript-eslint/typescript-estree': 3.10.1_typescript@4.4.4
       eslint: 7.31.0
       eslint-scope: 5.1.1
       eslint-utils: 2.1.0
@@ -1468,7 +1473,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/experimental-utils/4.28.5_eslint@7.31.0:
+  /@typescript-eslint/experimental-utils/4.28.5_eslint@7.31.0+typescript@4.4.4:
     resolution: {integrity: sha512-bGPLCOJAa+j49hsynTaAtQIWg6uZd8VLiPcyDe4QPULsvQwLHGLSGKKcBN8/lBxIX14F74UEMK2zNDI8r0okwA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -1477,7 +1482,7 @@ packages:
       '@types/json-schema': 7.0.11
       '@typescript-eslint/scope-manager': 4.28.5
       '@typescript-eslint/types': 4.28.5
-      '@typescript-eslint/typescript-estree': 4.28.5
+      '@typescript-eslint/typescript-estree': 4.28.5_typescript@4.4.4
       eslint: 7.31.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@7.31.0
@@ -1486,7 +1491,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/experimental-utils/4.31.2_eslint@7.31.0:
+  /@typescript-eslint/experimental-utils/4.31.2_eslint@7.31.0+typescript@4.4.4:
     resolution: {integrity: sha512-3tm2T4nyA970yQ6R3JZV9l0yilE2FedYg8dcXrTar34zC9r6JB7WyBQbpIVongKPlhEMjhQ01qkwrzWy38Bk1Q==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -1495,7 +1500,7 @@ packages:
       '@types/json-schema': 7.0.11
       '@typescript-eslint/scope-manager': 4.31.2
       '@typescript-eslint/types': 4.31.2
-      '@typescript-eslint/typescript-estree': 4.31.2
+      '@typescript-eslint/typescript-estree': 4.31.2_typescript@4.4.4
       eslint: 7.31.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@7.31.0
@@ -1504,7 +1509,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/parser/4.28.5_eslint@7.31.0:
+  /@typescript-eslint/parser/4.28.5_eslint@7.31.0+typescript@4.4.4:
     resolution: {integrity: sha512-NPCOGhTnkXGMqTznqgVbA5LqVsnw+i3+XA1UKLnAb+MG1Y1rP4ZSK9GX0kJBmAZTMIktf+dTwXToT6kFwyimbw==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -1516,14 +1521,15 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 4.28.5
       '@typescript-eslint/types': 4.28.5
-      '@typescript-eslint/typescript-estree': 4.28.5
+      '@typescript-eslint/typescript-estree': 4.28.5_typescript@4.4.4
       debug: 4.3.4
       eslint: 7.31.0
+      typescript: 4.4.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/4.31.2_eslint@7.31.0:
+  /@typescript-eslint/parser/4.31.2_eslint@7.31.0+typescript@4.4.4:
     resolution: {integrity: sha512-EcdO0E7M/sv23S/rLvenHkb58l3XhuSZzKf6DBvLgHqOYdL6YFMYVtreGFWirxaU2mS1GYDby3Lyxco7X5+Vjw==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -1535,9 +1541,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 4.31.2
       '@typescript-eslint/types': 4.31.2
-      '@typescript-eslint/typescript-estree': 4.31.2
+      '@typescript-eslint/typescript-estree': 4.31.2_typescript@4.4.4
       debug: 4.3.4
       eslint: 7.31.0
+      typescript: 4.4.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1573,7 +1580,7 @@ packages:
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
     dev: true
 
-  /@typescript-eslint/typescript-estree/3.10.1:
+  /@typescript-eslint/typescript-estree/3.10.1_typescript@4.4.4:
     resolution: {integrity: sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -1589,12 +1596,13 @@ packages:
       is-glob: 4.0.3
       lodash: 4.17.21
       semver: 7.5.0
-      tsutils: 3.21.0
+      tsutils: 3.21.0_typescript@4.4.4
+      typescript: 4.4.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree/4.28.5:
+  /@typescript-eslint/typescript-estree/4.28.5_typescript@4.4.4:
     resolution: {integrity: sha512-FzJUKsBX8poCCdve7iV7ShirP8V+ys2t1fvamVeD1rWpiAnIm550a+BX/fmTHrjEpQJ7ZAn+Z7ZZwJjytk9rZw==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -1609,12 +1617,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.0
-      tsutils: 3.21.0
+      tsutils: 3.21.0_typescript@4.4.4
+      typescript: 4.4.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree/4.31.2:
+  /@typescript-eslint/typescript-estree/4.31.2_typescript@4.4.4:
     resolution: {integrity: sha512-ieBq8U9at6PvaC7/Z6oe8D3czeW5d//Fo1xkF/s9394VR0bg/UaMYPdARiWyKX+lLEjY3w/FNZJxitMsiWv+wA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -1629,7 +1638,8 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.0
-      tsutils: 3.21.0
+      tsutils: 3.21.0_typescript@4.4.4
+      typescript: 4.4.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2773,16 +2783,17 @@ packages:
       eslint: 7.31.0
     dev: true
 
-  /eslint-plugin-deprecation/1.2.1_eslint@7.31.0:
+  /eslint-plugin-deprecation/1.2.1_eslint@7.31.0+typescript@4.4.4:
     resolution: {integrity: sha512-8KFAWPO3AvF0szxIh1ivRtHotd1fzxVOuNR3NI8dfCsQKgcxu9fAgEY+eTKvCRLAwwI8kaDDfImMt+498+EgRw==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0
       typescript: ^3.7.5 || ^4.0.0
     dependencies:
-      '@typescript-eslint/experimental-utils': 3.10.1_eslint@7.31.0
+      '@typescript-eslint/experimental-utils': 3.10.1_eslint@7.31.0+typescript@4.4.4
       eslint: 7.31.0
       tslib: 1.14.1
-      tsutils: 3.21.0
+      tsutils: 3.21.0_typescript@4.4.4
+      typescript: 4.4.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5386,13 +5397,14 @@ packages:
   /tslib/2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
 
-  /tsutils/3.21.0:
+  /tsutils/3.21.0_typescript@4.4.4:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
+      typescript: 4.4.4
     dev: true
 
   /tunnel-agent/0.6.0:

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -33,7 +33,7 @@ importers:
   ../../clients/imodels-client-management:
     specifiers:
       '@itwin/imodels-client-common-config': workspace:*
-      '@types/node': ~18.11.18
+      '@types/node': ^18.11.18
       axios: ^1.0.0
       cspell: ~5.21.0
       eslint: ~7.31.0
@@ -245,7 +245,7 @@ importers:
       '@types/chai': ~4.2.21
       '@types/chai-as-promised': ~7.1.5
       '@types/mocha': ~9.0.0
-      '@types/node': ~18.11.18
+      '@types/node': ^18.11.18
       axios: ^1.0.0
       chai: ~4.3.4
       chai-as-promised: ~7.1.1
@@ -295,7 +295,7 @@ importers:
       '@itwin/imodels-client-management': workspace:*
       '@itwin/imodels-client-test-utils': workspace:*
       '@types/chai': ~4.2.21
-      '@types/node': ~18.11.18
+      '@types/node': ^18.11.18
       chai: ~4.3.4
       cpx2: 4.2.0
       cspell: ~5.21.0
@@ -352,7 +352,7 @@ importers:
       '@itwin/imodels-client-management': workspace:*
       '@itwin/object-storage-core': ^1.6.0
       '@types/chai': ~4.2.21
-      '@types/node': ~18.11.18
+      '@types/node': ^18.11.18
       axios: ^1.0.0
       chai: ~4.3.4
       cpx2: 4.2.0

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -53,7 +53,7 @@ importers:
 
   ../../itwin-platform-access/imodels-access-backend:
     specifiers:
-      '@azure/abort-controller': ~1.1.0
+      '@azure/abort-controller': ^1.1.0
       '@itwin/core-backend': ^4.0.0
       '@itwin/core-bentley': ^4.0.0
       '@itwin/core-common': ^4.0.0
@@ -235,7 +235,7 @@ importers:
 
   ../../tests/imodels-clients-tests:
     specifiers:
-      '@azure/abort-controller': ~1.1.0
+      '@azure/abort-controller': ^1.1.0
       '@itwin/imodels-client-authoring': workspace:*
       '@itwin/imodels-client-common-config': workspace:*
       '@itwin/imodels-client-management': workspace:*

--- a/itwin-platform-access/imodels-access-backend/package.json
+++ b/itwin-platform-access/imodels-access-backend/package.json
@@ -31,7 +31,7 @@
     "extends": "./node_modules/@itwin/imodels-client-common-config/.eslintrc.json"
   },
   "dependencies": {
-    "@azure/abort-controller": "~1.1.0",
+    "@azure/abort-controller": "^1.1.0",
     "@itwin/imodels-client-authoring": "workspace:*",
     "axios": "^1.0.0"
   },

--- a/itwin-platform-access/imodels-access-backend/package.json
+++ b/itwin-platform-access/imodels-access-backend/package.json
@@ -50,8 +50,8 @@
     "typescript": "~4.4.0"
   },
   "peerDependencies": {
-    "@itwin/core-backend": "^3.6.0 || ^4.0.0",
-    "@itwin/core-bentley": "^3.6.0 || ^4.0.0",
-    "@itwin/core-common": "^3.6.0 || ^4.0.0"
+    "@itwin/core-backend": "^4.0.0",
+    "@itwin/core-bentley": "^4.0.0",
+    "@itwin/core-common": "^4.0.0"
   }
 }

--- a/itwin-platform-access/imodels-access-frontend/package.json
+++ b/itwin-platform-access/imodels-access-frontend/package.json
@@ -52,8 +52,8 @@
     "typescript": "~4.4.0"
   },
   "peerDependencies": {
-    "@itwin/core-bentley": "^3.6.0 || ^4.0.0",
-    "@itwin/core-common": "^3.6.0 || ^4.0.0",
-    "@itwin/core-frontend": "^3.6.0 || ^4.0.0"
+    "@itwin/core-bentley": "^4.0.0",
+    "@itwin/core-common": "^4.0.0",
+    "@itwin/core-frontend": "^4.0.0"
   }
 }

--- a/rush.json
+++ b/rush.json
@@ -2,7 +2,7 @@
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush.schema.json",
   "rushVersion": "5.88.0",
   "pnpmVersion": "6.35.1",
-  "nodeSupportedVersionRange": ">=12.13.0 <19.0.0",
+  "nodeSupportedVersionRange": "^18.12.0",
   "ensureConsistentVersions": true,
   "projectFolderMinDepth": 1,
   "projectFolderMaxDepth": 2,

--- a/tests/imodels-clients-tests-browser/package.json
+++ b/tests/imodels-clients-tests-browser/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@itwin/imodels-client-common-config": "workspace:*",
     "@types/chai": "~4.2.21",
-    "@types/node": "~18.11.18",
+    "@types/node": "^18.11.18",
     "cpx2": "4.2.0",
     "cspell": "~5.21.0",
     "eslint": "~7.31.0",

--- a/tests/imodels-clients-tests/package.json
+++ b/tests/imodels-clients-tests/package.json
@@ -36,7 +36,7 @@
     "extends": "./node_modules/@itwin/imodels-client-common-config/.eslintrc.json"
   },
   "dependencies": {
-    "@azure/abort-controller": "~1.1.0",
+    "@azure/abort-controller": "^1.1.0",
     "@itwin/imodels-client-authoring": "workspace:*",
     "@itwin/imodels-client-management": "workspace:*",
     "@itwin/imodels-client-test-utils": "workspace:*",

--- a/tests/imodels-clients-tests/package.json
+++ b/tests/imodels-clients-tests/package.json
@@ -55,7 +55,7 @@
     "@types/chai": "~4.2.21",
     "@types/chai-as-promised": "~7.1.5",
     "@types/mocha": "~9.0.0",
-    "@types/node": "~18.11.18",
+    "@types/node": "^18.11.18",
     "cpx2": "4.2.0",
     "cspell": "~5.21.0",
     "eslint": "~7.31.0",

--- a/utils/imodels-client-common-config/package.json
+++ b/utils/imodels-client-common-config/package.json
@@ -32,6 +32,7 @@
     "eslint": "~7.31.0",
     "eslint-plugin-import": "~2.23.4",
     "eslint-plugin-mocha": "~9.0.0",
-    "sort-package-json": "~1.53.1"
+    "sort-package-json": "~1.53.1",
+    "typescript": "~4.4.0"
   }
 }

--- a/utils/imodels-client-common-config/tsconfig.json
+++ b/utils/imodels-client-common-config/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "es2021",
     "module": "commonjs",
     "sourceMap": true,
     "inlineSources": true,
     "lib": [
-      "es2018",
+      "es2021",
       "esnext.asynciterable",
       "DOM"
     ],

--- a/utils/imodels-client-test-utils/package.json
+++ b/utils/imodels-client-test-utils/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@itwin/imodels-client-common-config": "workspace:*",
     "@types/chai": "~4.2.21",
-    "@types/node": "~18.11.18",
+    "@types/node": "^18.11.18",
     "cpx2": "4.2.0",
     "cspell": "~5.21.0",
     "eslint": "~7.31.0",


### PR DESCRIPTION
In this PR:
- Removed support for old Node 12, 14, 16 versions. This change will be released in a new major version together with iTwin.js 4.0 support.
- Removed support for iTwin.js ^3.6 package versions. ^3.6 || ^4.0 support was added in an attempt to avoid a major version in imodels-clients repo packages but we later noticed that iTwin.js 4.0 drops support for Node 12 and we very much want to drop support for old Node versions in clients. Since iTwin.js ^3.6 packages still support old Node versions we would rather drop support for iTwin.js ^3.6 in imodels-clients 4.0 rather than keep supporting both old iTwin.js and Node.