### PR TITLE
Fix releaseAllLocks and queryAllLocks methods to read all pages

### DIFF
--- a/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
@@ -354,13 +354,13 @@ export class BackendIModelsAccess implements BackendHubAccess {
     if (locks.length === 0)
       return [];
 
-    var lockPoperties: LockProps[] = new Array();
+    var lockProperties: LockProps[] = new Array();
 
     for (const locksPage of locks){
-      Array.prototype.push.apply(lockPoperties, ClientToPlatformAdapter.toLockProps(locksPage));
+      Array.prototype.push.apply(lockProperties, ClientToPlatformAdapter.toLockProps(locksPage));
     };
 
-    return lockPoperties;
+    return lockProperties;
   }
 
   public async releaseAllLocks(arg: BriefcaseDbArg): Promise<void> {

--- a/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
@@ -354,13 +354,8 @@ export class BackendIModelsAccess implements BackendHubAccess {
     if (locks.length === 0)
       return [];
 
-    let lockProperties: LockProps[] = [];
-
-    for (const locksPage of locks){
-      Array.prototype.push.apply(lockProperties, ClientToPlatformAdapter.toLockProps(locksPage));
-    }
-
-    return lockProperties;
+    const result: LockProps[] = locks.flatMap(ClientToPlatformAdapter.toLockProps);
+    return result;
   }
 
   public async releaseAllLocks(arg: BriefcaseDbArg): Promise<void> {

--- a/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
@@ -512,7 +512,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
     if (locksPage.length === 0)
       return;
 
-    for await (const lock of locksPage) {
+    for (const lock of locksPage) {
       this.setLockLevelToNone(lock.lockedObjects);
 
       const updateLockParams: UpdateLockParams = {

--- a/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
@@ -354,11 +354,11 @@ export class BackendIModelsAccess implements BackendHubAccess {
     if (locks.length === 0)
       return [];
 
-    var lockProperties: LockProps[] = new Array();
+    let lockProperties: LockProps[] = [];
 
     for (const locksPage of locks){
       Array.prototype.push.apply(lockProperties, ClientToPlatformAdapter.toLockProps(locksPage));
-    };
+    }
 
     return lockProperties;
   }
@@ -376,7 +376,6 @@ export class BackendIModelsAccess implements BackendHubAccess {
     if (locks.length === 0)
       return;
 
-
     for await (const locksPage of locks){
       this.setLockLevelToNone(locksPage.lockedObjects);
 
@@ -388,7 +387,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
       };
 
       await this._iModelsClient.locks.update(updateLockParams);
-    };
+    }
   }
 
   public async queryIModelByName(arg: IModelNameArg): Promise<GuidString | undefined> {

--- a/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
@@ -431,7 +431,6 @@ export class BackendIModelsAccess implements BackendHubAccess {
 
   private setLockLevelToNone(lockedObjectsForBriefcase: LockedObjects[]): void {
     for (const lockedObjects of lockedObjectsForBriefcase) {
-      "";
       lockedObjects.lockLevel = LockLevel.None;
     }
   }

--- a/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
+++ b/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
@@ -449,11 +449,14 @@ describe("BackendIModelsAccess", () => {
         briefcaseId,
         changeset: { id: "", index: 0 }
       };
-      const locksToAcquire: LockMap = new Map<string, LockState>([
-        ["0x1", LockState.Exclusive],
-        ["0x2", LockState.Exclusive],
-        ["0x3", LockState.Shared]
-      ]);
+
+
+      const locksToAcquire: LockMap = new Map<string, LockState>();
+
+      var objectIdsDec = Array.from({length: 201}, (_, i) => i + 1);
+      for (const objectId of objectIdsDec){
+        locksToAcquire.set("0x" + objectId.toString(16), LockState.Exclusive);
+      };
 
       await backendIModelsAccess.acquireLocks(briefcaseDbParams, locksToAcquire);
       await assertLocks({

--- a/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
+++ b/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
@@ -454,7 +454,7 @@ describe("BackendIModelsAccess", () => {
 
       const objectIdsDec = Array.from({length: 201}, (_, i) => i + 1);
       for (const objectId of objectIdsDec){
-        locksToAcquire.set(`0x ${objectId.toString(16)}`, LockState.Exclusive);
+        locksToAcquire.set(`0x${objectId.toString(16)}`, LockState.Exclusive);
       }
 
       await backendIModelsAccess.acquireLocks(briefcaseDbParams, locksToAcquire);

--- a/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
+++ b/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
@@ -450,13 +450,12 @@ describe("BackendIModelsAccess", () => {
         changeset: { id: "", index: 0 }
       };
 
-
       const locksToAcquire: LockMap = new Map<string, LockState>();
 
-      var objectIdsDec = Array.from({length: 201}, (_, i) => i + 1);
+      const objectIdsDec = Array.from({length: 201}, (_, i) => i + 1);
       for (const objectId of objectIdsDec){
-        locksToAcquire.set("0x" + objectId.toString(16), LockState.Exclusive);
-      };
+        locksToAcquire.set(`0x ${objectId.toString(16)}`, LockState.Exclusive);
+      }
 
       await backendIModelsAccess.acquireLocks(briefcaseDbParams, locksToAcquire);
       await assertLocks({


### PR DESCRIPTION
releaseAllLocks - queries locks and sends release locks request in pages to release all existing locks for the given briefcase
queryAllLocks - queries locks in pages until all are retrieved

This fix is addressing #180 issue.

This fix will need to be expanded in the future as currently the memory limit might be reached, but further improvement requires iModels API changes - either to have continuation token, or have asynchronous operation on the server side to release all locks.