### PR TITLE
Fix `MaximumNumberOfBriefcasesPerUser` error parsing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -35,6 +35,23 @@
       ]
     },
     {
+      "name": "Common iModels Access Tests",
+      "cwd": "${workspaceFolder}/tests/imodels-access-common-tests",
+      "type": "pwa-node",
+      "request": "launch",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": [
+        "run",
+        "test:unit"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/*/*/lib/**/*.js"
+      ],
+      "skipFiles": [
+        "<node_internals>/**"
+      ]
+    },
+    {
       "name": "Backend iModels Access Tests",
       "cwd": "${workspaceFolder}/tests/imodels-access-backend-tests",
       "type": "pwa-node",

--- a/clients/imodels-client-management/src/base/types/IModelsErrorInterfaces.ts
+++ b/clients/imodels-client-management/src/base/types/IModelsErrorInterfaces.ts
@@ -59,6 +59,14 @@ export interface IModelsErrorDetail {
   message: string;
   /** Name of the property or parameter which is related to the issue. */
   target?: string;
+  /** Inner error that potentially narrows down the issue specified in the `IModelsErrorDetail.code` property. */
+  innerError?: ErrorDetailInnerError;
+}
+
+/** Additional information that extends IModelsErrorDetail. See {@link IModelsErrorDetail} . */
+export interface ErrorDetailInnerError {
+  /** Error detail code. See {@link IModelsErrorCode}. */
+  code: IModelsErrorCode;
 }
 
 /** Base interface for all errors returned from iModels API. */

--- a/itwin-platform-access/imodels-access-common/src/ErrorAdapter.ts
+++ b/itwin-platform-access/imodels-access-common/src/ErrorAdapter.ts
@@ -6,7 +6,7 @@
 import { ChangeSetStatus, IModelHubStatus } from "@itwin/core-bentley";
 import { IModelError } from "@itwin/core-common";
 
-import { IModelsErrorCode, isIModelsApiError } from "@itwin/imodels-client-management";
+import { IModelsError, IModelsErrorCode, IModelsErrorDetail, isIModelsApiError } from "@itwin/imodels-client-management";
 
 export type OperationNameForErrorMapping = "acquireBriefcase" | "downloadChangesets";
 
@@ -24,6 +24,9 @@ export class ErrorAdapter {
       return error;
     if (ErrorAdapter.isAPIErrorWithoutCorrespondingStatus(error.code))
       return error;
+
+    if (error.code === IModelsErrorCode.InvalidIModelsRequest)
+      return ErrorAdapter.adaptInvalidRequestErrorIfPossible(error);
 
     let errorNumber = ErrorAdapter.tryMapGenericErrorCode(error.code, operationName);
     if (!errorNumber)
@@ -46,7 +49,6 @@ export class ErrorAdapter {
     switch (apiErrorCode) {
       case IModelsErrorCode.TooManyRequests:
       case IModelsErrorCode.RequestTooLarge:
-      case IModelsErrorCode.InvalidIModelsRequest:
       case IModelsErrorCode.InvalidValue:
       case IModelsErrorCode.InvalidHeaderValue:
       case IModelsErrorCode.InvalidRequestBody:
@@ -77,15 +79,23 @@ export class ErrorAdapter {
     }
   }
 
+  private static adaptInvalidRequestErrorIfPossible(originalError: IModelsError): IModelsError | IModelError {
+    if (!originalError.details || originalError.details.length === 0)
+      return originalError;
+
+    for (const errorDetail of originalError.details)
+      if (ErrorAdapter.hasInnerErrorProperty(errorDetail) && errorDetail.innerError.code === IModelsErrorCode.MaximumNumberOfBriefcasesPerUser)
+        return new IModelError(IModelHubStatus.MaximumNumberOfBriefcasesPerUser, originalError.message);
+
+    return originalError;
+  }
+
   private static tryMapGenericErrorCode(
     apiErrorCode: IModelsErrorCode,
     operationName?: OperationNameForErrorMapping
   ): IModelHubStatus | ChangeSetStatus | undefined {
     if (!operationName)
       return;
-
-    if (apiErrorCode === IModelsErrorCode.ResourceQuotaExceeded && operationName === "acquireBriefcase")
-      return IModelHubStatus.MaximumNumberOfBriefcasesPerUser;
 
     if (apiErrorCode === IModelsErrorCode.RateLimitExceeded && operationName === "acquireBriefcase")
       return IModelHubStatus.MaximumNumberOfBriefcasesPerUserPerMinute;
@@ -135,5 +145,9 @@ export class ErrorAdapter {
       default:
         return IModelHubStatus.Unknown;
     }
+  }
+
+  private static hasInnerErrorProperty(errorDetail: IModelsErrorDetail): errorDetail is IModelsErrorDetail & { innerError: { code: IModelsErrorCode } } {
+    return !!errorDetail.innerError && !!errorDetail.innerError.code;
   }
 }

--- a/itwin-platform-access/imodels-access-common/src/ErrorAdapter.ts
+++ b/itwin-platform-access/imodels-access-common/src/ErrorAdapter.ts
@@ -6,7 +6,7 @@
 import { ChangeSetStatus, IModelHubStatus } from "@itwin/core-bentley";
 import { IModelError } from "@itwin/core-common";
 
-import { IModelsError, IModelsErrorCode, IModelsErrorDetail, isIModelsApiError } from "@itwin/imodels-client-management";
+import { IModelsError, IModelsErrorCode, isIModelsApiError } from "@itwin/imodels-client-management";
 
 export type OperationNameForErrorMapping = "acquireBriefcase" | "downloadChangesets";
 
@@ -80,11 +80,11 @@ export class ErrorAdapter {
   }
 
   private static adaptInvalidRequestErrorIfPossible(originalError: IModelsError): IModelsError | IModelError {
-    if (!originalError.details || originalError.details.length === 0)
+    if (!originalError.details)
       return originalError;
 
     for (const errorDetail of originalError.details)
-      if (ErrorAdapter.hasInnerErrorProperty(errorDetail) && errorDetail.innerError.code === IModelsErrorCode.MaximumNumberOfBriefcasesPerUser)
+      if (errorDetail.innerError?.code === IModelsErrorCode.MaximumNumberOfBriefcasesPerUser)
         return new IModelError(IModelHubStatus.MaximumNumberOfBriefcasesPerUser, originalError.message);
 
     return originalError;
@@ -145,9 +145,5 @@ export class ErrorAdapter {
       default:
         return IModelHubStatus.Unknown;
     }
-  }
-
-  private static hasInnerErrorProperty(errorDetail: IModelsErrorDetail): errorDetail is IModelsErrorDetail & { innerError: { code: IModelsErrorCode } } {
-    return !!errorDetail.innerError && !!errorDetail.innerError.code;
   }
 }

--- a/tests/imodels-access-backend-tests/src/TestDiContainerProvider.ts
+++ b/tests/imodels-access-backend-tests/src/TestDiContainerProvider.ts
@@ -14,7 +14,7 @@ export function getTestDIContainer(): Container {
     return container;
 
   container = new Container();
-  TestUtilBootstrapper.bind(container, path.join(__dirname, "..", "..", ".env"));
+  TestUtilBootstrapper.bind(container, path.join(__dirname, "..", ".env"));
 
   return container;
 }

--- a/tests/imodels-access-common-tests/src/ErrorAdapter.test.ts
+++ b/tests/imodels-access-common-tests/src/ErrorAdapter.test.ts
@@ -164,6 +164,15 @@ describe("ErrorAdapter", () => {
         message: "Cannot acquire Briefcase.",
         details: [
           {
+            code: "foo",
+            message: "bar"
+          },
+          {
+            code: "foo",
+            message: "bar",
+            innerError: {}
+          },
+          {
             code: "ResourceQuotaExceeded",
             message: "Maximum number of Briefcases per user limit reached.",
             innerError: {
@@ -183,7 +192,9 @@ describe("ErrorAdapter", () => {
     expect(iModelError.errorNumber).to.be.equal(IModelHubStatus.MaximumNumberOfBriefcasesPerUser);
     expect(iModelError.message).to.be.equal(
       "Cannot acquire Briefcase. Details:\n" +
-      "1. ResourceQuotaExceeded: Maximum number of Briefcases per user limit reached.\n");
+      "1. Unrecognized: bar\n" +
+      "2. Unrecognized: bar\n" +
+      "3. ResourceQuotaExceeded: Maximum number of Briefcases per user limit reached.\n");
   });
 
   it("should correctly parse MaximumNumberOfBriefcasesPerUserPerMinute error", () => {

--- a/tests/imodels-access-common-tests/src/ErrorAdapter.test.ts
+++ b/tests/imodels-access-common-tests/src/ErrorAdapter.test.ts
@@ -5,7 +5,7 @@
 import { ChangeSetStatus, IModelHubStatus } from "@itwin/core-bentley";
 import { IModelError } from "@itwin/core-common";
 import { ErrorAdapter, OperationNameForErrorMapping } from "@itwin/imodels-access-common/lib/ErrorAdapter";
-import { IModelsErrorImpl } from "@itwin/imodels-client-management/lib/base/internal";
+import { IModelsErrorImpl, IModelsErrorParser } from "@itwin/imodels-client-management/lib/base/internal";
 import { expect } from "chai";
 
 import { IModelsErrorCode } from "@itwin/imodels-client-management";
@@ -155,5 +155,52 @@ describe("ErrorAdapter", () => {
       expect(iModelError.errorNumber).to.be.equal(IModelHubStatus.Unknown);
       expect(iModelError.message).to.be.equal(originalErrorMessage);
     });
+  });
+
+  it("should correctly parse MaximumNumberOfBriefcasesPerUser error", () => {
+    const apiResponse = {
+      error: {
+        code: "InvalidiModelsRequest",
+        message: "Cannot acquire Briefcase.",
+        details: [
+          {
+            code: "ResourceQuotaExceeded",
+            message: "Maximum number of Briefcases per user limit reached.",
+            innerError: {
+              code: "MaximumNumberOfBriefcasesPerUser"
+            }
+          }
+        ]
+      }
+    };
+    const apiError = IModelsErrorParser.parse({ statusCode: 422, body: apiResponse }, new Error());
+
+    const result = ErrorAdapter.toIModelError(apiError);
+
+    const isiModelError = result instanceof IModelError;
+    expect(isiModelError).to.be.true;
+    const iModelError = result as IModelError;
+    expect(iModelError.errorNumber).to.be.equal(IModelHubStatus.MaximumNumberOfBriefcasesPerUser);
+    expect(iModelError.message).to.be.equal(
+      "Cannot acquire Briefcase. Details:\n" +
+      "1. ResourceQuotaExceeded: Maximum number of Briefcases per user limit reached.\n");
+  });
+
+  it("should correctly parse MaximumNumberOfBriefcasesPerUserPerMinute error", () => {
+    const apiResponse = {
+      error: {
+        code: "RateLimitExceeded",
+        message: "Maximum number of briefcases per user per minute reached."
+      }
+    };
+    const apiError = IModelsErrorParser.parse({ statusCode: 429, body: apiResponse }, new Error());
+
+    const result = ErrorAdapter.toIModelError(apiError, "acquireBriefcase");
+
+    const isiModelError = result instanceof IModelError;
+    expect(isiModelError).to.be.true;
+    const iModelError = result as IModelError;
+    expect(iModelError.errorNumber).to.be.equal(IModelHubStatus.MaximumNumberOfBriefcasesPerUserPerMinute);
+    expect(iModelError.message).to.be.equal("Maximum number of briefcases per user per minute reached.");
   });
 });

--- a/tests/imodels-access-common-tests/src/ErrorAdapter.test.ts
+++ b/tests/imodels-access-common-tests/src/ErrorAdapter.test.ts
@@ -94,11 +94,6 @@ describe("ErrorAdapter", () => {
 
   [
     {
-      originalErrorCode: IModelsErrorCode.ResourceQuotaExceeded,
-      operationName: "acquireBriefcase" as const,
-      expectedErrorNumber: IModelHubStatus.MaximumNumberOfBriefcasesPerUser
-    },
-    {
       originalErrorCode: IModelsErrorCode.RateLimitExceeded,
       operationName: "acquireBriefcase" as const,
       expectedErrorNumber: IModelHubStatus.MaximumNumberOfBriefcasesPerUserPerMinute


### PR DESCRIPTION
In this PR:
- Fixed how `MaximumNumberOfBriefcasesPerUser` error is parsed.
- Added a test to see if the API response is correctly parsed to `MaximumNumberOfBriefcasesPerUser` error. Response is copied from the documentation: https://developer.bentley.com/apis/imodels-v2/operations/acquire-imodel-briefcase/#response-422-unprocessable-entity