### PR TITLE
Enabled application info assertion for Named Version create/update responses

### DIFF
--- a/tests/imodels-clients-tests/src/integration/management/NamedVersionOperations.test.ts
+++ b/tests/imodels-clients-tests/src/integration/management/NamedVersionOperations.test.ts
@@ -235,8 +235,7 @@ describe("[Management] NamedVersionOperations", () => {
       },
       expectedLinks: {
         changeset: true
-      },
-      isGetResponse: true
+      }
     });
   });
 
@@ -263,8 +262,7 @@ describe("[Management] NamedVersionOperations", () => {
       },
       expectedLinks: {
         changeset: true
-      },
-      isGetResponse: true
+      }
     });
   });
 
@@ -291,8 +289,7 @@ describe("[Management] NamedVersionOperations", () => {
       },
       expectedLinks: {
         changeset: false
-      },
-      isGetResponse: false
+      }
     });
   });
 
@@ -321,8 +318,7 @@ describe("[Management] NamedVersionOperations", () => {
       },
       expectedLinks: {
         changeset: true
-      },
-      isGetResponse: false
+      }
     });
   });
 

--- a/utils/imodels-client-test-utils/src/assertions/BrowserFriendlyAssertions.ts
+++ b/utils/imodels-client-test-utils/src/assertions/BrowserFriendlyAssertions.ts
@@ -110,7 +110,6 @@ export async function assertNamedVersion(params: {
   expectedLinks: {
     changeset: boolean;
   };
-  isGetResponse: boolean;
 }): Promise<void> {
   assertMinimalNamedVersion({
     actualNamedVersion: params.actualNamedVersion,
@@ -123,7 +122,7 @@ export async function assertNamedVersion(params: {
 
   assertApplication({
     actualApplication: params.actualNamedVersion.application,
-    expectNull: !params.isGetResponse
+    expectNull: false
   });
 
   expect(params.actualNamedVersion._links).to.exist;


### PR DESCRIPTION
In this PR:
- Enabled application assertion for Named Version create/update operations. Previously those operations always returned `null` for application info but that was recently fixed in iModels API.