### PR TITLE
Major version bump 3.1.0 -> 4.0.0

### DIFF
--- a/clients/imodels-client-authoring/CHANGELOG.md
+++ b/clients/imodels-client-authoring/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log - @itwin/imodels-client-authoring 
 
+## 4.0.0
+
+Breaking changes:
+- Dropped support for Node.js versions older than 18.12.0.
+
 ## 3.0.0
 
 Breaking changes:

--- a/clients/imodels-client-authoring/package.json
+++ b/clients/imodels-client-authoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-client-authoring",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "iModels API client wrapper for applications that author iModels.",
   "keywords": [
     "Bentley",

--- a/clients/imodels-client-management/CHANGELOG.md
+++ b/clients/imodels-client-management/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log - @itwin/imodels-client-management 
 
+## 4.0.0
+
+Breaking changes:
+- Dropped support for Node.js versions older than 18.12.0.
+
 ## 3.0.0
 
 Breaking changes:

--- a/clients/imodels-client-management/package.json
+++ b/clients/imodels-client-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-client-management",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "iModels API client wrapper for applications that manage iModels.",
   "keywords": [
     "Bentley",

--- a/itwin-platform-access/imodels-access-backend/CHANGELOG.md
+++ b/itwin-platform-access/imodels-access-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log - @itwin/imodels-access-backend
 
+## 4.0.0
+
+Breaking changes:
+- Updated iTwin.js peer dependencies to version 4.0.0.
+- Dropped support for Node.js versions older than 18.12.0.
+
 ## 3.0.0
 
 Breaking changes:

--- a/itwin-platform-access/imodels-access-backend/package.json
+++ b/itwin-platform-access/imodels-access-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-access-backend",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Interoperability package between iModels API and iTwin.js library for backend.",
   "keywords": [
     "Bentley",

--- a/itwin-platform-access/imodels-access-frontend/CHANGELOG.md
+++ b/itwin-platform-access/imodels-access-frontend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log - @itwin/imodels-access-frontend
 
+## 4.0.0
+
+Breaking changes:
+- Updated iTwin.js peer dependencies to version 4.0.0.
+- Dropped support for Node.js versions older than 18.12.0.
+
 ## 3.0.0
 
 Breaking changes:

--- a/itwin-platform-access/imodels-access-frontend/package.json
+++ b/itwin-platform-access/imodels-access-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-access-frontend",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Interoperability package between iModels API and iTwin.js library for frontend.",
   "keywords": [
     "Bentley",

--- a/tests/imodels-access-backend-tests/package.json
+++ b/tests/imodels-access-backend-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-access-backend-tests",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Tests for iTwin platform and iModels API interoperability package - @itwin/imodels-access-backend.",
   "keywords": [
     "Bentley",

--- a/tests/imodels-access-frontend-tests/package.json
+++ b/tests/imodels-access-frontend-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-access-frontend-tests",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Tests for iTwin platform and iModels API interoperability package - @itwin/imodels-access-frontend.",
   "keywords": [
     "Bentley",

--- a/tests/imodels-clients-tests-browser/package.json
+++ b/tests/imodels-clients-tests-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-clients-tests-browser",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Tests for iModels API client wrappers",
   "keywords": [
     "Bentley",

--- a/tests/imodels-clients-tests/package.json
+++ b/tests/imodels-clients-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-clients-tests",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Tests for iModels API client wrappers",
   "keywords": [
     "Bentley",

--- a/utils/imodels-client-common-config/package.json
+++ b/utils/imodels-client-common-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-client-common-config",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Common configuration for iModels API client wrappers.",
   "keywords": [
     "Bentley",

--- a/utils/imodels-client-test-utils/package.json
+++ b/utils/imodels-client-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-client-test-utils",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Common utilities for iModels API client wrappers tests.",
   "keywords": [
     "Bentley",


### PR DESCRIPTION
In this PR:
- Bumped the package version to release dropped old Node engine support and updated peer iTwin.js dependencies