### PR TITLE
Add Changeset Group operations

### DIFF
--- a/clients/imodels-client-authoring/src/IModelsClient.ts
+++ b/clients/imodels-client-authoring/src/IModelsClient.ts
@@ -17,7 +17,7 @@ import {
 import { NodeLocalFileSystem } from "./base/internal";
 import { IModelsErrorParser } from "./base/internal/IModelsErrorParser";
 import { LocalFileSystem } from "./base/types";
-import { BaselineFileOperations, BriefcaseOperations, ChangesetOperations, IModelOperations, IModelsApiUrlFormatter, LockOperations, OperationOptions } from "./operations";
+import { BaselineFileOperations, BriefcaseOperations, ChangesetGroupOperations, ChangesetOperations, IModelOperations, IModelsApiUrlFormatter, LockOperations, OperationOptions } from "./operations";
 
 /** User-configurable iModels client options. */
 export interface IModelsClientOptions extends ManagementIModelsClientOptions {
@@ -83,6 +83,11 @@ export class IModelsClient extends ManagementIModelsClient {
   /** Changeset operations. See {@link ChangesetOperations}. */
   public override get changesets(): ChangesetOperations<OperationOptions> {
     return new ChangesetOperations(this._operationsOptions, this);
+  }
+
+  /** Changeset Group operations. See {@link ChangesetGroupOperations}. */
+  public override get changesetGroups(): ChangesetGroupOperations<OperationOptions> {
+    return new ChangesetGroupOperations(this._operationsOptions, this);
   }
 
   /** Lock operations. See {@link LockOperations}. */

--- a/clients/imodels-client-authoring/src/operations/OperationExports.ts
+++ b/clients/imodels-client-authoring/src/operations/OperationExports.ts
@@ -6,4 +6,5 @@ export * from "./baseline-file/BaselineFileOperations";
 export * from "./imodel/IModelOperations";
 export * from "./briefcase/BriefcaseOperations";
 export * from "./changeset/ChangesetOperations";
+export * from "./changeset-group/ChangesetGroupOperations";
 export * from "./lock/LockOperations";

--- a/clients/imodels-client-authoring/src/operations/OperationParamExports.ts
+++ b/clients/imodels-client-authoring/src/operations/OperationParamExports.ts
@@ -6,4 +6,5 @@ export * from "./baseline-file/BaselineFileOperationParams";
 export * from "./imodel/IModelOperationParams";
 export * from "./briefcase/BriefcaseOperationParams";
 export * from "./changeset/ChangesetOperationParams";
+export * from "./changeset-group/ChangesetGroupOperationParams";
 export * from "./lock/LockOperationParams";

--- a/clients/imodels-client-authoring/src/operations/changeset-group/ChangesetGroupOperationParams.ts
+++ b/clients/imodels-client-authoring/src/operations/changeset-group/ChangesetGroupOperationParams.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { AtLeastOneProperty, ChangesetGroupState, IModelScopedOperationParams } from "@itwin/imodels-client-management";
+
+/** Properties that should be specified when creating a new Changeset Group. */
+export interface ChangesetGroupPropertiesForCreate {
+  /** Changeset Group description. */
+  description: string;
+}
+
+/** Parameters for create Changeset Group operation. */
+export interface CreateChangesetGroupParams extends IModelScopedOperationParams {
+  /** Properties of the new Changeset Group. */
+  changesetGroupProperties: ChangesetGroupPropertiesForCreate;
+}
+
+/** Changeset Group properties that can be updated. */
+export interface EditableChangesetGroupProperties {
+  /** State of the Changeset Group. Should be set to {@link ChangesetGroupState.Completed}. */
+  state: ChangesetGroupState;
+}
+
+/**
+ * Properties that can be specified when updating a Changeset Group.
+ * At least one of the editable properties should be specified.
+ */
+export type ChangesetGroupPropertiesForUpdate = AtLeastOneProperty<EditableChangesetGroupProperties>;
+
+/** Parameters for Changeset Group operation. */
+export interface UpdateChangesetGroupParams extends IModelScopedOperationParams {
+  /** Changeset Group id. */
+  changesetGroupId: string;
+  /** New values for some of the Changeset Group properties. */
+  changesetGroupProperties: ChangesetGroupPropertiesForUpdate;
+}

--- a/clients/imodels-client-authoring/src/operations/changeset-group/ChangesetGroupOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/changeset-group/ChangesetGroupOperations.ts
@@ -1,0 +1,64 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { ChangesetGroupResponse } from "@itwin/imodels-client-management/lib/base/internal";
+import { ChangesetGroupOperations as ManagementChangesetGroupOperations } from "@itwin/imodels-client-management/lib/operations";
+
+import { ChangesetGroup } from "@itwin/imodels-client-management";
+
+import { OperationOptions } from "../OperationOptions";
+
+import { ChangesetGroupPropertiesForCreate, ChangesetGroupPropertiesForUpdate, CreateChangesetGroupParams, UpdateChangesetGroupParams } from "./ChangesetGroupOperationParams";
+
+export class ChangesetGroupOperations<TOptions extends OperationOptions> extends ManagementChangesetGroupOperations<TOptions> {
+  /**
+   * Creates a Changeset Group. Wraps the
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/create-imodel-changeset-group/ Create iModel Changeset Group}
+   * operation from iModels API.
+   * @param {CreateChangesetGroupParams} params parameters for this operation. See {@link CreateChangesetGroupParams}.
+   * @returns {Promise<ChangesetGroup>} newly created Changeset Group. See {@link ChangesetGroup}.
+   */
+  public async create(params: CreateChangesetGroupParams): Promise<ChangesetGroup> {
+    const createChangesetGroupBody = this.getCreateChangesetGroupRequestBody(params.changesetGroupProperties);
+    const createChangesetGroupResponse = await this.sendPostRequest<ChangesetGroupResponse>({
+      authorization: params.authorization,
+      url: this._options.urlFormatter.getChangesetGroupListUrl({ iModelId: params.iModelId }),
+      body: createChangesetGroupBody,
+      headers: params.headers
+    });
+    const result = this.appendRelatedEntityCallbacks(params.authorization, createChangesetGroupResponse.changesetGroup, params.headers);
+    return result;
+  }
+
+  /**
+   * Closes an existing Changeset Group. Wraps the
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/update-imodel-changeset-group/ Update iModel Changeset Group}
+   * operation from iModels API.
+   * @param {UpdateChangesetGroupParams} params parameters for this operation. See {@link UpdateChangesetGroupParams}.
+   * @returns {Promise<ChangesetGroup>} updated Changeset Group. See {@link ChangesetGroup}.
+   */
+  public async update(params: UpdateChangesetGroupParams): Promise<ChangesetGroup> {
+    const updateChangesetGroupBody = this.getUpdateChangesetGroupRequestBody(params.changesetGroupProperties);
+    const updateChangesetGroupResponse = await this.sendPatchRequest<ChangesetGroupResponse>({
+      authorization: params.authorization,
+      url: this._options.urlFormatter.getSingleChangesetGroupUrl({ iModelId: params.iModelId, changesetGroupId: params.changesetGroupId }),
+      body: updateChangesetGroupBody,
+      headers: params.headers
+    });
+    const result = this.appendRelatedEntityCallbacks(params.authorization, updateChangesetGroupResponse.changesetGroup, params.headers);
+    return result;
+  }
+
+  private getCreateChangesetGroupRequestBody(changesetGroupProperties: ChangesetGroupPropertiesForCreate): object {
+    return {
+      description: changesetGroupProperties.description
+    };
+  }
+
+  private getUpdateChangesetGroupRequestBody(changesetGroupProperties: ChangesetGroupPropertiesForUpdate): object {
+    return {
+      state: changesetGroupProperties.state
+    };
+  }
+}

--- a/clients/imodels-client-authoring/src/operations/changeset/ChangesetOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/changeset/ChangesetOperations.ts
@@ -32,8 +32,9 @@ interface DownloadChangesetFileWithRetryParams extends IModelScopedOperationPara
 
 export class ChangesetOperations<TOptions extends OperationOptions> extends ManagementChangesetOperations<TOptions>{
   /**
-   * Creates a Changeset. Wraps the {@link https://developer.bentley.com/apis/imodels-v2/operations/create-imodel-changeset/
-   * Create iModel Changeset} operation from iModels API. Internally it creates a Changeset instance, uploads the Changeset
+   * Creates a Changeset. Wraps the
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/create-imodel-changeset/ Create iModel Changeset}
+   * operation from iModels API. Internally it creates a Changeset instance, uploads the Changeset
    * file and confirms Changeset file upload. The execution of this method depends on the Changeset file size - the larger
    * the file, the longer the upload will take.
    * @param {CreateChangesetParams} params parameters for this operation. See {@link CreateChangesetParams}.

--- a/clients/imodels-client-management/src/IModelsClient.ts
+++ b/clients/imodels-client-management/src/IModelsClient.ts
@@ -6,6 +6,7 @@ import { AxiosRestClient, IModelsErrorParser } from "./base/internal";
 import { ApiOptions, HeaderFactories, RecursiveRequired, RestClient } from "./base/types";
 import { Constants } from "./Constants";
 import { BriefcaseOperations, ChangesetOperations, IModelOperations, NamedVersionOperations, ThumbnailOperations, UserOperations, UserPermissionOperations } from "./operations";
+import { ChangesetGroupOperations } from "./operations/changeset-group/ChangesetGroupOperations";
 import { CheckpointOperations } from "./operations/checkpoint/CheckpointOperations";
 import { IModelsApiUrlFormatter } from "./operations/IModelsApiUrlFormatter";
 import { OperationOptions } from "./operations/OperationOptions";
@@ -56,6 +57,11 @@ export class IModelsClient {
   /** Changeset operations. See {@link ChangesetOperations}. */
   public get changesets(): ChangesetOperations<OperationOptions> {
     return new ChangesetOperations(this._operationsOptions, this);
+  }
+
+  /** Changeset Group operations. See {@link ChangesetGroupOperations}. */
+  public get changesetGroups(): ChangesetGroupOperations<OperationOptions> {
+    return new ChangesetGroupOperations(this._operationsOptions, this);
   }
 
   /** Named version operations. See {@link NamedVersionOperations}. */

--- a/clients/imodels-client-management/src/base/internal/ApiResponseInterfaces.ts
+++ b/clients/imodels-client-management/src/base/internal/ApiResponseInterfaces.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { Briefcase, Changeset, Checkpoint, IModel, Link, MinimalBriefcase, MinimalChangeset, MinimalIModel, MinimalNamedVersion, MinimalUser, NamedVersion, User } from "../types";
+import { Briefcase, Changeset, ChangesetGroup, Checkpoint, IModel, Link, MinimalBriefcase, MinimalChangeset, MinimalIModel, MinimalNamedVersion, MinimalUser, NamedVersion, User } from "../types";
 
 /**
  * Links that are included in all entity list page responses. They simplify pagination implementation because users
@@ -38,6 +38,10 @@ export interface ChangesetsResponse<TChangeset extends MinimalChangeset> extends
   changesets: TChangeset[];
 }
 
+export interface ChangesetGroupsResponse extends CollectionResponse {
+  changesetGroups: ChangesetGroup[];
+}
+
 export interface UsersResponse<TUser extends MinimalUser> extends CollectionResponse {
   users: TUser[];
 }
@@ -48,6 +52,10 @@ export interface BriefcaseResponse {
 
 export interface ChangesetResponse {
   changeset: Changeset;
+}
+
+export interface ChangesetGroupResponse {
+  changesetGroup: ChangesetGroup;
 }
 
 export interface CheckpointResponse {

--- a/clients/imodels-client-management/src/base/types/IModelsErrorInterfaces.ts
+++ b/clients/imodels-client-management/src/base/types/IModelsErrorInterfaces.ts
@@ -34,6 +34,7 @@ export enum IModelsErrorCode {
   IModelNotFound = "iModelNotFound",
   NamedVersionNotFound = "NamedVersionNotFound",
   ChangesetNotFound = "ChangesetNotFound",
+  ChangesetGroupNotFound = "ChangesetGroupNotFound",
   UserNotFound = "UserNotFound",
   BriefcaseNotFound = "BriefcaseNotFound",
   MaximumNumberOfBriefcasesPerUser = "MaximumNumberOfBriefcasesPerUser",

--- a/clients/imodels-client-management/src/base/types/apiEntities/ChangesetGroupInterfaces.ts
+++ b/clients/imodels-client-management/src/base/types/apiEntities/ChangesetGroupInterfaces.ts
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { Link } from "../CommonInterfaces";
+
+import { User } from "./UserInterfaces";
+
+/** Possible Changeset Group states. */
+export enum ChangesetGroupState {
+  /** Changeset Group is in progress and Changesets can be pushed to it. */
+  InProgress = "inProgress",
+  /** Changeset Group is closed and Changesets cannot be pushed to it anymore. */
+  Completed = "completed",
+  /** Changeset Group was not completed within the specified timeout period so it was closed by the service. */
+  TimedOut = "timedOut",
+  /** Changeset group was forcibly closed before cloning to the target iModel. */
+  ForciblyClosed = "forciblyClosed"
+}
+
+/** Links that belong to a Changeset Group entity returned from iModels API. */
+export interface ChangesetGroupLinks {
+  /** Link to the User which created the Changeset Group. Link points to a specific User in iModels API. */
+  creator: Link | null;
+}
+
+/** Changeset Group. */
+export interface ChangesetGroup {
+  /** Changeset Group id. */
+  id: string;
+  /** Changeset Group description. */
+  description: string;
+  /** Changeset Group state. See {@link ChangesetGroupState}. */
+  state: ChangesetGroupState;
+  /** Id of the user who created the Changeset Group. */
+  creatorId: string;
+  /** Datetime string of when the Changeset Group was created. */
+  createdDateTime: string;
+  /** Changeset Group links. See {@link ChangesetGroupLinks}. */
+  _links: ChangesetGroupLinks;
+  /**
+   * Function to query User who created the Changeset Group. If the information is not present the
+   * function returns `undefined`. This function reuses authorization information passed to specific Changeset Group
+   * operation that originally queried the Changeset Group from API.
+   */
+  getCreator: () => Promise<User | undefined>;
+}

--- a/clients/imodels-client-management/src/base/types/index.ts
+++ b/clients/imodels-client-management/src/base/types/index.ts
@@ -5,6 +5,7 @@
 export * from "./apiEntities/IModelInterfaces";
 export * from "./apiEntities/BriefcaseInterfaces";
 export * from "./apiEntities/ChangesetInterfaces";
+export * from "./apiEntities/ChangesetGroupInterfaces";
 export * from "./apiEntities/NamedVersionInterfaces";
 export * from "./apiEntities/CheckpointInterfaces";
 export * from "./apiEntities/ThumbnailInterfaces";

--- a/clients/imodels-client-management/src/operations/IModelsApiUrlFormatter.ts
+++ b/clients/imodels-client-management/src/operations/IModelsApiUrlFormatter.ts
@@ -6,6 +6,7 @@ import { CollectionRequestParams, Dictionary,OrderBy } from "../base/types";
 
 import { GetBriefcaseListUrlParams } from "./briefcase/BriefcaseOperationParams";
 import { ChangesetIdOrIndex, GetChangesetListUrlParams } from "./changeset/ChangesetOperationParams";
+import { GetChangesetGroupListUrlParams } from "./changeset-group/ChangesetGroupOperationParams";
 import { CheckpointParentEntityId } from "./checkpoint/CheckpointOperationParams";
 import { GetIModelListUrlParams } from "./imodel/IModelOperationParams";
 import { GetNamedVersionListUrlParams } from "./named-version/NamedVersionOperationParams";
@@ -57,6 +58,14 @@ export class IModelsApiUrlFormatter {
 
   public getChangesetListUrl(params: { iModelId: string, urlParams?: GetChangesetListUrlParams }): string {
     return `${this.baseUrl}/${params.iModelId}/changesets${this.formQueryString({ ...params.urlParams })}`;
+  }
+
+  public getSingleChangesetGroupUrl(params: { iModelId: string } & { changesetGroupId: string }): string {
+    return `${this.baseUrl}/${params.iModelId}/changesetgroups/${params.changesetGroupId}`;
+  }
+
+  public getChangesetGroupListUrl(params: { iModelId: string, urlParams?: GetChangesetGroupListUrlParams }): string {
+    return `${this.baseUrl}/${params.iModelId}/changesetgroups${this.formQueryString({ ...params.urlParams })}`;
   }
 
   public parseChangesetUrl(url: string): { iModelId: string } & ChangesetIdOrIndex {

--- a/clients/imodels-client-management/src/operations/OperationExports.ts
+++ b/clients/imodels-client-management/src/operations/OperationExports.ts
@@ -5,6 +5,7 @@
 export * from "./imodel/IModelOperations";
 export * from "./briefcase/BriefcaseOperations";
 export * from "./changeset/ChangesetOperations";
+export * from "./changeset-group/ChangesetGroupOperations";
 export * from "./named-version/NamedVersionOperations";
 export * from "./checkpoint/CheckpointOperations";
 export * from "./thumbnail/ThumbnailOperations";

--- a/clients/imodels-client-management/src/operations/OperationParamExports.ts
+++ b/clients/imodels-client-management/src/operations/OperationParamExports.ts
@@ -5,6 +5,7 @@
 export * from "./imodel/IModelOperationParams";
 export * from "./briefcase/BriefcaseOperationParams";
 export * from "./changeset/ChangesetOperationParams";
+export * from "./changeset-group/ChangesetGroupOperationParams";
 export * from "./named-version/NamedVersionOperationParams";
 export * from "./checkpoint/CheckpointOperationParams";
 export * from "./thumbnail/ThumbnailOperationParams";

--- a/clients/imodels-client-management/src/operations/changeset-group/ChangesetGroupOperationParams.ts
+++ b/clients/imodels-client-management/src/operations/changeset-group/ChangesetGroupOperationParams.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { CollectionRequestParams, IModelScopedOperationParams } from "../../base/types";
+
+/** Url parameters supported in Changeset Group list query. */
+export type GetChangesetGroupListUrlParams = CollectionRequestParams;
+
+/** Parameters for get Changeset Group list operation. */
+export interface GetChangesetGroupListParams extends IModelScopedOperationParams {
+  /** Parameters that will be appended to the entity list request url that will narrow down the results. */
+  urlParams?: GetChangesetGroupListUrlParams;
+}
+
+/** Parameters for get single Changeset Group operation. */
+export interface GetSingleChangesetGroupParams extends IModelScopedOperationParams {
+  /** Changeset Group id. */
+  changesetGroupId: string;
+}

--- a/clients/imodels-client-management/src/operations/changeset-group/ChangesetGroupOperations.ts
+++ b/clients/imodels-client-management/src/operations/changeset-group/ChangesetGroupOperations.ts
@@ -51,12 +51,10 @@ export class ChangesetGroupOperations<TOptions extends OperationOptions> extends
    * @returns {Promise<ChangesetGroup>} a Changeset Group with the specified id. See {@link ChangesetGroup}.
    */
   public async getSingle(params: GetSingleChangesetGroupParams): Promise<ChangesetGroup> {
-    const { authorization, iModelId, headers, changesetGroupId } = params;
-
     const response = await this.sendGetRequest<ChangesetGroupResponse>({
-      authorization,
-      url: this._options.urlFormatter.getSingleChangesetGroupUrl({iModelId, changesetGroupId}),
-      headers
+      authorization: params.authorization,
+      url: this._options.urlFormatter.getSingleChangesetGroupUrl({ iModelId: params.iModelId, changesetGroupId: params.changesetGroupId }),
+      headers: params.headers
     });
 
     const result: ChangesetGroup = this.appendRelatedEntityCallbacks(

--- a/clients/imodels-client-management/src/operations/changeset-group/ChangesetGroupOperations.ts
+++ b/clients/imodels-client-management/src/operations/changeset-group/ChangesetGroupOperations.ts
@@ -1,0 +1,87 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { ChangesetGroupResponse, ChangesetGroupsResponse, EntityListIteratorImpl, OperationsBase } from "../../base/internal";
+import { AuthorizationCallback, EntityListIterator, HeaderFactories } from "../../base/types";
+import { ChangesetGroup } from "../../base/types/apiEntities/ChangesetGroupInterfaces";
+import { IModelsClient } from "../../IModelsClient";
+import { OperationOptions } from "../OperationOptions";
+import { getUser } from "../SharedFunctions";
+
+import { GetChangesetGroupListParams, GetSingleChangesetGroupParams } from "./ChangesetGroupOperationParams";
+
+export class ChangesetGroupOperations<TOptions extends OperationOptions> extends OperationsBase<TOptions> {
+  constructor(
+    options: TOptions,
+    private _iModelsClient: IModelsClient
+  ) {
+    super(options);
+  }
+
+  /**
+   * Gets Changeset Groups for a specific iModel. Wraps the
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/get-imodel-changeset-groups/ Get iModel Changeset Groups}
+   * operation from iModels API.
+   * @param {GetChangesetGroupListParams} params parameters for this operation. See {@link GetChangesetGroupListParams}.
+   * @returns {EntityListIterator<ChangesetGroup>} iterator for Changeset Group list, which internally queries entities in pages.
+   * See {@link EntityListIterator}, {@link ChangesetGroup}.
+   */
+  public getList(params: GetChangesetGroupListParams): EntityListIterator<ChangesetGroup> {
+    const entityCollectionAccessor = (response: unknown) => {
+      const changesetGroups = (response as ChangesetGroupsResponse).changesetGroups;
+      const mappedChangesetGroups = changesetGroups.map((changesetGroup) =>
+        this.appendRelatedEntityCallbacks(params.authorization, changesetGroup, params.headers));
+      return mappedChangesetGroups;
+    };
+
+    return new EntityListIteratorImpl(async () => this.getEntityCollectionPage<ChangesetGroup>({
+      authorization: params.authorization,
+      url: this._options.urlFormatter.getChangesetGroupListUrl({ iModelId: params.iModelId, urlParams: params.urlParams }),
+      entityCollectionAccessor,
+      headers: params.headers
+    }));
+  }
+
+  /**
+   * Gets a single Changeset Group identified by id. Wraps the
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/get-imodel-changeset-group-details/ Get iModel Changeset Group}
+   * operation from iModels API.
+   * @param {GetSingleChangesetGroupParams} params parameters for this operation. See {@link GetSingleChangesetGroupParams}.
+   * @returns {Promise<ChangesetGroup>} a Changeset Group with the specified id. See {@link ChangesetGroup}.
+   */
+  public async getSingle(params: GetSingleChangesetGroupParams): Promise<ChangesetGroup> {
+    const { authorization, iModelId, headers, changesetGroupId } = params;
+
+    const response = await this.sendGetRequest<ChangesetGroupResponse>({
+      authorization,
+      url: this._options.urlFormatter.getSingleChangesetGroupUrl({iModelId, changesetGroupId}),
+      headers
+    });
+
+    const result: ChangesetGroup = this.appendRelatedEntityCallbacks(
+      params.authorization,
+      response.changesetGroup,
+      params.headers
+    );
+
+    return result;
+  }
+
+  protected appendRelatedEntityCallbacks(authorization: AuthorizationCallback, changesetGroup: ChangesetGroup, headers?: HeaderFactories): ChangesetGroup {
+    const getCreator = async () => getUser(
+      authorization,
+      this._iModelsClient.users,
+      this._options.urlFormatter,
+      changesetGroup._links.creator?.href,
+      headers
+    );
+
+    const result: ChangesetGroup = {
+      ...changesetGroup,
+      getCreator
+    };
+
+    return result;
+  }
+}

--- a/clients/imodels-client-management/src/operations/changeset/ChangesetOperations.ts
+++ b/clients/imodels-client-management/src/operations/changeset/ChangesetOperations.ts
@@ -69,9 +69,10 @@ export class ChangesetOperations<TOptions extends OperationOptions> extends Oper
   }
 
   /**
-   * Gets a single Changeset identified by either index or id. This method returns a Changeset in its full
-   * representation. Wraps the {@link https://developer.bentley.com/apis/imodels-v2/operations/get-imodel-changeset-details/
-   * Get iModel Changeset} operation from iModels API.
+   * Gets a single Changeset identified by either index or id. This method returns a Changeset in its full representation.
+   * Wraps the
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/get-imodel-changeset-details/ Get iModel Changeset}
+   * operation from iModels API.
    * @param {GetSingleChangesetParams} params parameters for this operation. See {@link GetSingleChangesetParams}.
    * @returns {Promise<Changeset>} a Changeset with specified id or index. See {@link Changeset}.
    */
@@ -112,7 +113,7 @@ export class ChangesetOperations<TOptions extends OperationOptions> extends Oper
     return result;
   }
 
-  protected appendRelatedEntityCallbacks(authorization: AuthorizationCallback, changeset: Changeset, headers?: HeaderFactories ): Changeset {
+  protected appendRelatedEntityCallbacks(authorization: AuthorizationCallback, changeset: Changeset, headers?: HeaderFactories): Changeset {
     const getNamedVersion = async () => this.getNamedVersion(authorization, changeset._links.namedVersion?.href, headers);
     const getCurrentOrPrecedingCheckpoint = async () => this.getCurrentOrPrecedingCheckpoint(authorization, changeset._links.currentOrPrecedingCheckpoint?.href, headers);
 

--- a/tests/imodels-clients-tests/src/integration/authoring/ChangesetGroupOperations.test.ts
+++ b/tests/imodels-clients-tests/src/integration/authoring/ChangesetGroupOperations.test.ts
@@ -1,0 +1,85 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { AuthorizationCallback, ChangesetGroup, ChangesetGroupState, CreateChangesetGroupParams, IModelsClient, IModelsClientOptions, UpdateChangesetGroupParams } from "@itwin/imodels-client-authoring";
+import { IModelMetadata, TestAuthorizationProvider, TestIModelCreator, TestIModelGroup, TestIModelGroupFactory, TestUtilTypes, assertChangesetGroup } from "@itwin/imodels-client-test-utils";
+
+import { Constants, getTestDIContainer, getTestRunId } from "../common";
+
+describe("[Authoring] ChangesetGroupOperations", () => {
+  let iModelsClient: IModelsClient;
+  let authorization: AuthorizationCallback;
+
+  let testIModelGroup: TestIModelGroup;
+  let testIModel: IModelMetadata;
+
+  before(async () => {
+    const container = getTestDIContainer();
+
+    const iModelsClientOptions = container.get<IModelsClientOptions>(TestUtilTypes.IModelsClientOptions);
+    iModelsClient = new IModelsClient(iModelsClientOptions);
+
+    const authorizationProvider = container.get(TestAuthorizationProvider);
+    authorization = authorizationProvider.getAdmin1Authorization();
+
+    const testIModelGroupFactory = container.get(TestIModelGroupFactory);
+    testIModelGroup = testIModelGroupFactory.create({ testRunId: getTestRunId(), packageName: Constants.PackagePrefix, testSuiteName: "AuthoringChangesetGroupOperations" });
+
+    const testIModelCreator = container.get(TestIModelCreator);
+    testIModel = await testIModelCreator.createEmpty(testIModelGroup.getPrefixedUniqueIModelName("Test iModel for write"));
+  });
+
+  after(async () => {
+    await testIModelGroup.cleanupIModels();
+  });
+
+  it("should create changeset group", async () => {
+    // Arrange
+    const createChangesetGroupParams: CreateChangesetGroupParams = {
+      authorization,
+      iModelId: testIModel.id,
+      changesetGroupProperties: {
+        description: "some description"
+      }
+    };
+
+    // Act
+    const changesetGroup: ChangesetGroup = await iModelsClient.changesetGroups.create(createChangesetGroupParams);
+
+    // Assert
+    await assertChangesetGroup({ actualChangesetGroup: changesetGroup, expectedChangesetGroupProperties: createChangesetGroupParams.changesetGroupProperties });
+  });
+
+  it("should update changeset group", async () => {
+    // Arrange
+    const createChangesetGroupParams: CreateChangesetGroupParams = {
+      authorization,
+      iModelId: testIModel.id,
+      changesetGroupProperties: {
+        description: "some description"
+      }
+    };
+    const changesetGroup: ChangesetGroup = await iModelsClient.changesetGroups.create(createChangesetGroupParams);
+    const updateChangesetGroupParams: UpdateChangesetGroupParams = {
+      authorization,
+      iModelId: testIModel.id,
+      changesetGroupId: changesetGroup.id,
+      changesetGroupProperties: {
+        state: ChangesetGroupState.Completed
+      }
+    };
+
+    // Act
+    const updatedChangesetGroup = await iModelsClient.changesetGroups.update(updateChangesetGroupParams);
+
+    // Assert
+    await assertChangesetGroup({
+      actualChangesetGroup: updatedChangesetGroup,
+      expectedChangesetGroupProperties: {
+        ...createChangesetGroupParams.changesetGroupProperties,
+        ...updateChangesetGroupParams.changesetGroupProperties
+      }
+    });
+  });
+});

--- a/tests/imodels-clients-tests/src/integration/management/ChangesetGroupOperations.test.ts
+++ b/tests/imodels-clients-tests/src/integration/management/ChangesetGroupOperations.test.ts
@@ -1,0 +1,87 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { AuthorizationCallback, GetChangesetGroupListParams, GetSingleChangesetGroupParams, IModelsClient, IModelsClientOptions, IModelsErrorCode } from "@itwin/imodels-client-management";
+import { ReusableIModelMetadata, ReusableTestIModelProvider, TestAuthorizationProvider, TestUtilTypes, assertChangesetGroup, assertCollection, assertError } from "@itwin/imodels-client-test-utils";
+
+import { getTestDIContainer } from "../common";
+
+describe("[Management] ChangesetGroupOperations", () => {
+  let iModelsClient: IModelsClient;
+  let authorization: AuthorizationCallback;
+  let testIModel: ReusableIModelMetadata;
+
+  before(async () => {
+    const container = getTestDIContainer();
+
+    const iModelsClientOptions = container.get<IModelsClientOptions>(TestUtilTypes.IModelsClientOptions);
+    iModelsClient = new IModelsClient(iModelsClientOptions);
+
+    const authorizationProvider = container.get(TestAuthorizationProvider);
+    authorization = authorizationProvider.getAdmin1Authorization();
+
+    const reusableTestIModelProvider = container.get(ReusableTestIModelProvider);
+    testIModel = await reusableTestIModelProvider.getOrCreate();
+  });
+
+  it("should return all items when querying collection", async () => {
+    // Arrange
+    const getChangesetGroupListParams: GetChangesetGroupListParams = {
+      authorization,
+      iModelId: testIModel.id
+    };
+
+    // Act
+    const changesetGroups = iModelsClient.changesetGroups.getList(getChangesetGroupListParams);
+
+    // Assert
+    await assertCollection({
+      asyncIterable: changesetGroups,
+      isEntityCountCorrect: (count) => count === testIModel.changesetGroups.length
+    });
+  });
+
+  it("should get changeset group by id", async () => {
+    // Arrange
+    const expectedChangesetGroup = testIModel.changesetGroups[0];
+    const expectedChangesetGroupProperties = { description: expectedChangesetGroup.description };
+    const getSingleChangesetGroupParams: GetSingleChangesetGroupParams = {
+      authorization,
+      iModelId: testIModel.id,
+      changesetGroupId: expectedChangesetGroup.id
+    };
+
+    // Act
+    const changesetGroup = await iModelsClient.changesetGroups.getSingle(getSingleChangesetGroupParams);
+
+    // Assert
+    await assertChangesetGroup({ actualChangesetGroup: changesetGroup, expectedChangesetGroupProperties });
+  });
+
+  it("should return error when querying non-existent changeset group", async () => {
+    // Arrange
+    const getSingleChangesetGroupParams: GetSingleChangesetGroupParams = {
+      authorization,
+      iModelId: testIModel.id,
+      changesetGroupId: "invalid group id"
+    };
+
+    // Act
+    let objectThrown: unknown;
+    try {
+      await iModelsClient.changesetGroups.getSingle(getSingleChangesetGroupParams);
+    } catch (e) {
+      objectThrown = e;
+    }
+
+    // Assert
+    assertError({
+      objectThrown,
+      expectedError: {
+        code: IModelsErrorCode.ChangesetGroupNotFound,
+        message: "Requested Changeset Group is not available."
+      }
+    });
+  });
+});

--- a/tests/imodels-clients-tests/src/integration/management/ChangesetGroupOperations.test.ts
+++ b/tests/imodels-clients-tests/src/integration/management/ChangesetGroupOperations.test.ts
@@ -38,7 +38,7 @@ describe("[Management] ChangesetGroupOperations", () => {
     // Assert
     await assertCollection({
       asyncIterable: changesetGroups,
-      isEntityCountCorrect: (count) => count === testIModel.changesetGroups.length
+      isEntityCountCorrect: (count) => (count > 0 && count === testIModel.changesetGroups.length)
     });
   });
 

--- a/tests/imodels-clients-tests/src/integration/management/ChangesetGroupOperations.test.ts
+++ b/tests/imodels-clients-tests/src/integration/management/ChangesetGroupOperations.test.ts
@@ -2,7 +2,9 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { AuthorizationCallback, GetChangesetGroupListParams, GetSingleChangesetGroupParams, IModelsClient, IModelsClientOptions, IModelsErrorCode } from "@itwin/imodels-client-management";
+import { expect } from "chai";
+
+import { AuthorizationCallback, GetChangesetGroupListParams, GetSingleChangesetGroupParams, IModelsClient, IModelsClientOptions, IModelsErrorCode, take } from "@itwin/imodels-client-management";
 import { ReusableIModelMetadata, ReusableTestIModelProvider, TestAuthorizationProvider, TestUtilTypes, assertChangesetGroup, assertCollection, assertError } from "@itwin/imodels-client-test-utils";
 
 import { getTestDIContainer } from "../common";
@@ -40,6 +42,28 @@ describe("[Management] ChangesetGroupOperations", () => {
       asyncIterable: changesetGroups,
       isEntityCountCorrect: (count) => (count > 0 && count === testIModel.changesetGroups.length)
     });
+  });
+
+  it("should get valid changeset group when querying collection", async () => {
+    // Arrange
+    const getChangesetGroupListParams: GetChangesetGroupListParams = {
+      authorization,
+      iModelId: testIModel.id,
+      urlParams: {
+        $top: 1
+      }
+    };
+
+    // Act
+    const changesetGroups = iModelsClient.changesetGroups.getList(getChangesetGroupListParams);
+
+    // Assert
+    const changesetGroupList = await take(changesetGroups, 1);
+    expect(changesetGroupList.length).to.be.equal(1);
+    const actualChangesetGroup = changesetGroupList[0];
+    const expectedChangesetGroup = testIModel.changesetGroups.find((x) => x.id === actualChangesetGroup.id);
+    expect(expectedChangesetGroup).to.exist;
+    await assertChangesetGroup({ actualChangesetGroup, expectedChangesetGroupProperties: expectedChangesetGroup! });
   });
 
   it("should get changeset group by id", async () => {

--- a/tests/imodels-clients-tests/src/integration/management/IModelOperations.test.ts
+++ b/tests/imodels-clients-tests/src/integration/management/IModelOperations.test.ts
@@ -485,7 +485,7 @@ describe("[Management] IModelOperations", () => {
       objectThrown,
       expectedError: {
         code: IModelsErrorCode.Unauthorized,
-        message: "Invalid JWT."
+        message: "Access denied due to invalid access_token. Make sure that issuer is correct, the token is not expired and is not corrupted."
       }
     });
   });

--- a/tests/imodels-clients-tests/src/unit/management/IModelsApiUrlFormatter.test.ts
+++ b/tests/imodels-clients-tests/src/unit/management/IModelsApiUrlFormatter.test.ts
@@ -197,6 +197,30 @@ describe("[Management] IModelsApiUrlFormatter", () => {
     });
   });
 
+  describe("Changeset Group urls", () => {
+    it("should format changeset group list url", () => {
+      // Arrange
+      const getChangesetGroupListUrlParams = { iModelId: "IMODEL_ID" };
+
+      // Act
+      const changesetGroupListUrl = iModelsApiUrlFormatter.getChangesetGroupListUrl(getChangesetGroupListUrlParams);
+
+      // Assert
+      expect(changesetGroupListUrl).to.be.equal("https://api.bentley.com/imodels/IMODEL_ID/changesetgroups");
+    });
+
+    it("should format single changeset group url", () => {
+      // Arrange
+      const getSingleChangesetGroupUrlParams = { iModelId: "IMODEL_ID", changesetGroupId: "GROUP_ID" };
+
+      // Act
+      const singleChangesetGroupUrl = iModelsApiUrlFormatter.getSingleChangesetGroupUrl(getSingleChangesetGroupUrlParams);
+
+      // Assert
+      expect(singleChangesetGroupUrl).to.be.equal("https://api.bentley.com/imodels/IMODEL_ID/changesetgroups/GROUP_ID");
+    });
+  });
+
   describe("Checkpoint urls", () => {
     [
       {

--- a/utils/imodels-client-common-config/README.md
+++ b/utils/imodels-client-common-config/README.md
@@ -4,6 +4,6 @@ Copyright © Bentley Systems, Incorporated. All rights reserved. See [LICENSE.md
 
 ## About this package
 
-This package groups development dependencies and contains various config files shared accross iModels API client packages. That includes but is not limited to linting, spell checking, TypeScript compilation configuration files and setup.
+This package groups development dependencies and contains various config files shared across iModels API client packages. That includes but is not limited to linting, spell checking, TypeScript compilation configuration files and setup.
 
 **Note:** This package is not intended for outside use - it is internal and meant to be consumed only by packages in this repository.

--- a/utils/imodels-client-test-utils/src/IModelsClientsTestsConfig.ts
+++ b/utils/imodels-client-test-utils/src/IModelsClientsTestsConfig.ts
@@ -90,7 +90,7 @@ export class IModelsClientsTestsConfig {
     };
 
     this.behaviorOptions = {
-      recreateReusableIModel: false
+      recreateReusableIModel: Number(process.env.TEST_BEHAVIOR_OPTIONS_RECREATE_IMODEL) > 0
     };
   }
 
@@ -115,10 +115,21 @@ export class IModelsClientsTestsConfig {
 
     this.validateConfigValue("TEST_USERS_ADMIN2_FULLY_FEATURED_EMAIL");
     this.validateConfigValue("TEST_USERS_ADMIN2_FULLY_FEATURED_PASSWORD");
+
+    this.validateConfigOptionalNumericValue("TEST_BEHAVIOR_OPTIONS_RECREATE_IMODEL");
   }
 
   private validateConfigValue(key: string): void {
     if (!process.env[key])
       throw new TestSetupError(`Invalid configuration: missing ${key} value.`);
+  }
+
+  private validateConfigOptionalNumericValue(key: string): void {
+    const value = process.env[key];
+    if (value === undefined)
+      return;
+
+    if (isNaN(Number(value)))
+      throw new TestSetupError(`Invalid configuration: ${key} value must be a number.`);
   }
 }

--- a/utils/imodels-client-test-utils/src/assertions/NodeOnlyAssertions.ts
+++ b/utils/imodels-client-test-utils/src/assertions/NodeOnlyAssertions.ts
@@ -144,11 +144,11 @@ export async function assertChangesetGroup(params: {
 }): Promise<void> {
   expect(params.actualChangesetGroup.id).to.not.be.empty;
   expect(params.actualChangesetGroup.description).to.equal(params.expectedChangesetGroupProperties.description);
-  expect(params.actualChangesetGroup.creatorId).to.exist;
+  expect(params.actualChangesetGroup.creatorId).to.not.be.empty;
   expect(params.actualChangesetGroup.createdDateTime).to.not.be.empty;
   expect(params.actualChangesetGroup.state).to.equal(params.expectedChangesetGroupProperties.state ?? ChangesetGroupState.InProgress);
-  expect(params.actualChangesetGroup._links).to.exist;
-  expect(params.actualChangesetGroup._links.creator).to.exist;
+  expect(params.actualChangesetGroup._links).to.not.be.empty;
+  expect(params.actualChangesetGroup._links.creator).to.not.be.empty;
   expect(params.actualChangesetGroup._links.creator!.href).to.not.be.empty;
 
   await assertChangesetGroupCallbacks({

--- a/utils/imodels-client-test-utils/src/assertions/NodeOnlyAssertions.ts
+++ b/utils/imodels-client-test-utils/src/assertions/NodeOnlyAssertions.ts
@@ -6,12 +6,12 @@ import * as fs from "fs";
 
 import { expect } from "chai";
 
-import { BaselineFile, BaselineFileState, Changeset, ChangesetPropertiesForCreate, ChangesetState, DownloadedChangeset, IModelsError, IModelsErrorCode, Lock, MinimalChangeset, SynchronizationInfo, SynchronizationInfoForCreate, isIModelsApiError } from "@itwin/imodels-client-authoring";
+import { BaselineFile, BaselineFileState, Changeset, ChangesetGroup, ChangesetGroupPropertiesForCreate, ChangesetGroupPropertiesForUpdate, ChangesetGroupState, ChangesetPropertiesForCreate, ChangesetState, DownloadedChangeset, IModelsError, IModelsErrorCode, Lock, MinimalChangeset, SynchronizationInfo, SynchronizationInfoForCreate, isIModelsApiError } from "@itwin/imodels-client-authoring";
 
 import { TestChangesetFile, TestIModelBaselineFile } from "../test-context-providers";
 
 import { assertApplication, assertOptionalLink, assertOptionalProperty } from "./BrowserFriendlyAssertions";
-import { assertChangesetCallbacks, assertMinimalChangesetCallbacks } from "./RelatedEntityCallbackAssertions";
+import { assertChangesetCallbacks, assertChangesetGroupCallbacks, assertMinimalChangesetCallbacks } from "./RelatedEntityCallbackAssertions";
 
 export async function assertBaselineFile(params: {
   actualBaselineFile: BaselineFile;
@@ -136,6 +136,24 @@ export async function assertDownloadedChangeset(params: {
 
   // Check if the downloaded file size matches the size of the changeset file used for test iModel creation
   expect(fs.statSync(params.actualChangeset.filePath).size).to.equal(fs.statSync(params.expectedTestChangesetFile.filePath).size);
+}
+
+export async function assertChangesetGroup(params: {
+  actualChangesetGroup: ChangesetGroup;
+  expectedChangesetGroupProperties: ChangesetGroupPropertiesForCreate & Partial<ChangesetGroupPropertiesForUpdate>;
+}): Promise<void> {
+  expect(params.actualChangesetGroup.id).to.not.be.empty;
+  expect(params.actualChangesetGroup.description).to.equal(params.expectedChangesetGroupProperties.description);
+  expect(params.actualChangesetGroup.creatorId).to.exist;
+  expect(params.actualChangesetGroup.createdDateTime).to.not.be.empty;
+  expect(params.actualChangesetGroup.state).to.equal(params.expectedChangesetGroupProperties.state ?? ChangesetGroupState.InProgress);
+  expect(params.actualChangesetGroup._links).to.exist;
+  expect(params.actualChangesetGroup._links.creator).to.exist;
+  expect(params.actualChangesetGroup._links.creator!.href).to.not.be.empty;
+
+  await assertChangesetGroupCallbacks({
+    changesetGroup: params.actualChangesetGroup
+  });
 }
 
 export function assertLock(params: {

--- a/utils/imodels-client-test-utils/src/assertions/NodeOnlyAssertions.ts
+++ b/utils/imodels-client-test-utils/src/assertions/NodeOnlyAssertions.ts
@@ -147,8 +147,8 @@ export async function assertChangesetGroup(params: {
   expect(params.actualChangesetGroup.creatorId).to.not.be.empty;
   expect(params.actualChangesetGroup.createdDateTime).to.not.be.empty;
   expect(params.actualChangesetGroup.state).to.equal(params.expectedChangesetGroupProperties.state ?? ChangesetGroupState.InProgress);
-  expect(params.actualChangesetGroup._links).to.not.be.empty;
-  expect(params.actualChangesetGroup._links.creator).to.not.be.empty;
+  expect(params.actualChangesetGroup._links).to.exist;
+  expect(params.actualChangesetGroup._links.creator).to.exist;
   expect(params.actualChangesetGroup._links.creator!.href).to.not.be.empty;
 
   await assertChangesetGroupCallbacks({

--- a/utils/imodels-client-test-utils/src/assertions/RelatedEntityCallbackAssertions.ts
+++ b/utils/imodels-client-test-utils/src/assertions/RelatedEntityCallbackAssertions.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
 
-import { Briefcase, Changeset, Checkpoint, IModel, MinimalChangeset, NamedVersion, User } from "@itwin/imodels-client-authoring";
+import { Briefcase, Changeset, ChangesetGroup, Checkpoint, IModel, MinimalChangeset, NamedVersion, User } from "@itwin/imodels-client-authoring";
 
 import { assertUser } from "./BrowserFriendlyAssertions";
 
@@ -63,6 +63,17 @@ export async function assertChangesetCallbacks(params: {
     expect(checkpoint).to.exist;
   else
     expect(checkpoint).to.be.undefined;
+}
+
+export async function assertChangesetGroupCallbacks(params: {
+  changesetGroup: ChangesetGroup;
+}): Promise<void> {
+  expect(params.changesetGroup.getCreator).to.exist;
+
+  const creator: User | undefined = await params.changesetGroup.getCreator();
+  assertUser({
+    actualUser: creator!
+  });
 }
 
 export async function assertNamedVersionCallbacks(params: {

--- a/utils/imodels-client-test-utils/src/test-context-providers/imodel/TestIModelInterfaces.ts
+++ b/utils/imodels-client-test-utils/src/test-context-providers/imodel/TestIModelInterfaces.ts
@@ -16,6 +16,11 @@ export interface NamedVersionMetadata {
   changesetIndex: number;
 }
 
+export interface ChangesetGroupMetadata {
+  id: string;
+  description: string;
+}
+
 export interface IModelMetadata {
   id: string;
   name: string;
@@ -26,6 +31,7 @@ export interface ReusableIModelMetadata extends IModelMetadata {
   briefcase: BriefcaseMetadata;
   namedVersions: NamedVersionMetadata[];
   lock: Lock;
+  changesetGroups: ChangesetGroupMetadata[];
 }
 
 export interface TestIModelSetupContext extends AuthorizationParam {

--- a/utils/imodels-client-test-utils/src/test-context-providers/imodel/TestIModelRetriever.ts
+++ b/utils/imodels-client-test-utils/src/test-context-providers/imodel/TestIModelRetriever.ts
@@ -21,8 +21,7 @@ export class TestIModelRetriever {
     private readonly _iModelsClient: TestIModelsClient,
     private readonly _testAuthorizationProvider: TestAuthorizationProvider,
     private readonly _testITwinProvider: TestITwinProvider,
-    private readonly _testIModelFileProvider: TestIModelFileProvider,
-    private readonly _testIModelCreator: TestIModelCreator
+    private readonly _testIModelFileProvider: TestIModelFileProvider
   ) { }
 
   public async findIModelByName(iModelName: string): Promise<IModel | undefined> {
@@ -44,7 +43,7 @@ export class TestIModelRetriever {
     const briefcase = await this.queryAndValidateBriefcase(iModel.id);
     const namedVersions = await this.queryAndValidateNamedVersions(iModel.id);
     const lock = await this.queryAndValidateLock(iModel.id);
-    const changesetGroups = await this.ensureChangesetGroups(iModel.id);
+    const changesetGroups = await this.queryAndValidateChangesetGroups(iModel.id);
 
     return {
       id: iModel.id,
@@ -108,16 +107,13 @@ export class TestIModelRetriever {
     return locks[0];
   }
 
-  private async ensureChangesetGroups(iModelId: string): Promise<ChangesetGroupMetadata[]> {
+  private async queryAndValidateChangesetGroups(iModelId: string): Promise<ChangesetGroupMetadata[]> {
     const getChangesetGroupListParams: GetChangesetGroupListParams = {
       authorization: this._testAuthorizationProvider.getAdmin1Authorization(),
       iModelId
     };
-    let changesetGroups: ChangesetGroupMetadata[] = await toArray(this._iModelsClient.changesetGroups.getList(getChangesetGroupListParams));
-
-    if (changesetGroups.length === 0)
-      changesetGroups = await this._testIModelCreator.createChangesetGroups(iModelId);
-    else if (changesetGroups.length !== TestIModelCreator.changesetGroups.length)
+    const changesetGroups: ChangesetGroupMetadata[] = await toArray(this._iModelsClient.changesetGroups.getList(getChangesetGroupListParams));
+    if (changesetGroups.length !== TestIModelCreator.changesetGroups.length)
       throw new TestSetupError(`${changesetGroups.length} is an unexpected changeset group count for reusable test iModel.`);
 
     return changesetGroups;


### PR DESCRIPTION
- Added `Changeset Group` operations.
- Using `TEST_BEHAVIOR_OPTIONS_RECREATE_IMODEL` value from `.env` file instead of hardcoded `false` for tests.
- Fixed broken `Invalid JWT` test - the error message has changed.