### PR TITLE
Add `skipLibCheck` to @itwin/imodels-access-* package tsconfig files

### DIFF
--- a/itwin-platform-access/imodels-access-backend/tsconfig.json
+++ b/itwin-platform-access/imodels-access-backend/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "./node_modules/@itwin/imodels-client-common-config/tsconfig.json",
   "compilerOptions": {
     "outDir": "./lib",
+    "skipLibCheck": true
   },
   "include": [
     "./src/**/*.ts"

--- a/itwin-platform-access/imodels-access-common/tsconfig.json
+++ b/itwin-platform-access/imodels-access-common/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "./node_modules/@itwin/imodels-client-common-config/tsconfig.json",
   "compilerOptions": {
     "outDir": "./lib",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "include": [
     "./src/**/*.ts"

--- a/itwin-platform-access/imodels-access-frontend/tsconfig.esm.json
+++ b/itwin-platform-access/imodels-access-frontend/tsconfig.esm.json
@@ -2,7 +2,8 @@
   "extends": "./node_modules/@itwin/imodels-client-common-config/tsconfig.esm.json",
   "compilerOptions": {
     "outDir": "./lib/esm",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "include": [
     "./src/**/*.ts"

--- a/itwin-platform-access/imodels-access-frontend/tsconfig.json
+++ b/itwin-platform-access/imodels-access-frontend/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "./node_modules/@itwin/imodels-client-common-config/tsconfig.json",
   "compilerOptions": {
     "outDir": "./lib",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "include": [
     "./src/**/*.ts"

--- a/tests/imodels-access-backend-tests/tsconfig.json
+++ b/tests/imodels-access-backend-tests/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "./node_modules/@itwin/imodels-client-common-config/tsconfig.json",
   "compilerOptions": {
     "outDir": "./lib",
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "skipLibCheck": true
   },
   "include": [
     "./src/**/*.ts"

--- a/tests/imodels-access-common-tests/tsconfig.json
+++ b/tests/imodels-access-common-tests/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "./node_modules/@itwin/imodels-client-common-config/tsconfig.json",
   "compilerOptions": {
     "outDir": "./lib",
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "skipLibCheck": true
   },
   "include": [
     "./src/**/*.ts"

--- a/tests/imodels-access-frontend-tests/tsconfig.json
+++ b/tests/imodels-access-frontend-tests/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "./lib",
     "experimentalDecorators": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "include": [
     "./src/**/*.ts"


### PR DESCRIPTION
In this PR:
- Added `skipLibCheck` option to packages that pull in iTwin.js core