### PR TITLE
Add get Create iModel Operation Details operation

### DIFF
--- a/clients/imodels-client-management/src/IModelsClient.ts
+++ b/clients/imodels-client-management/src/IModelsClient.ts
@@ -5,7 +5,7 @@
 import { AxiosRestClient, IModelsErrorParser } from "./base/internal";
 import { ApiOptions, HeaderFactories, RecursiveRequired, RestClient } from "./base/types";
 import { Constants } from "./Constants";
-import { BriefcaseOperations, ChangesetOperations, IModelOperations, NamedVersionOperations, ThumbnailOperations, UserOperations, UserPermissionOperations } from "./operations";
+import { BriefcaseOperations, ChangesetOperations, IModelOperations, NamedVersionOperations, OperationOperations, ThumbnailOperations, UserOperations, UserPermissionOperations } from "./operations";
 import { ChangesetGroupOperations } from "./operations/changeset-group/ChangesetGroupOperations";
 import { CheckpointOperations } from "./operations/checkpoint/CheckpointOperations";
 import { IModelsApiUrlFormatter } from "./operations/IModelsApiUrlFormatter";
@@ -87,6 +87,11 @@ export class IModelsClient {
   /** User Permission operations. See {@link UserPermissionOperations}. */
   public get userPermissions(): UserPermissionOperations<OperationOptions> {
     return new UserPermissionOperations(this._operationsOptions);
+  }
+
+  /** Operation operations. See {@link OperationOperations}. */
+  public get operations(): OperationOperations<OperationOptions> {
+    return new OperationOperations(this._operationsOptions);
   }
 
   private static fillManagementClientConfiguration(

--- a/clients/imodels-client-management/src/base/internal/ApiResponseInterfaces.ts
+++ b/clients/imodels-client-management/src/base/internal/ApiResponseInterfaces.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { Briefcase, Changeset, ChangesetGroup, Checkpoint, IModel, Link, MinimalBriefcase, MinimalChangeset, MinimalIModel, MinimalNamedVersion, MinimalUser, NamedVersion, User } from "../types";
+import { Briefcase, Changeset, ChangesetGroup, Checkpoint, CreateIModelOperationDetails, IModel, Link, MinimalBriefcase, MinimalChangeset, MinimalIModel, MinimalNamedVersion, MinimalUser, NamedVersion, User } from "../types";
 
 /**
  * Links that are included in all entity list page responses. They simplify pagination implementation because users
@@ -72,4 +72,8 @@ export interface UserResponse {
 
 export interface NamedVersionResponse {
   namedVersion: NamedVersion;
+}
+
+export interface CreateIModelOperationDetailsResponse {
+  createOperation: CreateIModelOperationDetails;
 }

--- a/clients/imodels-client-management/src/base/types/apiEntities/OperationInterfaces.ts
+++ b/clients/imodels-client-management/src/base/types/apiEntities/OperationInterfaces.ts
@@ -21,8 +21,8 @@ export interface ClonedFrom {
   iModelId: string;
   /**
    * Id of the latest source iModel Changeset which was copied to this iModel.
-   * This corresponds to the Changeset specified in changesetId or changesetIndex properties when cloning an iModel.
-   * If changesetId is an empty string it means that no Changesets were copied from the source iModel to this one, only iModel Baseline.
+   * This corresponds to the Changeset specified in `changesetId` or `changesetIndex` properties when cloning an iModel.
+   * The value will be an empty string if no Changesets were copied from the source iModel to this one, only iModel Baseline.
    */
   changesetId: string;
 }

--- a/clients/imodels-client-management/src/base/types/apiEntities/OperationInterfaces.ts
+++ b/clients/imodels-client-management/src/base/types/apiEntities/OperationInterfaces.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+/** Possible Create iModel Operation states. */
+export enum IModelCreationState {
+  /** iModel creation process completed successfully. */
+  Successful = "successful",
+  /** iModel is being created from a Baseline File and the file upload to file storage has not been completed yet. */
+  WaitingForFile = "waitingForFile",
+  /** iModel creation process is scheduled or in progress. */
+  Scheduled = "scheduled",
+  /** iModel creation process failed. */
+  Failed = "failed"
+}
+
+/** Information about the source iModel of an iModel clone. */
+export interface ClonedFrom {
+  /** Id of the source iModel. */
+  iModelId: string;
+  /**
+   * Id of the latest source iModel Changeset which was copied to this iModel.
+   * This corresponds to the Changeset specified in changesetId or changesetIndex properties when cloning an iModel.
+   * If changesetId is an empty string it means that no Changesets were copied from the source iModel to this one, only iModel Baseline.
+   */
+  changesetId: string;
+}
+
+/** Information about iModel creation process. */
+export interface CreateIModelOperationDetails {
+  /** Indicates the current state of the iModel creation process. See {@link IModelCreationState}. */
+  state: IModelCreationState;
+  /**
+   * Information about the source iModel of an iModel clone (see {@link ClonedFrom}).
+   * If the iModel was not created using Clone iModel operation, the value of this property will be `null`.
+   */
+  clonedFrom: ClonedFrom | null;
+}

--- a/clients/imodels-client-management/src/base/types/index.ts
+++ b/clients/imodels-client-management/src/base/types/index.ts
@@ -11,6 +11,7 @@ export * from "./apiEntities/CheckpointInterfaces";
 export * from "./apiEntities/ThumbnailInterfaces";
 export * from "./apiEntities/UserInterfaces";
 export * from "./apiEntities/UserPermissionInterfaces";
+export * from "./apiEntities/OperationInterfaces";
 
 export * from "./iterators/EntityListIterator";
 export * from "./iterators/IteratorUtilFunctions";

--- a/clients/imodels-client-management/src/operations/IModelsApiUrlFormatter.ts
+++ b/clients/imodels-client-management/src/operations/IModelsApiUrlFormatter.ts
@@ -108,6 +108,10 @@ export class IModelsApiUrlFormatter {
     return `${this.baseUrl}/${params.iModelId}/permissions`;
   }
 
+  public getCreateIModelOperationDetailsUrl(params: { iModelId: string }): string {
+    return `${this.baseUrl}/${params.iModelId}/operations/create`;
+  }
+
   public parseCheckpointUrl(url: string): { iModelId: string } & ChangesetIdOrIndex {
     const matchedGroups: Dictionary<string> = this._checkpointUrlRegex.exec(url)!.groups!;
     return {

--- a/clients/imodels-client-management/src/operations/OperationExports.ts
+++ b/clients/imodels-client-management/src/operations/OperationExports.ts
@@ -11,3 +11,4 @@ export * from "./checkpoint/CheckpointOperations";
 export * from "./thumbnail/ThumbnailOperations";
 export * from "./user/UserOperations";
 export * from "./user-permission/UserPermissionOperations";
+export * from "./operation/OperationOperations";

--- a/clients/imodels-client-management/src/operations/OperationParamExports.ts
+++ b/clients/imodels-client-management/src/operations/OperationParamExports.ts
@@ -11,3 +11,4 @@ export * from "./checkpoint/CheckpointOperationParams";
 export * from "./thumbnail/ThumbnailOperationParams";
 export * from "./user/UserOperationParams";
 export * from "./user-permission/UserPermissionOperationParams";
+export * from "./operation/OperationParams";

--- a/clients/imodels-client-management/src/operations/operation/OperationOperations.ts
+++ b/clients/imodels-client-management/src/operations/operation/OperationOperations.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { CreateIModelOperationDetailsResponse, OperationsBase } from "../../base/internal";
+import { CreateIModelOperationDetails } from "../../base/types";
+import { OperationOptions } from "../OperationOptions";
+
+import { GetCreateIModelOperationDetailsParams } from "./OperationParams";
+
+export class OperationOperations<TOptions extends OperationOptions> extends OperationsBase<TOptions> {
+  constructor(options: TOptions) {
+    super(options);
+  }
+
+  /**
+   * Returns the information about iModel creation process. Wraps the
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/get-create-imodel-operation-details/ Get Create iModel Operation Details}
+   * operation from iModels API.
+   * @param {GetCreateIModelOperationDetailsParams} params parameters for this operation. See {@link GetCreateIModelOperationDetailsParams}.
+   * @returns {Promise<CreateIModelOperationDetails>} iModel creation details. See {@link CreateIModelOperationDetails}.
+   */
+  public async getCreateIModelDetails(params: GetCreateIModelOperationDetailsParams): Promise<CreateIModelOperationDetails> {
+    const response = await this.sendGetRequest<CreateIModelOperationDetailsResponse>({
+      authorization: params.authorization,
+      url: this._options.urlFormatter.getCreateIModelOperationDetailsUrl({ iModelId: params.iModelId }),
+      headers: params.headers
+    });
+    return response.createOperation;
+  }
+}

--- a/clients/imodels-client-management/src/operations/operation/OperationParams.ts
+++ b/clients/imodels-client-management/src/operations/operation/OperationParams.ts
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { IModelScopedOperationParams } from "../../base/types";
+
+/** Parameters for get Create iModel Operation Details operation. */
+export type GetCreateIModelOperationDetailsParams = IModelScopedOperationParams;

--- a/tests/imodels-clients-tests/src/integration/authoring/ChangesetGroupOperations.test.ts
+++ b/tests/imodels-clients-tests/src/integration/authoring/ChangesetGroupOperations.test.ts
@@ -48,7 +48,13 @@ describe("[Authoring] ChangesetGroupOperations", () => {
     const changesetGroup: ChangesetGroup = await iModelsClient.changesetGroups.create(createChangesetGroupParams);
 
     // Assert
-    await assertChangesetGroup({ actualChangesetGroup: changesetGroup, expectedChangesetGroupProperties: createChangesetGroupParams.changesetGroupProperties });
+    await assertChangesetGroup({
+      actualChangesetGroup: changesetGroup,
+      expectedChangesetGroupProperties: {
+        ...createChangesetGroupParams.changesetGroupProperties,
+        state: ChangesetGroupState.InProgress
+      }
+    });
   });
 
   it("should update changeset group", async () => {

--- a/tests/imodels-clients-tests/src/integration/management/OperationOperations.test.ts
+++ b/tests/imodels-clients-tests/src/integration/management/OperationOperations.test.ts
@@ -40,6 +40,6 @@ describe("[Management] OperationOperations", () => {
 
     // Assert
     expect(operationDetails.clonedFrom).to.be.null;
-    expect(operationDetails.state).to.be.oneOf([IModelCreationState.Scheduled, IModelCreationState.Successful]);
+    expect(operationDetails.state).to.equal(IModelCreationState.Successful);
   });
 });

--- a/tests/imodels-clients-tests/src/integration/management/OperationOperations.test.ts
+++ b/tests/imodels-clients-tests/src/integration/management/OperationOperations.test.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+
+import { AuthorizationCallback, GetCreateIModelOperationDetailsParams, IModelCreationState, IModelsClient, IModelsClientOptions } from "@itwin/imodels-client-management";
+import { ReusableIModelMetadata, ReusableTestIModelProvider, TestAuthorizationProvider, TestUtilTypes } from "@itwin/imodels-client-test-utils";
+
+import { getTestDIContainer } from "../common";
+
+describe("[Management] OperationOperations", () => {
+  let iModelsClient: IModelsClient;
+  let authorization: AuthorizationCallback;
+  let testIModel: ReusableIModelMetadata;
+
+  before(async () => {
+    const container = getTestDIContainer();
+
+    const iModelsClientOptions = container.get<IModelsClientOptions>(TestUtilTypes.IModelsClientOptions);
+    iModelsClient = new IModelsClient(iModelsClientOptions);
+
+    const authorizationProvider = container.get(TestAuthorizationProvider);
+    authorization = authorizationProvider.getAdmin1Authorization();
+
+    const reusableTestIModelProvider = container.get(ReusableTestIModelProvider);
+    testIModel = await reusableTestIModelProvider.getOrCreate();
+  });
+
+  it("should get create iModel operation details", async () => {
+    // Arrange
+    const operationParams: GetCreateIModelOperationDetailsParams = {
+      authorization,
+      iModelId: testIModel.id
+    };
+
+    // Act
+    const operationDetails = await iModelsClient.operations.getCreateIModelDetails(operationParams);
+
+    // Assert
+    expect(operationDetails.clonedFrom).to.be.null;
+    expect(operationDetails.state).to.be.oneOf([IModelCreationState.Scheduled, IModelCreationState.Successful]);
+  });
+});

--- a/tests/imodels-clients-tests/src/unit/management/IModelsApiUrlFormatter.test.ts
+++ b/tests/imodels-clients-tests/src/unit/management/IModelsApiUrlFormatter.test.ts
@@ -342,13 +342,13 @@ describe("[Management] IModelsApiUrlFormatter", () => {
   describe("Operation urls", () => {
     it("should format create iModel operation details url", () => {
       // Arrange
-      const getIModelCreationDetailsUrl = { iModelId: "IMODEL_ID" };
+      const getCreateIModelOperationDetailsUrlParams = { iModelId: "IMODEL_ID" };
 
       // Act
-      const iModelCreationDetailsUrl = iModelsApiUrlFormatter.getCreateIModelOperationDetailsUrl(getIModelCreationDetailsUrl);
+      const getCreateIModelOperationDetailsUrl = iModelsApiUrlFormatter.getCreateIModelOperationDetailsUrl(getCreateIModelOperationDetailsUrlParams);
 
       // Assert
-      expect(iModelCreationDetailsUrl).to.be.equal("https://api.bentley.com/imodels/IMODEL_ID/operations/create");
+      expect(getCreateIModelOperationDetailsUrl).to.be.equal("https://api.bentley.com/imodels/IMODEL_ID/operations/create");
     });
   });
 

--- a/tests/imodels-clients-tests/src/unit/management/IModelsApiUrlFormatter.test.ts
+++ b/tests/imodels-clients-tests/src/unit/management/IModelsApiUrlFormatter.test.ts
@@ -339,6 +339,19 @@ describe("[Management] IModelsApiUrlFormatter", () => {
     });
   });
 
+  describe("Operation urls", () => {
+    it("should format create iModel operation details url", () => {
+      // Arrange
+      const getIModelCreationDetailsUrl = { iModelId: "IMODEL_ID" };
+
+      // Act
+      const iModelCreationDetailsUrl = iModelsApiUrlFormatter.getCreateIModelOperationDetailsUrl(getIModelCreationDetailsUrl);
+
+      // Assert
+      expect(iModelCreationDetailsUrl).to.be.equal("https://api.bentley.com/imodels/IMODEL_ID/operations/create");
+    });
+  });
+
   describe("Url parameter forming", () => {
     it("should append all url params", () => {
       // Arrange

--- a/utils/imodels-client-test-utils/src/assertions/NodeOnlyAssertions.ts
+++ b/utils/imodels-client-test-utils/src/assertions/NodeOnlyAssertions.ts
@@ -147,7 +147,7 @@ export async function assertChangesetGroup(params: {
   expect(params.actualChangesetGroup.description).to.equal(params.expectedChangesetGroupProperties.description);
   expect(params.actualChangesetGroup.creatorId).to.not.be.empty;
   expect(params.actualChangesetGroup.createdDateTime).to.not.be.empty;
-  expect(params.actualChangesetGroup.state).to.equal(params.expectedChangesetGroupProperties.state ?? ChangesetGroupState.InProgress);
+  expect(params.actualChangesetGroup.state).to.equal(params.expectedChangesetGroupProperties.state ?? ChangesetGroupState.Completed);
   expect(params.actualChangesetGroup._links).to.exist;
   expect(params.actualChangesetGroup._links.creator).to.exist;
   expect(params.actualChangesetGroup._links.creator!.href).to.not.be.empty;


### PR DESCRIPTION
- Added `Get Create iModel Operation Details` operation.
- Fixed Changeset Group integration tests. Reusable iModel's changeset groups were getting in state `timedOut` due to not being completed in time. To fix it, I added code which completes reusable iModel's changeset groups immediately after uploading the changesets.