### PR TITLE
Pin `axios` version to `~1.1.0`

### DIFF
--- a/clients/imodels-client-management/package.json
+++ b/clients/imodels-client-management/package.json
@@ -33,7 +33,7 @@
     "extends": "./node_modules/@itwin/imodels-client-common-config/.eslintrc.json"
   },
   "dependencies": {
-    "axios": "~1.1.0"
+    "axios": "1.1.0"
   },
   "devDependencies": {
     "@itwin/imodels-client-common-config": "workspace:*",

--- a/clients/imodels-client-management/package.json
+++ b/clients/imodels-client-management/package.json
@@ -33,7 +33,7 @@
     "extends": "./node_modules/@itwin/imodels-client-common-config/.eslintrc.json"
   },
   "dependencies": {
-    "axios": "^1.0.0"
+    "axios": "~1.1.0"
   },
   "devDependencies": {
     "@itwin/imodels-client-common-config": "workspace:*",

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -34,14 +34,14 @@ importers:
     specifiers:
       '@itwin/imodels-client-common-config': workspace:*
       '@types/node': ^18.11.18
-      axios: ~1.1.0
+      axios: 1.1.0
       cspell: ~5.21.0
       eslint: ~7.31.0
       rimraf: ~3.0.2
       sort-package-json: ~1.53.1
       typescript: ~4.4.0
     dependencies:
-      axios: 1.1.3
+      axios: 1.1.0
     devDependencies:
       '@itwin/imodels-client-common-config': link:../../utils/imodels-client-common-config
       '@types/node': 18.16.16
@@ -63,7 +63,7 @@ importers:
       '@itwin/imodels-client-common-config': workspace:*
       '@types/node': 14.14.31
       '@types/ws': ^7.0.0
-      axios: ~1.1.0
+      axios: 1.1.0
       cspell: ~5.21.0
       eslint: ~7.31.0
       rimraf: ~3.0.2
@@ -73,7 +73,7 @@ importers:
       '@azure/abort-controller': 1.1.0
       '@itwin/imodels-access-common': link:../imodels-access-common
       '@itwin/imodels-client-authoring': link:../../clients/imodels-client-authoring
-      axios: 1.1.3
+      axios: 1.1.0
     devDependencies:
       '@itwin/core-backend': 4.0.0_acda798b3eb76717c9a14158b1be73d0
       '@itwin/core-bentley': 4.0.0
@@ -316,7 +316,7 @@ importers:
       '@types/node': ^18.11.18
       '@types/sinon': ^10.0.15
       '@types/sinon-chai': ^3.2.9
-      axios: ~1.1.0
+      axios: 1.1.0
       chai: ~4.3.4
       chai-as-promised: ~7.1.1
       cpx2: 4.2.0
@@ -340,7 +340,7 @@ importers:
       '@itwin/imodels-client-test-utils': link:../../utils/imodels-client-test-utils
       '@itwin/object-storage-azure': 2.0.0_90b3e846c411421b9b95929cf52f60fd
       '@itwin/object-storage-core': 2.0.0_90b3e846c411421b9b95929cf52f60fd
-      axios: 1.1.3
+      axios: 1.1.0
       chai: 4.3.7
       chai-as-promised: 7.1.1_chai@4.3.7
       dotenv: 10.0.0
@@ -433,7 +433,7 @@ importers:
       '@itwin/object-storage-core': ^2.0.0
       '@types/chai': ~4.2.21
       '@types/node': ^18.11.18
-      axios: ~1.1.0
+      axios: 1.1.0
       chai: ~4.3.4
       cpx2: 4.2.0
       cspell: ~5.21.0
@@ -449,7 +449,7 @@ importers:
       '@itwin/imodels-client-authoring': link:../../clients/imodels-client-authoring
       '@itwin/imodels-client-management': link:../../clients/imodels-client-management
       '@itwin/object-storage-core': 2.0.0_90b3e846c411421b9b95929cf52f60fd
-      axios: 1.1.3
+      axios: 1.1.0
       chai: 4.3.7
       dotenv: 10.0.0
       inversify: 6.0.1
@@ -2155,8 +2155,8 @@ packages:
     transitivePeerDependencies:
       - debug
 
-  /axios/1.1.3:
-    resolution: {integrity: sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==}
+  /axios/1.1.0:
+    resolution: {integrity: sha512-hsJgcqz4JY7f+HZ4cWTrPZ6tZNCNFPTRx1MjRqu/hbpgpHdSCUpLVuplc+jE/h7dOvyANtw/ERA3HC2Rz/QoMg==}
     dependencies:
       follow-redirects: 1.15.2
       form-data: 4.0.0

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -34,14 +34,14 @@ importers:
     specifiers:
       '@itwin/imodels-client-common-config': workspace:*
       '@types/node': ^18.11.18
-      axios: ^1.0.0
+      axios: ~1.1.0
       cspell: ~5.21.0
       eslint: ~7.31.0
       rimraf: ~3.0.2
       sort-package-json: ~1.53.1
       typescript: ~4.4.0
     dependencies:
-      axios: 1.4.0
+      axios: 1.1.3
     devDependencies:
       '@itwin/imodels-client-common-config': link:../../utils/imodels-client-common-config
       '@types/node': 18.16.16
@@ -63,7 +63,7 @@ importers:
       '@itwin/imodels-client-common-config': workspace:*
       '@types/node': 14.14.31
       '@types/ws': ^7.0.0
-      axios: ^1.0.0
+      axios: ~1.1.0
       cspell: ~5.21.0
       eslint: ~7.31.0
       rimraf: ~3.0.2
@@ -73,7 +73,7 @@ importers:
       '@azure/abort-controller': 1.1.0
       '@itwin/imodels-access-common': link:../imodels-access-common
       '@itwin/imodels-client-authoring': link:../../clients/imodels-client-authoring
-      axios: 1.4.0
+      axios: 1.1.3
     devDependencies:
       '@itwin/core-backend': 4.0.0_acda798b3eb76717c9a14158b1be73d0
       '@itwin/core-bentley': 4.0.0
@@ -316,7 +316,7 @@ importers:
       '@types/node': ^18.11.18
       '@types/sinon': ^10.0.15
       '@types/sinon-chai': ^3.2.9
-      axios: ^1.0.0
+      axios: ~1.1.0
       chai: ~4.3.4
       chai-as-promised: ~7.1.1
       cpx2: 4.2.0
@@ -340,7 +340,7 @@ importers:
       '@itwin/imodels-client-test-utils': link:../../utils/imodels-client-test-utils
       '@itwin/object-storage-azure': 2.0.0_90b3e846c411421b9b95929cf52f60fd
       '@itwin/object-storage-core': 2.0.0_90b3e846c411421b9b95929cf52f60fd
-      axios: 1.4.0
+      axios: 1.1.3
       chai: 4.3.7
       chai-as-promised: 7.1.1_chai@4.3.7
       dotenv: 10.0.0
@@ -433,7 +433,7 @@ importers:
       '@itwin/object-storage-core': ^2.0.0
       '@types/chai': ~4.2.21
       '@types/node': ^18.11.18
-      axios: ^1.0.0
+      axios: ~1.1.0
       chai: ~4.3.4
       cpx2: 4.2.0
       cspell: ~5.21.0
@@ -449,7 +449,7 @@ importers:
       '@itwin/imodels-client-authoring': link:../../clients/imodels-client-authoring
       '@itwin/imodels-client-management': link:../../clients/imodels-client-management
       '@itwin/object-storage-core': 2.0.0_90b3e846c411421b9b95929cf52f60fd
-      axios: 1.4.0
+      axios: 1.1.3
       chai: 4.3.7
       dotenv: 10.0.0
       inversify: 6.0.1
@@ -2155,8 +2155,8 @@ packages:
     transitivePeerDependencies:
       - debug
 
-  /axios/1.4.0:
-    resolution: {integrity: sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==}
+  /axios/1.1.3:
+    resolution: {integrity: sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==}
     dependencies:
       follow-redirects: 1.15.2
       form-data: 4.0.0

--- a/itwin-platform-access/imodels-access-backend/package.json
+++ b/itwin-platform-access/imodels-access-backend/package.json
@@ -34,7 +34,7 @@
     "@azure/abort-controller": "^1.1.0",
     "@itwin/imodels-access-common": "workspace:*",
     "@itwin/imodels-client-authoring": "workspace:*",
-    "axios": "^1.0.0"
+    "axios": "~1.1.0"
   },
   "devDependencies": {
     "@itwin/core-backend": "^4.0.0",

--- a/itwin-platform-access/imodels-access-backend/package.json
+++ b/itwin-platform-access/imodels-access-backend/package.json
@@ -34,7 +34,7 @@
     "@azure/abort-controller": "^1.1.0",
     "@itwin/imodels-access-common": "workspace:*",
     "@itwin/imodels-client-authoring": "workspace:*",
-    "axios": "~1.1.0"
+    "axios": "1.1.0"
   },
   "devDependencies": {
     "@itwin/core-backend": "^4.0.0",

--- a/itwin-platform-access/imodels-access-backend/src/CheckpointHelperFunctions.ts
+++ b/itwin-platform-access/imodels-access-backend/src/CheckpointHelperFunctions.ts
@@ -7,6 +7,7 @@ import {
   CheckpointArg, CheckpointProps,
   V2CheckpointAccessProps
 } from "@itwin/core-backend";
+import { Logger } from "@itwin/core-bentley";
 import { Constants } from "@itwin/imodels-access-common/lib/Constants";
 import { handleAPIErrors } from "@itwin/imodels-access-common/lib/ErrorHandlingFunctions";
 import axios, { AxiosResponse } from "axios";
@@ -79,7 +80,12 @@ export async function getV1CheckpointSize(downloadUrl: string): Promise<number> 
   const contentRangeHeaderName = "content-range";
 
   const response: AxiosResponse = await axios.get(downloadUrl, { headers: { Range: emptyRangeHeaderValue } });
-  const rangeHeaderValue: string = response.headers[contentRangeHeaderName];
+  const rangeHeaderValue: string | undefined = response.headers[contentRangeHeaderName];
+  if (!rangeHeaderValue) {
+    Logger.logError("BackendIModelsAccess", "Cannot determine total V1 checkpoint size");
+    return 0;
+  }
+
   const rangeTotalBytesString: string = rangeHeaderValue.split("/")[1];
   const rangeTotalBytes: number = parseInt(rangeTotalBytesString, 10);
 

--- a/tests/imodels-clients-tests/package.json
+++ b/tests/imodels-clients-tests/package.json
@@ -42,7 +42,7 @@
     "@itwin/imodels-client-test-utils": "workspace:*",
     "@itwin/object-storage-azure": "^2.0.0",
     "@itwin/object-storage-core": "^2.0.0",
-    "axios": "^1.0.0",
+    "axios": "~1.1.0",
     "chai": "~4.3.4",
     "chai-as-promised": "~7.1.1",
     "dotenv": "~10.0.0",

--- a/tests/imodels-clients-tests/package.json
+++ b/tests/imodels-clients-tests/package.json
@@ -42,7 +42,7 @@
     "@itwin/imodels-client-test-utils": "workspace:*",
     "@itwin/object-storage-azure": "^2.0.0",
     "@itwin/object-storage-core": "^2.0.0",
-    "axios": "~1.1.0",
+    "axios": "1.1.0",
     "chai": "~4.3.4",
     "chai-as-promised": "~7.1.1",
     "dotenv": "~10.0.0",

--- a/utils/imodels-client-test-utils/package.json
+++ b/utils/imodels-client-test-utils/package.json
@@ -33,7 +33,7 @@
     "@itwin/imodels-client-authoring": "workspace:*",
     "@itwin/imodels-client-management": "workspace:*",
     "@itwin/object-storage-core": "^2.0.0",
-    "axios": "~1.1.0",
+    "axios": "1.1.0",
     "chai": "~4.3.4",
     "dotenv": "~10.0.0",
     "inversify": "~6.0.1",

--- a/utils/imodels-client-test-utils/package.json
+++ b/utils/imodels-client-test-utils/package.json
@@ -33,7 +33,7 @@
     "@itwin/imodels-client-authoring": "workspace:*",
     "@itwin/imodels-client-management": "workspace:*",
     "@itwin/object-storage-core": "^2.0.0",
-    "axios": "^1.0.0",
+    "axios": "~1.1.0",
     "chai": "~4.3.4",
     "dotenv": "~10.0.0",
     "inversify": "~6.0.1",


### PR DESCRIPTION
In this PR:
- Changed `axios` version specifier from `^1.0.0` to `~1.1.0` because of the following issue: https://github.com/axios/axios/issues/5011