### PR TITLE
iTwin.js adapter package version bump 4.0.4 -> 4.0.5, API client version bump 4.1.1 -> 4.1.2

### DIFF
--- a/clients/imodels-client-authoring/package.json
+++ b/clients/imodels-client-authoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-client-authoring",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "iModels API client wrapper for applications that author iModels.",
   "keywords": [
     "Bentley",

--- a/clients/imodels-client-management/package.json
+++ b/clients/imodels-client-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-client-management",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "iModels API client wrapper for applications that manage iModels.",
   "keywords": [
     "Bentley",

--- a/itwin-platform-access/imodels-access-backend/package.json
+++ b/itwin-platform-access/imodels-access-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-access-backend",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "Interoperability package between iModels API and iTwin.js library for backend.",
   "keywords": [
     "Bentley",

--- a/itwin-platform-access/imodels-access-frontend/package.json
+++ b/itwin-platform-access/imodels-access-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-access-frontend",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "Interoperability package between iModels API and iTwin.js library for frontend.",
   "keywords": [
     "Bentley",


### PR DESCRIPTION
In this PR:
- Bumped the versions of monorepo packages. What will be included in the path releases:
  - @itwin/imodels-client-management and @itwin-imodels-client-authoring 
    - https://github.com/iTwin/imodels-clients/pull/189
    - https://github.com/iTwin/imodels-clients/pull/188
  - @itwin/imodels-access-backend and @itwin/imodels-access-frontend packages
    - https://github.com/iTwin/imodels-clients/pull/190
    - https://github.com/iTwin/imodels-clients/pull/191
    - https://github.com/iTwin/imodels-clients/pull/192