### PR TITLE
`BackendIModelsAccess.downloadV1Checkpoint` fix: skip over Checkpoints V2 when searching for the preceding Checkpoint V1

### DIFF
--- a/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
@@ -15,11 +15,10 @@ import {
   IModelVersion
 } from "@itwin/core-common";
 import { downloadFile } from "@itwin/imodels-client-authoring/lib/operations";
-import axios, { AxiosResponse } from "axios";
 
 import {
-  AcquireBriefcaseParams, AuthorizationCallback, AuthorizationParam, Briefcase, Changeset, ChangesetIdOrIndex,
-  ChangesetOrderByProperty, Checkpoint, ContainerAccessInfo, CreateChangesetParams, CreateIModelFromBaselineParams,
+  AcquireBriefcaseParams, AuthorizationCallback, AuthorizationParam, Briefcase, Changeset,
+  ChangesetOrderByProperty, Checkpoint, CreateChangesetParams, CreateIModelFromBaselineParams,
   DeleteIModelParams, DownloadChangesetListParams, DownloadSingleChangesetParams, DownloadedChangeset,
   EntityListIterator, GetBriefcaseListParams, GetChangesetListParams, GetIModelListParams, GetLockListParams,
   GetNamedVersionListParams, GetSingleChangesetParams, GetSingleCheckpointParams, IModel, IModelScopedOperationParams, IModelsClient, IModelsErrorCode,
@@ -27,13 +26,14 @@ import {
   OrderByOperator, ReleaseBriefcaseParams, SPECIAL_VALUES_ME, UpdateLockParams, isIModelsApiError, take, toArray
 } from "@itwin/imodels-client-authoring";
 
+import { getV1CheckpointSize, queryCurrentOrPrecedingV1Checkpoint, queryCurrentOrPrecedingV2Checkpoint } from "./CheckpointHelperFunctions";
+import { Constants } from "./Constants";
 import { AccessTokenAdapter } from "./interface-adapters/AccessTokenAdapter";
 import { ClientToPlatformAdapter } from "./interface-adapters/ClientToPlatformAdapter";
 import { PlatformToClientAdapter } from "./interface-adapters/PlatformToClientAdapter";
 
 export class BackendIModelsAccess implements BackendHubAccess {
   protected readonly _iModelsClient: IModelsClient;
-  private readonly _changeSet0 = { id: "", changesType: 0, description: "initialChangeset", parentId: "", briefcaseId: 0, pushDate: "", userCreated: "", index: 0, size: 0 };
 
   constructor(iModelsClient?: IModelsClient) {
     this._iModelsClient = iModelsClient ?? new IModelsClient();
@@ -133,7 +133,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
     const changesetsIterator: EntityListIterator<MinimalChangeset> = this._iModelsClient.changesets.getMinimalList(getChangesetListParams);
     const changesets: MinimalChangeset[] = await take(changesetsIterator, 1);
     if (changesets.length === 0)
-      return this._changeSet0;
+      return Constants.ChangeSet0;
     const result: ChangesetProps = ClientToPlatformAdapter.toChangesetProps(changesets[0]);
     return result;
   }
@@ -141,7 +141,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
   public async getChangesetFromVersion(arg: IModelIdArg & { version: IModelVersion }): Promise<ChangesetProps> {
     const version = arg.version;
     if (version.isFirst)
-      return this._changeSet0;
+      return Constants.ChangeSet0;
 
     const namedVersionChangesetId = version.getAsOfChangeSet();
     if (namedVersionChangesetId)
@@ -210,11 +210,19 @@ export class BackendIModelsAccess implements BackendHubAccess {
 
   // eslint-disable-next-line deprecation/deprecation
   public async downloadV1Checkpoint(arg: CheckpointArg): Promise<ChangesetIndexAndId> {
-    const checkpoint: Checkpoint | undefined = await this.queryCurrentOrPrecedingCheckpoint(arg);
+    const iModelScopedOperationParams: IModelScopedOperationParams = {
+      ...this.getAuthorizationParam(arg.checkpoint),
+      iModelId: arg.checkpoint.iModelId
+    };
+    const checkpoint: Checkpoint | undefined = await queryCurrentOrPrecedingV1Checkpoint(
+      this._iModelsClient,
+      iModelScopedOperationParams,
+      arg
+    );
     if (!checkpoint || !checkpoint._links?.download)
       throw new IModelError(BriefcaseStatus.VersionNotFound, "V1 checkpoint not found");
 
-    const v1CheckpointSize = await this.getV1CheckpointSize(checkpoint._links.download.href);
+    const v1CheckpointSize = await getV1CheckpointSize(checkpoint._links.download.href);
     const [progressCallback, abortSignal] = PlatformToClientAdapter.toProgressCallback(arg.onProgress) ?? [];
     const totalDownloadCallback = progressCallback ? (downloaded: number) => progressCallback?.(downloaded, v1CheckpointSize) : undefined;
 
@@ -229,81 +237,8 @@ export class BackendIModelsAccess implements BackendHubAccess {
     return { index: checkpoint.changesetIndex, id: checkpoint.changesetId };
   }
 
-  /**
-   * iModels API returns a link to a file in Azure Blob Storage. The API does not return checkpoint file size as
-   * a standalone property so we query it from Azure using the method described below.
-   *
-   * To get the total size of the file we send a GET request to the file download url with `Range: bytes=0-0` header
-   * specified which requests to get only the first byte of the file. As a response we get the first file byte in
-   * the body and `Content-Range` response header which contains information about the total file size. See
-   * https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob#response-headers,
-   * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Range.
-   *
-   * The format of returned `Content-Range` header in this case is
-   * `<unit> <range-start>-<range-end>/<size>`, e.g. `bytes 0-0/1253376`.
-   */
-  private async getV1CheckpointSize(downloadUrl: string): Promise<number> {
-    const emptyRangeHeaderValue = "bytes=0-0";
-    const contentRangeHeaderName = "content-range";
-
-    const response: AxiosResponse = await axios.get(downloadUrl, { headers: { Range: emptyRangeHeaderValue } });
-    const rangeHeaderValue: string = response.headers[contentRangeHeaderName];
-    const rangeTotalBytesString: string = rangeHeaderValue.split("/")[1];
-    const rangeTotalBytes: number = parseInt(rangeTotalBytesString, 10);
-
-    return rangeTotalBytes;
-  }
-
-  // The imodels api does not distinguish between a v2 and a v1 checkpoint when calling getCurrentOrPrecedingCheckpoint.
-  // It is possible that a preceding v2 checkpoint exists, but earlier in the timeline than the most recent v1 checkpoint. In this case we would miss out on the preceding v2 checkpoint.
-  // To get around this, this function decrements the changesetIndex of the discovered checkpoint if it is not a v2 checkpoint and searches again.
-  private async findLatestV2CheckpointForChangeset(arg: CheckpointProps, changesetIndex: number): Promise<ContainerAccessInfo | undefined> {
-    if (changesetIndex <= 0)
-      return undefined;
-
-    const getSingleChangesetParams: GetSingleChangesetParams = {
-      ...this.getIModelScopedOperationParams(arg),
-      ...PlatformToClientAdapter.toChangesetIdOrIndex({ index: changesetIndex })
-    };
-
-    const changeset = await this._iModelsClient.changesets.getSingle(getSingleChangesetParams);
-    const checkpoint = await changeset.getCurrentOrPrecedingCheckpoint();
-
-    if (!checkpoint)
-      return undefined;
-
-    if (checkpoint.containerAccessInfo !== null)
-      return checkpoint.containerAccessInfo;
-
-    const previousChangesetIndex = checkpoint.changesetIndex - 1;
-    return this.findLatestV2CheckpointForChangeset(arg, previousChangesetIndex);
-  }
-
-  private async resolveChangesetIndexFromParamsOrQueryApi(arg: CheckpointProps): Promise<number> {
-    if (arg.changeset.id === this._changeSet0.id || arg.changeset.index === this._changeSet0.index)
-      return this._changeSet0.index;
-
-    if (arg.changeset.index !== undefined)
-      return arg.changeset.index;
-
-    const getSingleChangesetParams: GetSingleChangesetParams = {
-      ...this.getIModelScopedOperationParams(arg),
-      changesetId: arg.changeset.id
-    };
-    const changeset = await this._iModelsClient.changesets.getSingle(getSingleChangesetParams);
-    return changeset.index;
-  }
-
-  private async queryCurrentOrPrecedingV2Checkpoint(arg: CheckpointProps): Promise<V2CheckpointAccessProps | undefined> {
-    const changesetIndex = await this.resolveChangesetIndexFromParamsOrQueryApi(arg);
-    const containerAccessInfo = await this.findLatestV2CheckpointForChangeset(arg, changesetIndex);
-    if (containerAccessInfo === undefined)
-      return undefined;
-
-    return ClientToPlatformAdapter.toV2CheckpointAccessProps(containerAccessInfo);
-  }
-
   public async queryV2Checkpoint(arg: CheckpointProps): Promise<V2CheckpointAccessProps | undefined> {
+    const iModelScopedOperationParams = this.getIModelScopedOperationParams(arg);
     const getSingleCheckpointParams: GetSingleCheckpointParams = {
       ...this.getIModelScopedOperationParams(arg),
       ...PlatformToClientAdapter.toChangesetIdOrIndex(arg.changeset)
@@ -315,7 +250,13 @@ export class BackendIModelsAccess implements BackendHubAccess {
     } catch (error) {
       // Means that neither v1 nor v2 checkpoint exists
       if (isIModelsApiError(error) && error.code === IModelsErrorCode.CheckpointNotFound) {
-        return arg?.allowPreceding ? this.queryCurrentOrPrecedingV2Checkpoint(arg) : undefined;
+        return arg?.allowPreceding
+          ? queryCurrentOrPrecedingV2Checkpoint(
+            this._iModelsClient,
+            iModelScopedOperationParams,
+            arg
+          )
+          : undefined;
       }
 
       throw error;
@@ -323,7 +264,13 @@ export class BackendIModelsAccess implements BackendHubAccess {
 
     // Means the v2 checkpoint does not exist.
     if (checkpoint.containerAccessInfo === null) {
-      return arg?.allowPreceding ? this.queryCurrentOrPrecedingV2Checkpoint(arg) : undefined;
+      return arg?.allowPreceding
+        ? queryCurrentOrPrecedingV2Checkpoint(
+          this._iModelsClient,
+          iModelScopedOperationParams,
+          arg
+        )
+        : undefined;
     }
 
     const result = ClientToPlatformAdapter.toV2CheckpointAccessProps(checkpoint.containerAccessInfo);
@@ -462,22 +409,6 @@ export class BackendIModelsAccess implements BackendHubAccess {
     }
 
     return tempBaselineFilePath;
-  }
-
-  // eslint-disable-next-line deprecation/deprecation
-  private async queryCurrentOrPrecedingCheckpoint(arg: CheckpointArg): Promise<Checkpoint | undefined> {
-    const changesetIdOrIndex: ChangesetIdOrIndex = PlatformToClientAdapter.toChangesetIdOrIndex(arg.checkpoint.changeset);
-    const getCheckpointParams: GetSingleCheckpointParams = {
-      ...this.getAuthorizationParam(arg.checkpoint),
-      iModelId: arg.checkpoint.iModelId,
-      ...changesetIdOrIndex
-    };
-
-    if (changesetIdOrIndex.changesetIndex === 0)
-      return this._iModelsClient.checkpoints.getSingle(getCheckpointParams);
-
-    const changeset: Changeset = await this._iModelsClient.changesets.getSingle(getCheckpointParams);
-    return changeset.getCurrentOrPrecedingCheckpoint();
   }
 
   private async getFirstLocksPage(arg: BriefcaseDbArg): Promise<Lock[]> {

--- a/itwin-platform-access/imodels-access-backend/src/CheckpointHelperFunctions.ts
+++ b/itwin-platform-access/imodels-access-backend/src/CheckpointHelperFunctions.ts
@@ -1,0 +1,143 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import {
+  CheckpointArg, CheckpointProps,
+  V2CheckpointAccessProps
+} from "@itwin/core-backend";
+import axios, { AxiosResponse } from "axios";
+
+import {
+  Checkpoint,
+  GetSingleChangesetParams,
+  GetSingleCheckpointParams,
+  IModelScopedOperationParams,
+  IModelsClient
+} from "@itwin/imodels-client-authoring";
+
+import { Constants } from "./Constants";
+import { ClientToPlatformAdapter } from "./interface-adapters/ClientToPlatformAdapter";
+import { PlatformToClientAdapter } from "./interface-adapters/PlatformToClientAdapter";
+
+export async function queryCurrentOrPrecedingV2Checkpoint(
+  iModelsClient: IModelsClient,
+  iModelScopedOperationParams: IModelScopedOperationParams,
+  checkpointProps: CheckpointProps
+): Promise<V2CheckpointAccessProps | undefined> {
+  const changesetIndex = await resolveChangesetIndexFromParamsOrQueryApi(iModelsClient, iModelScopedOperationParams, checkpointProps);
+
+  if (changesetIndex === 0) {
+    const baselineCheckpoint = await getBaselineCheckpoint(iModelsClient, iModelScopedOperationParams);
+    if (!baselineCheckpoint?.containerAccessInfo)
+      return undefined;
+    return ClientToPlatformAdapter.toV2CheckpointAccessProps(baselineCheckpoint.containerAccessInfo);
+  }
+
+  const isQueriedCheckpointValid = (queriedCheckpoint: Checkpoint) => !!queriedCheckpoint.containerAccessInfo !== null;
+  const checkpoint = await findLatestCheckpointForChangeset(iModelsClient, iModelScopedOperationParams, changesetIndex, isQueriedCheckpointValid);
+  if (checkpoint === undefined)
+    return undefined;
+  return ClientToPlatformAdapter.toV2CheckpointAccessProps(checkpoint.containerAccessInfo!);
+}
+
+export async function queryCurrentOrPrecedingV1Checkpoint(
+  iModelsClient: IModelsClient,
+  iModelScopedOperationParams: IModelScopedOperationParams,
+  // eslint-disable-next-line deprecation/deprecation
+  checkpointArg: CheckpointArg
+): Promise<Checkpoint | undefined> {
+  const changesetIndex = await resolveChangesetIndexFromParamsOrQueryApi(iModelsClient, iModelScopedOperationParams, checkpointArg.checkpoint);
+
+  if (changesetIndex === 0) {
+    const baselineCheckpoint = await getBaselineCheckpoint(iModelsClient, iModelScopedOperationParams);
+    return baselineCheckpoint;
+  }
+
+  const isQueriedCheckpointValid = (queriedCheckpoint: Checkpoint) => !!queriedCheckpoint._links.download;
+  const checkpoint = await findLatestCheckpointForChangeset(iModelsClient, iModelScopedOperationParams, changesetIndex, isQueriedCheckpointValid);
+  return checkpoint;
+}
+
+/**
+ * iModels API returns a link to a file in Azure Blob Storage. The API does not return checkpoint file size as
+ * a standalone property so we query it from Azure using the method described below.
+ *
+ * To get the total size of the file we send a GET request to the file download url with `Range: bytes=0-0` header
+ * specified which requests to get only the first byte of the file. As a response we get the first file byte in
+ * the body and `Content-Range` response header which contains information about the total file size. See
+ * https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob#response-headers,
+ * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Range.
+ *
+ * The format of returned `Content-Range` header in this case is
+ * `<unit> <range-start>-<range-end>/<size>`, e.g. `bytes 0-0/1253376`.
+ */
+export async function getV1CheckpointSize(downloadUrl: string): Promise<number> {
+  const emptyRangeHeaderValue = "bytes=0-0";
+  const contentRangeHeaderName = "content-range";
+
+  const response: AxiosResponse = await axios.get(downloadUrl, { headers: { Range: emptyRangeHeaderValue } });
+  const rangeHeaderValue: string = response.headers[contentRangeHeaderName];
+  const rangeTotalBytesString: string = rangeHeaderValue.split("/")[1];
+  const rangeTotalBytes: number = parseInt(rangeTotalBytesString, 10);
+
+  return rangeTotalBytes;
+}
+
+async function findLatestCheckpointForChangeset(
+  iModelsClient: IModelsClient,
+  iModelScopedOperationParams: IModelScopedOperationParams,
+  changesetIndex: number,
+  isExpectedCheckpoint: (checkpoint: Checkpoint) => boolean
+): Promise<Checkpoint | undefined> {
+  if (changesetIndex <= 0)
+    return undefined;
+
+  const getSingleChangesetParams: GetSingleChangesetParams = {
+    ...iModelScopedOperationParams,
+    ...PlatformToClientAdapter.toChangesetIdOrIndex({ index: changesetIndex })
+  };
+
+  const changeset = await iModelsClient.changesets.getSingle(getSingleChangesetParams);
+  const checkpoint = await changeset.getCurrentOrPrecedingCheckpoint();
+
+  if (!checkpoint)
+    return undefined;
+
+  if (isExpectedCheckpoint(checkpoint))
+    return checkpoint;
+
+  const previousChangesetIndex = checkpoint.changesetIndex - 1;
+  return findLatestCheckpointForChangeset(iModelsClient, iModelScopedOperationParams, previousChangesetIndex, isExpectedCheckpoint);
+}
+
+async function getBaselineCheckpoint(
+  iModelsClient: IModelsClient,
+  iModelScopedOperationParams: IModelScopedOperationParams
+): Promise<Checkpoint | undefined> {
+  const getCheckpointParams: GetSingleCheckpointParams = {
+    ...iModelScopedOperationParams,
+    changesetIndex: 0
+  };
+  return iModelsClient.checkpoints.getSingle(getCheckpointParams);
+}
+
+async function resolveChangesetIndexFromParamsOrQueryApi(
+  iModelsClient: IModelsClient,
+  iModelScopedOperationParams: IModelScopedOperationParams,
+  checkpointProps: CheckpointProps
+): Promise<number> {
+  if (checkpointProps.changeset.id === Constants.ChangeSet0.id || checkpointProps.changeset.index === Constants.ChangeSet0.index)
+    return Constants.ChangeSet0.index;
+
+  if (checkpointProps.changeset.index !== undefined)
+    return checkpointProps.changeset.index;
+
+  const getSingleChangesetParams: GetSingleChangesetParams = {
+    ...iModelScopedOperationParams,
+    changesetId: checkpointProps.changeset.id
+  };
+  const changeset = await iModelsClient.changesets.getSingle(getSingleChangesetParams);
+  return changeset.index;
+}

--- a/itwin-platform-access/imodels-access-backend/src/CheckpointHelperFunctions.ts
+++ b/itwin-platform-access/imodels-access-backend/src/CheckpointHelperFunctions.ts
@@ -35,7 +35,7 @@ export async function queryCurrentOrPrecedingV2Checkpoint(
     return ClientToPlatformAdapter.toV2CheckpointAccessProps(baselineCheckpoint.containerAccessInfo);
   }
 
-  const isQueriedCheckpointValid = (queriedCheckpoint: Checkpoint) => !!queriedCheckpoint.containerAccessInfo !== null;
+  const isQueriedCheckpointValid = (queriedCheckpoint: Checkpoint) => !!queriedCheckpoint.containerAccessInfo;
   const checkpoint = await findLatestCheckpointForChangeset(iModelsClient, iModelScopedOperationParams, changesetIndex, isQueriedCheckpointValid);
   if (checkpoint === undefined)
     return undefined;

--- a/itwin-platform-access/imodels-access-backend/src/Constants.ts
+++ b/itwin-platform-access/imodels-access-backend/src/Constants.ts
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+export class Constants {
+  public static readonly ChangeSet0 = { id: "", changesType: 0, description: "initialChangeset", parentId: "", briefcaseId: 0, pushDate: "", userCreated: "", index: 0, size: 0 };
+}

--- a/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
+++ b/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
@@ -256,7 +256,7 @@ describe("BackendIModelsAccess", () => {
       const iModelId = "1aca14e4-32df-44d3-85d7-b892959a0fba";
       await assertHardcodedIModelExists(
         iModelId,
-        "iModel for queryV2Checkpoint test was not found. Please recreate the test iModel as described within the test, or disable the test.")
+        "iModel for queryV2Checkpoint test was not found. Please recreate the test iModel as described within the test, or disable the test.");
 
       const mostRecentChangeset = testIModelFileProvider.changesets[testIModelFileProvider.changesets.length - 1];
       const queryV2CheckpointParams: CheckpointProps = {
@@ -308,7 +308,7 @@ describe("BackendIModelsAccess", () => {
       expect(fs.statSync(localCheckpointFilePath).size).to.be.greaterThan(0);
     });
 
-    it("should skip over a preceding v2 checkpoint in favor of finding a preceding v1 checkpoint", async() => {
+    it("should skip over a preceding v2 checkpoint in favor of finding a preceding v1 checkpoint", async () => {
       // Arrange
       // iModel has 3 checkpoints
       //  baseline             - v1 and v2
@@ -319,8 +319,8 @@ describe("BackendIModelsAccess", () => {
       const iModelId = "74eac4a1-6c04-4279-89bf-fd72218e3f1b";
       await assertHardcodedIModelExists(
         iModelId,
-        "iModel for downloadV1Checkpoint test was not found. Please recreate the test iModel as described within the test, or disable the test.")
- 
+        "iModel for downloadV1Checkpoint test was not found. Please recreate the test iModel as described within the test, or disable the test.");
+
       const secondToLastChangeset = testIModelFileProvider.changesets[testIModelFileProvider.changesets.length - 2];
       const localCheckpointFilePath = path.join(testDownloadPath, "checkpoint_skip_v2_checkpoint.bim");
       const downloadV1CheckpointParams: DownloadRequest = {
@@ -330,16 +330,17 @@ describe("BackendIModelsAccess", () => {
           iModelId,
           changeset: {
             id: secondToLastChangeset.id
-          },
+          }
         }
-      }
+      };
 
       // Act
+      // eslint-disable-next-line deprecation/deprecation
       const changesetIndexAndId: ChangesetIndexAndId = await backendIModelsAccess.downloadV1Checkpoint(downloadV1CheckpointParams);
 
       // Asssert
       expect(changesetIndexAndId.index).to.be.equal(0);
-      expect(changesetIndexAndId.id).to.be.equal('');
+      expect(changesetIndexAndId.id).to.be.equal("");
     });
 
     it("should report progress when downloading checkpoint", async () => {

--- a/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
+++ b/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
@@ -6,7 +6,7 @@ import { assert } from "console";
 import * as fs from "fs";
 import * as path from "path";
 
-import { AcquireNewBriefcaseIdArg, BriefcaseDbArg, ChangesetRangeArg, CheckpointProps, DownloadChangesetRangeArg, IModelHost, IModelIdArg, LockMap, LockProps, LockState, ProgressFunction, ProgressStatus, V2CheckpointAccessProps } from "@itwin/core-backend";
+import { AcquireNewBriefcaseIdArg, BriefcaseDbArg, ChangesetRangeArg, CheckpointProps, DownloadChangesetRangeArg, DownloadRequest, IModelHost, IModelIdArg, LockMap, LockProps, LockState, ProgressFunction, ProgressStatus, V2CheckpointAccessProps } from "@itwin/core-backend";
 import { BriefcaseId, ChangeSetStatus, ChangesetFileProps, ChangesetIndexAndId, ChangesetType, LocalDirName } from "@itwin/core-common";
 import { BackendIModelsAccess } from "@itwin/imodels-access-backend";
 import { expect } from "chai";
@@ -247,22 +247,16 @@ describe("BackendIModelsAccess", () => {
 
     it("should skip over a preceding v1 checkpoint in favor of finding a preceding v2 checkpoint", async () => {
       // Arrange
-      // iModel has 3 checkpoints. changeset index 10 has only v1 checkpoint, changeset index 5 has only v1 checkpoint. iModel has only 10 changesets. baseline has v1 and v2 checkpoint.
-      // This iModel is a clone of the testIModelFileProvider aka "[do not delete][iModelsClientsTests] Reusable Test iModel" so it will have the same changesets.
+      // iModel has 3 checkpoints:
+      //  baseline             - v1 and v2
+      //  changeset index 5    - only v1 (v2 failed)
+      //  changeset index 10   - only v1 (v2 failed)
+      // This iModel is a clone of the testIModelFileProvider aka "[do not delete][iModelsClientsTests] Reusable Test iModel"
+      // so it will have the same 10 changesets in total.
       const iModelId = "1aca14e4-32df-44d3-85d7-b892959a0fba";
-      try {
-        // Make sure iModel exists since we're hardcoding this ID.
-        const iModel = await iModelsClient.iModels.getSingle({
-          iModelId,
-          authorization: authorizationCallback
-        });
-        expect(iModel).to.not.be.undefined;
-      } catch (error) {
-        if (isIModelsApiError(error) && error.code === IModelsErrorCode.IModelNotFound) {
-          throw new Error("iModel was not found. Please recreate the test iModel as described within the test, or disable the test.");
-        }
-        throw error;
-      }
+      await assertHardcodedIModelExists(
+        iModelId,
+        "iModel for queryV2Checkpoint test was not found. Please recreate the test iModel as described within the test, or disable the test.")
 
       const mostRecentChangeset = testIModelFileProvider.changesets[testIModelFileProvider.changesets.length - 1];
       const queryV2CheckpointParams: CheckpointProps = {
@@ -281,7 +275,6 @@ describe("BackendIModelsAccess", () => {
       // Assert
       expect(queryCheckpoint).to.not.be.undefined;
       expect(queryCheckpoint!.dbName === "BASELINE.bim").to.be.true;
-
     });
 
     it("should download preceding checkpoint if one for current changeset does not exist", async () => {
@@ -313,6 +306,40 @@ describe("BackendIModelsAccess", () => {
       expect(downloadedCheckpoint.index).to.be.equal(firstNamedVersion.changesetIndex);
       expect(fs.existsSync(localCheckpointFilePath)).to.be.equal(true);
       expect(fs.statSync(localCheckpointFilePath).size).to.be.greaterThan(0);
+    });
+
+    it("should skip over a preceding v2 checkpoint in favor of finding a preceding v1 checkpoint", async() => {
+      // Arrange
+      // iModel has 3 checkpoints
+      //  baseline             - v1 and v2
+      //  changeset index 5    - only v2 (v1 entry non existent)
+      //  changeset index 10   - v1 and v2
+      // This iModel is a clone of the testIModelFileProvider aka "[do not delete][iModelsClientsTests] Reusable Test iModel"
+      // so it will have the same 10 changesets in total.
+      const iModelId = "74eac4a1-6c04-4279-89bf-fd72218e3f1b";
+      await assertHardcodedIModelExists(
+        iModelId,
+        "iModel for downloadV1Checkpoint test was not found. Please recreate the test iModel as described within the test, or disable the test.")
+ 
+      const secondToLastChangeset = testIModelFileProvider.changesets[testIModelFileProvider.changesets.length - 2];
+      const localCheckpointFilePath = path.join(testDownloadPath, "checkpoint_skip_v2_checkpoint.bim");
+      const downloadV1CheckpointParams: DownloadRequest = {
+        localFile: localCheckpointFilePath,
+        checkpoint: {
+          iTwinId,
+          iModelId,
+          changeset: {
+            id: secondToLastChangeset.id
+          },
+        }
+      }
+
+      // Act
+      const changesetIndexAndId: ChangesetIndexAndId = await backendIModelsAccess.downloadV1Checkpoint(downloadV1CheckpointParams);
+
+      // Asssert
+      expect(changesetIndexAndId.index).to.be.equal(0);
+      expect(changesetIndexAndId.id).to.be.equal('');
     });
 
     it("should report progress when downloading checkpoint", async () => {
@@ -387,6 +414,22 @@ describe("BackendIModelsAccess", () => {
       const lastReportedLog = progressLogs[progressLogs.length - 1];
       expect(lastReportedLog.total).to.be.greaterThan(fs.statSync(localCheckpointFilePath).size);
     });
+
+    async function assertHardcodedIModelExists(iModelId: string, errorMessage: string): Promise<void> {
+      try {
+        // Make sure iModel exists since we're hardcoding this ID.
+        const iModel = await iModelsClient.iModels.getSingle({
+          iModelId,
+          authorization: authorizationCallback
+        });
+        expect(iModel).to.not.be.undefined;
+      } catch (error) {
+        if (isIModelsApiError(error) && error.code === IModelsErrorCode.IModelNotFound) {
+          throw new Error(errorMessage);
+        }
+        throw error;
+      }
+    }
   });
 
   describe("locks", () => {


### PR DESCRIPTION
In this PR:
- Fixed a bug where if user attempted to download a Checkpoint V1 for a specific changeset and the nearest Checkpoint for that Changeset was a V2 Checkpoint, then the code would throw an error. Changed the code to iteratively search for the nearest valid V1 Checkpoint similarly as we current do with `BackendIModelsAccess.queryV2Checkpoint`.
- Added an integration test