### PR TITLE
Version bump: iModels API clients `4.1.2` -> `4.2.0`, iTwin.js interop packages `4.0.5` -> `4.1.0`

### DIFF
--- a/clients/imodels-client-authoring/package.json
+++ b/clients/imodels-client-authoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-client-authoring",
-  "version": "4.1.2",
+  "version": "4.2.0",
   "description": "iModels API client wrapper for applications that author iModels.",
   "keywords": [
     "Bentley",

--- a/clients/imodels-client-management/package.json
+++ b/clients/imodels-client-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-client-management",
-  "version": "4.1.2",
+  "version": "4.2.0",
   "description": "iModels API client wrapper for applications that manage iModels.",
   "keywords": [
     "Bentley",

--- a/itwin-platform-access/imodels-access-backend/package.json
+++ b/itwin-platform-access/imodels-access-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-access-backend",
-  "version": "4.0.5",
+  "version": "4.1.0",
   "description": "Interoperability package between iModels API and iTwin.js library for backend.",
   "keywords": [
     "Bentley",

--- a/itwin-platform-access/imodels-access-common/package.json
+++ b/itwin-platform-access/imodels-access-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-access-common",
-  "version": "4.0.5",
+  "version": "4.1.0",
   "description": "Common code package for @itwin/imodels-access-frontend and @itwin/imodels-access-backend.",
   "keywords": [
     "Bentley",

--- a/itwin-platform-access/imodels-access-frontend/package.json
+++ b/itwin-platform-access/imodels-access-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-access-frontend",
-  "version": "4.0.5",
+  "version": "4.1.0",
   "description": "Interoperability package between iModels API and iTwin.js library for frontend.",
   "keywords": [
     "Bentley",


### PR DESCRIPTION
In this PR:
- Bumped package versions:
  - `4.1.2` -> `4.2.0`
    - `@itwin/imodels-client-authoring`
    - `@itwin/imodels-client-management`
  - `4.0.5` -> `4.1.0`
    - `@itwin/imodels-access-backend`
    - `@itwin/imodels-access-common`
    - `@itwin/imodels-access-frontend`