### PR TITLE
Bump clients to 4.1.0, iTwin.js interop packages to 4.0.1

### DIFF
--- a/clients/imodels-client-authoring/package.json
+++ b/clients/imodels-client-authoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-client-authoring",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "iModels API client wrapper for applications that author iModels.",
   "keywords": [
     "Bentley",

--- a/clients/imodels-client-management/package.json
+++ b/clients/imodels-client-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-client-management",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "iModels API client wrapper for applications that manage iModels.",
   "keywords": [
     "Bentley",

--- a/itwin-platform-access/imodels-access-backend/package.json
+++ b/itwin-platform-access/imodels-access-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-access-backend",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Interoperability package between iModels API and iTwin.js library for backend.",
   "keywords": [
     "Bentley",

--- a/itwin-platform-access/imodels-access-frontend/package.json
+++ b/itwin-platform-access/imodels-access-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-access-frontend",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Interoperability package between iModels API and iTwin.js library for frontend.",
   "keywords": [
     "Bentley",

--- a/tests/imodels-access-backend-tests/package.json
+++ b/tests/imodels-access-backend-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-access-backend-tests",
-  "version": "4.0.0",
+  "version": "0.0.0",
   "description": "Tests for iTwin platform and iModels API interoperability package - @itwin/imodels-access-backend.",
   "keywords": [
     "Bentley",

--- a/tests/imodels-access-frontend-tests/package.json
+++ b/tests/imodels-access-frontend-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-access-frontend-tests",
-  "version": "4.0.0",
+  "version": "0.0.0",
   "description": "Tests for iTwin platform and iModels API interoperability package - @itwin/imodels-access-frontend.",
   "keywords": [
     "Bentley",

--- a/tests/imodels-clients-tests-browser/package.json
+++ b/tests/imodels-clients-tests-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-clients-tests-browser",
-  "version": "4.0.0",
+  "version": "0.0.0",
   "description": "Tests for iModels API client wrappers",
   "keywords": [
     "Bentley",

--- a/tests/imodels-clients-tests/package.json
+++ b/tests/imodels-clients-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-clients-tests",
-  "version": "4.0.0",
+  "version": "0.0.0",
   "description": "Tests for iModels API client wrappers",
   "keywords": [
     "Bentley",

--- a/utils/imodels-client-common-config/package.json
+++ b/utils/imodels-client-common-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-client-common-config",
-  "version": "4.0.0",
+  "version": "0.0.0",
   "description": "Common configuration for iModels API client wrappers.",
   "keywords": [
     "Bentley",

--- a/utils/imodels-client-test-utils/package.json
+++ b/utils/imodels-client-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-client-test-utils",
-  "version": "4.0.0",
+  "version": "0.0.0",
   "description": "Common utilities for iModels API client wrappers tests.",
   "keywords": [
     "Bentley",


### PR DESCRIPTION
In this PR:
- Bumped the package versions:
  - @itwin/imodels-client-management to 4.1.0 
  - @itwin/imodels-client-authoring to 4.1.0
  - @itwin/imodels-access-backend to 4.0.1  
  - @itwin/imodels-access-frontend to 4.0.1
- Changed the versions of non-published packages to 0.0.0 