### PR TITLE
Make Thumbnail test iModel name more unique

### DIFF
--- a/tests/imodels-clients-tests-browser/src/ThumbnailOperations.test.ts
+++ b/tests/imodels-clients-tests-browser/src/ThumbnailOperations.test.ts
@@ -28,11 +28,12 @@ describe(`[Management] ${ThumbnailOperations.name}`, () => {
     testIModelForReadId = Cypress.env(FrontendTestEnvVariableKeys.testIModelForReadId);
 
     const iTwinId: string = Cypress.env(FrontendTestEnvVariableKeys.testITwinId);
+    const uniqueId = new Date().getTime();
     const testIModelForWrite = await iModelsClient.iModels.createEmpty({
       authorization,
       iModelProperties: {
         iTwinId,
-        name: "Thumbnail browser tests"
+        name: `Thumbnail browser tests [${uniqueId}]`
       }
     });
     testIModelForWriteId = testIModelForWrite.id;


### PR DESCRIPTION
In this PR:
- Added a numeric value to make Thumbnail browser test iModel name more unique. The numeric value is [miliseconds elapsed since the epoch](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime).