### PR TITLE
Allow releases from `backport/*` branches

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,3 +17,19 @@ All submissions go through a review process.
 We use GitHub pull requests for this purpose.
 All pull requests must be approved by at least one person and must pass build checks before they can be merged to the `main` branch.
 Consult [GitHub Help](https://help.github.com/articles/about-pull-requests/) for more information on using pull requests.
+
+### Releases
+
+Releases are allowed only from the following branches ([pipeline](common/config/azure-pipelines/templates/publish.yml)):
+
+- `main`
+- `backport/*`
+
+Increasing the package version number is currently done manually, meaning we make the change in `package.json` files and merge it to `main` branch using a pull request.
+
+Backporting is also done manually. If you need to backport a change:
+
+1. Checkout a branch from the desired commit. Branch name should match the `backport/*` pattern. Push it to the remote.
+2. Create a pull request to `backport/*` branch with needed changes/fixes, merge it.
+3. Create a pull request to `backport/*` branch with increased version number (we follow [semver](https://semver.org/) rules), merge it.
+4. Kick of the release pipeline from `backport/*` branch.

--- a/common/config/azure-pipelines/templates/publish.yml
+++ b/common/config/azure-pipelines/templates/publish.yml
@@ -13,6 +13,6 @@ steps:
 
   - script: node common/scripts/install-run-rush.js publish --publish --include-all --set-access-level public
     displayName: rush publish package
-    condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/backport/')))
     env:
       NPM_AUTH_TOKEN: $(npmToken)


### PR DESCRIPTION
In this PR:
- Edited the release step to allow publishing from `backport/*` branches
- Appended CONTRIBUTING.md file with a short description of the process