### PR TITLE
Backport "Fix releaseAllLocks and queryAllLocks methods to read all pages (#181)"

### DIFF
--- a/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
@@ -344,34 +344,20 @@ export class BackendIModelsAccess implements BackendHubAccess {
     if (locks.length === 0)
       return [];
 
-    const result: LockProps[] = ClientToPlatformAdapter.toLockProps(locks[0]);
+    const result: LockProps[] = locks.flatMap(ClientToPlatformAdapter.toLockProps);
     return result;
   }
 
   public async releaseAllLocks(arg: BriefcaseDbArg): Promise<void> {
-    const getLockListParams: GetLockListParams = {
-      ...this.getIModelScopedOperationParams(arg),
-      urlParams: {
-        briefcaseId: arg.briefcaseId
-      }
-    };
+    let shouldQueryMoreLocks = true;
 
-    const locksIterator: EntityListIterator<Lock> = this._iModelsClient.locks.getList(getLockListParams);
-    const locks: Lock[] = await toArray(locksIterator);
-    if (locks.length === 0)
-      return;
+    do {
+      const locksPage: Lock[] = await this.getFirstLocksPage(arg);
+      shouldQueryMoreLocks = this.shouldQueryMoreLocks(locksPage);
 
-    const lock: Lock = locks[0];
-    this.setLockLevelToNone(lock.lockedObjects);
+      await this.releaseLocksPage(arg, locksPage);
 
-    const updateLockParams: UpdateLockParams = {
-      ...this.getIModelScopedOperationParams(arg),
-      briefcaseId: lock.briefcaseId,
-      changesetId: arg.changeset.id,
-      lockedObjects: lock.lockedObjects
-    };
-
-    await this._iModelsClient.locks.update(updateLockParams);
+    } while (shouldQueryMoreLocks);
   }
 
   public async queryIModelByName(arg: IModelNameArg): Promise<GuidString | undefined> {
@@ -482,5 +468,51 @@ export class BackendIModelsAccess implements BackendHubAccess {
 
     const changeset: Changeset = await this._iModelsClient.changesets.getSingle(getCheckpointParams);
     return changeset.getCurrentOrPrecedingCheckpoint();
+  }
+
+  private async getFirstLocksPage(arg: BriefcaseDbArg): Promise<Lock[]> {
+    const getLockListParams: GetLockListParams = {
+      ...this.getIModelScopedOperationParams(arg),
+      urlParams: {
+        briefcaseId: arg.briefcaseId
+      }
+    };
+
+    const lockPagesIterator = this._iModelsClient.locks.getList(getLockListParams).byPage();
+    for await (const lockPage of lockPagesIterator)
+      // Return the result of only a the first http request to iModels API
+      return lockPage;
+
+    return [];
+  }
+
+  private shouldQueryMoreLocks(currentResult: Lock[]): boolean {
+    // `$top` parameter in "Get iModel Locks" operation limits `objectIds` within Lock entity, not `Lock` entities themselves.
+    // https://developer.bentley.com/apis/imodels-v2/operations/get-imodel-locks/#paging
+    // So instead of checking for `currentResult.length === pageSize` we should check if `currentResult[idx].objectIds === pageSize`
+    // which would require to iterate over all `currentResult` entities.
+
+    // To simplify logic we check for a non-empty result. This means that we will terminate iteration over Locks only
+    // after we receive an empty response.
+
+    return currentResult.length !== 0;
+  }
+
+  private async releaseLocksPage(arg: BriefcaseDbArg, locksPage: Lock[]): Promise<void> {
+    if (locksPage.length === 0)
+      return;
+
+    for (const lock of locksPage) {
+      this.setLockLevelToNone(lock.lockedObjects);
+
+      const updateLockParams: UpdateLockParams = {
+        ...this.getIModelScopedOperationParams(arg),
+        briefcaseId: lock.briefcaseId,
+        changesetId: arg.changeset.id,
+        lockedObjects: lock.lockedObjects
+      };
+
+      await this._iModelsClient.locks.update(updateLockParams);
+    }
   }
 }

--- a/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
@@ -33,7 +33,7 @@ import { PlatformToClientAdapter } from "./interface-adapters/PlatformToClientAd
 
 export class BackendIModelsAccess implements BackendHubAccess {
   protected readonly _iModelsClient: IModelsClient;
-  private readonly _changeSet0 = { id: "", changesType: 0, description: "initialChangeset", parentId: "", briefcaseId: 0, pushDate: "", userCreated: "", index: 0 };
+  private readonly _changeSet0 = { id: "", changesType: 0, description: "initialChangeset", parentId: "", briefcaseId: 0, pushDate: "", userCreated: "", index: 0, size: 0 };
 
   constructor(iModelsClient?: IModelsClient) {
     this._iModelsClient = iModelsClient ?? new IModelsClient();
@@ -344,7 +344,10 @@ export class BackendIModelsAccess implements BackendHubAccess {
     if (locks.length === 0)
       return [];
 
-    const result: LockProps[] = locks.flatMap(ClientToPlatformAdapter.toLockProps);
+    const result = [];
+    for (const lock of locks)
+      result.push(...ClientToPlatformAdapter.toLockProps(lock));
+
     return result;
   }
 

--- a/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
+++ b/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
@@ -449,11 +449,13 @@ describe("BackendIModelsAccess", () => {
         briefcaseId,
         changeset: { id: "", index: 0 }
       };
-      const locksToAcquire: LockMap = new Map<string, LockState>([
-        ["0x1", LockState.Exclusive],
-        ["0x2", LockState.Exclusive],
-        ["0x3", LockState.Shared]
-      ]);
+
+      const locksToAcquire: LockMap = new Map<string, LockState>();
+
+      const objectIdsDec = Array.from({length: 201}, (_, i) => i + 1);
+      for (const objectId of objectIdsDec){
+        locksToAcquire.set(`0x${objectId.toString(16)}`, LockState.Exclusive);
+      }
 
       await backendIModelsAccess.acquireLocks(briefcaseDbParams, locksToAcquire);
       await assertLocks({


### PR DESCRIPTION
Fix releaseAllLocks and queryAllLocks methods to read all the pages per issue #180