### PR TITLE
`BackendIModelsAccess.queryV2Checkpoint` fix: do not attempt to query Changeset with index 0

### DIFF
--- a/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
@@ -279,7 +279,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
     return this.findLatestV2CheckpointForChangeset(arg, previousChangesetIndex);
   }
 
-  private async resolveChangesetIndex(arg: CheckpointProps): Promise<number> {
+  private async resolveChangesetIndexFromParamsOrQueryApi(arg: CheckpointProps): Promise<number> {
     if (arg.changeset.id === this._changeSet0.id || arg.changeset.index === this._changeSet0.index)
       return this._changeSet0.index;
 
@@ -295,7 +295,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
   }
 
   private async queryCurrentOrPrecedingV2Checkpoint(arg: CheckpointProps): Promise<V2CheckpointAccessProps | undefined> {
-    const changesetIndex = await this.resolveChangesetIndex(arg);
+    const changesetIndex = await this.resolveChangesetIndexFromParamsOrQueryApi(arg);
     const containerAccessInfo = await this.findLatestV2CheckpointForChangeset(arg, changesetIndex);
     if (containerAccessInfo === undefined)
       return undefined;

--- a/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
@@ -7,7 +7,7 @@ import { join } from "path";
 import {
   AcquireNewBriefcaseIdArg, BackendHubAccess, BriefcaseDbArg, BriefcaseIdArg, BriefcaseLocalValue, ChangesetArg,
   ChangesetRangeArg, CheckpointArg, CheckpointProps, CreateNewIModelProps, DownloadChangesetArg, DownloadChangesetRangeArg,
-  IModelDb, IModelHost, IModelIdArg, IModelJsFs,  IModelNameArg, ITwinIdArg, LockMap, LockProps, SnapshotDb, TokenArg, V2CheckpointAccessProps
+  IModelDb, IModelHost, IModelIdArg, IModelJsFs, IModelNameArg, ITwinIdArg, LockMap, LockProps, SnapshotDb, TokenArg, V2CheckpointAccessProps
 } from "@itwin/core-backend";
 import { BriefcaseStatus, Guid, GuidString, IModelStatus, Logger, OpenMode } from "@itwin/core-bentley";
 import {
@@ -263,7 +263,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
 
     const getSingleChangesetParams: GetSingleChangesetParams = {
       ...this.getIModelScopedOperationParams(arg),
-      ...PlatformToClientAdapter.toChangesetIdOrIndex({index: changesetIndex})
+      ...PlatformToClientAdapter.toChangesetIdOrIndex({ index: changesetIndex })
     };
 
     const changeset = await this._iModelsClient.changesets.getSingle(getSingleChangesetParams);
@@ -279,14 +279,24 @@ export class BackendIModelsAccess implements BackendHubAccess {
     return this.findLatestV2CheckpointForChangeset(arg, previousChangesetIndex);
   }
 
-  private async queryCurrentOrPrecedingV2Checkpoint(arg: CheckpointProps): Promise<V2CheckpointAccessProps | undefined> {
+  private async resolveChangesetIndex(arg: CheckpointProps): Promise<number> {
+    if (arg.changeset.id === this._changeSet0.id || arg.changeset.index === this._changeSet0.index)
+      return this._changeSet0.index;
+
+    if (arg.changeset.index !== undefined)
+      return arg.changeset.index;
+
     const getSingleChangesetParams: GetSingleChangesetParams = {
       ...this.getIModelScopedOperationParams(arg),
-      ...PlatformToClientAdapter.toChangesetIdOrIndex(arg.changeset)
+      changesetId: arg.changeset.id
     };
-
     const changeset = await this._iModelsClient.changesets.getSingle(getSingleChangesetParams);
-    const containerAccessInfo = await this.findLatestV2CheckpointForChangeset(arg, changeset.index);
+    return changeset.index;
+  }
+
+  private async queryCurrentOrPrecedingV2Checkpoint(arg: CheckpointProps): Promise<V2CheckpointAccessProps | undefined> {
+    const changesetIndex = await this.resolveChangesetIndex(arg);
+    const containerAccessInfo = await this.findLatestV2CheckpointForChangeset(arg, changesetIndex);
     if (containerAccessInfo === undefined)
       return undefined;
 


### PR DESCRIPTION
In this PR:
- Fixed `BackendIModelsAccess.queryV2Checkpoint` to not attempt to query changeset if index if 0. 