### PR TITLE
Allow publishing from non-`main` branch

### DIFF
--- a/common/config/azure-pipelines/templates/publish.yml
+++ b/common/config/azure-pipelines/templates/publish.yml
@@ -13,6 +13,5 @@ steps:
 
   - script: node common/scripts/install-run-rush.js publish --publish --include-all --set-access-level public
     displayName: rush publish package
-    condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
     env:
       NPM_AUTH_TOKEN: $(npmToken)


### PR DESCRIPTION
In this PR:
- Removed the `main` branch constraint from publishing. This will allow to release older versions with backported changes,