### PR TITLE
imodels v1 and client-management readme cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,17 @@ Copyright © Bentley Systems, Incorporated. All rights reserved. See [LICENSE.md
 
 ## About this Repository
 
-This repository contains packages that help consumption of iModels API. Please visit the [iModels API documentation page](https://developer.bentley.com/apis/imodels/) on iTwin developer portal to learn more about the iModels service and its APIs. API clients contain methods that either act as a thin wrapper for sending a single request to the API or combine several requests to execute a more complex operation.
+This repository contains packages that help consumption of iModels API. Please visit the [iModels API documentation page](https://developer.bentley.com/apis/imodels-v2/) on iTwin developer portal to learn more about the iModels service and its APIs. API clients contain methods that either act as a thin wrapper for sending a single request to the API or combine several requests to execute a more complex operation.
 
 iModels API is a part of [iTwin Platform](https://developer.bentley.com/). iTwin platform together with an open source [iTwin.js](https://www.itwinjs.org/) library provides capabilities for creating, querying, modifying, and displaying Infrastructure Digital Twins.
 
 This repository contains multiple packages:
+
 - [`@itwin/imodels-client-management`](clients/imodels-client-management/README.md) is an API client that exposes a subset of iModels API operations and is intended to use in iModel management applications. Such applications do not edit the iModel file itself, they allow user to perform administrative tasks - create Named Versions, view Changeset metadata and such. An example of iTwin management application is the [iTwin Demo Portal](https://itwindemo.bentley.com/).
+
 - [`@itwin/imodels-client-authoring`](clients/imodels-client-authoring/README.md) is an API client that extends `@itwin/imodels-client-management` and exposes additional API operations to facilitate iModel editing workflows. This client should not be used directly as the operations it exposes can only be used meaningfully via [iTwin.js](https://www.itwinjs.org/) library.
 - [`@itwin/imodels-access-frontend`](itwin-platform-access/imodels-access-frontend/README.md) package contains an implementation of [`FrontendHubAccess`](https://github.com/iTwin/itwinjs-core/blob/master/core/frontend/src/FrontendHubAccess.ts) interface which enables the iTwin.js platform to use iModels API.
-- [`@itwin/imodels-access-backend`](itwin-platform-access/imodels-access-backend/README.md) package contains an implementation of [`BackendHubAccess`](https://github.com/iTwin/itwinjs-core/blob/master/core/backend/src/BackendHubAccess.ts) interface which enables the iTwin.js platform to use iModels API. 
+- [`@itwin/imodels-access-backend`](itwin-platform-access/imodels-access-backend/README.md) package contains an implementation of [`BackendHubAccess`](https://github.com/iTwin/itwinjs-core/blob/master/core/backend/src/BackendHubAccess.ts) interface which enables the iTwin.js platform to use iModels API.
 - [`@itwin/imodels-client-common-config`](utils/imodels-client-common-config/README.md) package is used internally to share common configuration across the API clients.
 - [`@itwin/imodels-clients-tests`](tests/imodels-clients-tests/README.md) package is used internally for `@itwin/imodels-client-management` and `@itwin/imodels-client-authoring` package testing.
 - [`@itwin/imodels-access-backend-tests`](tests/imodels-access-backend-tests/README.md) package is used internally for API client testing.

--- a/clients/imodels-client-authoring/README.md
+++ b/clients/imodels-client-authoring/README.md
@@ -4,7 +4,7 @@ Copyright © Bentley Systems, Incorporated. All rights reserved. See [LICENSE.md
 
 ## About this package
 
-This package contains an API client that exposes a subset of [iModels API](https://developer.bentley.com/apis/imodels/) operations - it extends the client from the [`@itwin/imodels-client-management`](../imodels-client-management/README.md) package and adds more operations that enable applications to author iModels - acquire Birefcases, manage Locks, etc. This library also adds the ability to perform iModel operations that include file transfer - create or download Changesets, create iModel from Baseline file.
+This package contains an API client that exposes a subset of [iModels API](https://developer.bentley.com/apis/imodels-v2/) operations - it extends the client from the [`@itwin/imodels-client-management`](../imodels-client-management/README.md) package and adds more operations that enable applications to author iModels - acquire Birefcases, manage Locks, etc. This library also adds the ability to perform iModel operations that include file transfer - create or download Changesets, create iModel from Baseline file.
 
 Please see the [list of key methods and types](../../docs/IModelsClientAuthoring.md) to discover what API operations are exposed by this client package.
 
@@ -15,13 +15,17 @@ Please see the [list of key methods and types](../../docs/IModelsClientAuthoring
 ### Authorization
 
 `IModelsClient` expects the authorization info to be passed in a form of an asynchronous callback that returns authorization info. It is a common use case to consume `IModelsClient` in iTwin.js platform based applications which use `IModelApp.getAccessToken` or `IModelHost.getAccessToken` to get the authorization header value returned as a string. The authorization header value specifies the schema and access token e.g. `Bearer ey...`. To convert this value into the format that `IModelsClients` expect users can use `AccessTokenAdapter` class which is exported by both [`@itwin/imodels-access-frontend`](../../itwin-platform-access/imodels-access-frontend/src/interface-adapters/AccessTokenAdapter.ts) and [`@itwin/imodels-access-backend`](../../itwin-platform-access/imodels-access-backend/src/interface-adapters/AccessTokenAdapter.ts) packages.
+
 ```typescript
-const iModelIterator: EntityListIterator<MinimalIModel> = iModelsClient.iModels.getMinimalList({
-  authorization: AccessTokenAdapter.toAuthorizationCallback(await IModelHost.getAccessToken()),
-  urlParams: {
-    projectId: "8a1fcd73-8c23-460d-a392-8b4afc00affc"
-  }
-});
+const iModelIterator: EntityListIterator<MinimalIModel> =
+  iModelsClient.iModels.getMinimalList({
+    authorization: AccessTokenAdapter.toAuthorizationCallback(
+      await IModelHost.getAccessToken()
+    ),
+    urlParams: {
+      projectId: "8a1fcd73-8c23-460d-a392-8b4afc00affc",
+    },
+  });
 ```
 
 ### Headers
@@ -29,25 +33,31 @@ const iModelIterator: EntityListIterator<MinimalIModel> = iModelsClient.iModels.
 To include custom headers in your requests, you have the option to provide additional headers or header factories. When constructing an instance of `IModelsClient`, any headers passed to the constructor will be automatically added to all requests made by the client. On the other hand, when invoking specific operations, you can pass headers through the operation parameters, which will be included only in the requests related to that particular operation. If a header with the same key is specified in both the constructor and operation parameters, the header from the operation parameters will overwrite the corresponding header from the constructor.
 
 **Note:** Whitespace values, such as empty strings or spaces are treated as regular headers in our requests. This means that if you provide a whitespace header value it will be sent with the request.
+
 ```typescript
 iModelsClient = new IModelsClient({
   headers: {
     "X-Correlation-Id": () => "xCorrelationIdValue",
-    "some-custom-header": "someCustomValue"
-  }
+    "some-custom-header": "someCustomValue",
+  },
 });
 
 iModelsClient.baselineFiles.getSingle({
   headers: {
     "X-Correlation-Id": "some value that overrides factory",
-    "new-custom-header": "header that will be sent in this operation requests"
-  }
-})
+    "new-custom-header": "header that will be sent in this operation requests",
+  },
+});
 ```
 
 ### Create iModel from Baseline File
+
 ```typescript
-import { Authorization, IModel, IModelsClient } from "@itwin/imodels-client-authoring";
+import {
+  Authorization,
+  IModel,
+  IModelsClient,
+} from "@itwin/imodels-client-authoring";
 
 /** Function that creates a new iModel from Baseline file and prints its id to the console. */
 async function createIModelFromBaselineFile(): Promise<void> {
@@ -58,8 +68,8 @@ async function createIModelFromBaselineFile(): Promise<void> {
       projectId: "8a1fcd73-8c23-460d-a392-8b4afc00affc",
       name: "Sun City Renewable-energy Plant",
       description: "Overall model of wind and solar farms in Sun City",
-      filePath: "D:\\imodels\\sun-city.bim"
-    }
+      filePath: "D:\\imodels\\sun-city.bim",
+    },
   });
 
   console.log(iModel.id);

--- a/clients/imodels-client-authoring/src/IModelsClient.ts
+++ b/clients/imodels-client-authoring/src/IModelsClient.ts
@@ -37,7 +37,7 @@ export interface IModelsClientOptions extends ManagementIModelsClientOptions {
 
 /**
  * iModels API client for iModel authoring workflows. For more information on the API visit the
- * {@link https://developer.bentley.com/apis/imodels/ iModels API documentation page}.
+ * {@link https://developer.bentley.com/apis/imodels-v2/ iModels API documentation page}.
  */
 export class IModelsClient extends ManagementIModelsClient {
   protected override _operationsOptions: OperationOptions;

--- a/clients/imodels-client-management/README.md
+++ b/clients/imodels-client-management/README.md
@@ -4,20 +4,24 @@ Copyright © Bentley Systems, Incorporated. All rights reserved. See [LICENSE.md
 
 ## About this package
 
-This package contains an API client that exposes a subset of [iModels API](https://developer.bentley.com/apis/imodels/) operations that enable applications to manage iModels - query Changesets, Locks and other related entities, create Named Versions, etc. This is a lightweight library intended to be used by iTwin management applications that do not write any data into the iModel itself, an example of such application is the [iTwin Demo Portal](https://itwindemo.bentley.com/).
+This package contains an API client that exposes a subset of [iModels v2 API](https://developer.bentley.com/apis/imodels-v2/) operations that enable applications to manage iModels - query Changesets, Locks and other related entities, create Named Versions, etc. This is a lightweight library intended to be used by iTwin management applications that do not write any data into the iModel itself.
 
 Please see the [list of key methods and types](../../docs/IModelsClientManagement.md) to discover what API operations are exposed by this client package.
 
 ### Authorization
 
 `IModelsClient` expects the authorization info to be passed in a form of an asynchronous callback that returns authorization info. It is a common use case to consume `IModelsClient` in iTwin.js platform based applications which use `IModelApp.getAccessToken` or `IModelHost.getAccessToken` to get the authorization header value returned as a string. The authorization header value specifies the schema and access token e.g. `Bearer ey...`. To convert this value into the format that `IModelsClients` expect users can use `AccessTokenAdapter` class which is exported by both [`@itwin/imodels-access-frontend`](../../itwin-platform-access/imodels-access-frontend/src/interface-adapters/AccessTokenAdapter.ts) and [`@itwin/imodels-access-backend`](../../itwin-platform-access/imodels-access-backend/src/interface-adapters/AccessTokenAdapter.ts) packages.
+
 ```typescript
-const iModelIterator: EntityListIterator<MinimalIModel> = iModelsClient.iModels.getMinimalList({
-  authorization: AccessTokenAdapter.toAuthorizationCallback(await IModelApp.getAccessToken()),
-  urlParams: {
-    projectId: "8a1fcd73-8c23-460d-a392-8b4afc00affc"
-  }
-});
+const iModelIterator: EntityListIterator<MinimalIModel> =
+  iModelsClient.iModels.getMinimalList({
+    authorization: AccessTokenAdapter.toAuthorizationCallback(
+      await IModelApp.getAccessToken()
+    ),
+    urlParams: {
+      projectId: "8a1fcd73-8c23-460d-a392-8b4afc00affc",
+    },
+  });
 ```
 
 ### Headers
@@ -25,38 +29,45 @@ const iModelIterator: EntityListIterator<MinimalIModel> = iModelsClient.iModels.
 To include custom headers in your requests, you have the option to provide additional headers or header factories. When constructing an instance of `IModelsClient`, any headers passed to the constructor will be automatically added to all requests made by the client. On the other hand, when invoking specific operations, you can pass headers through the operation parameters, which will be included only in the requests related to that particular operation. If a header with the same key is specified in both the constructor and operation parameters, the header from the operation parameters will overwrite the corresponding header from the constructor.
 
 **Note:** Whitespace values, such as empty strings or spaces are treated as regular headers in our requests. This means that if you provide a whitespace header value it will be sent with the request.
+
 ```typescript
 iModelsClient = new IModelsClient({
   headers: {
     "X-Correlation-Id": () => "xCorrelationIdValue",
-    "some-custom-header": "someCustomValue"
-  }
+    "some-custom-header": "someCustomValue",
+  },
 });
 
 iModelsClient.baselineFiles.getSingle({
   headers: {
     "X-Correlation-Id": "some value that overrides factory",
-    "new-custom-header": "header that will be sent in this operation requests"
-  }
-})
+    "new-custom-header": "header that will be sent in this operation requests",
+  },
+});
 ```
 
 ### Get all project iModels
+
 ```typescript
-import { Authorization, EntityListIterator, IModelsClient, MinimalIModel } from "@itwin/imodels-client-management";
+import {
+  Authorization,
+  EntityListIterator,
+  IModelsClient,
+  MinimalIModel,
+} from "@itwin/imodels-client-management";
 
 /** Function that queries all iModels for a particular project and prints their ids to the console. */
 async function printiModelIds(): Promise<void> {
   const iModelsClient: IModelsClient = new IModelsClient();
-  const iModelIterator: EntityListIterator<MinimalIModel> = iModelsClient.iModels.getMinimalList({
-    authorization: () => getAuthorization(),
-    urlParams: {
-      projectId: "8a1fcd73-8c23-460d-a392-8b4afc00affc"
-    }
-  });
+  const iModelIterator: EntityListIterator<MinimalIModel> =
+    iModelsClient.iModels.getMinimalList({
+      authorization: () => getAuthorization(),
+      urlParams: {
+        projectId: "8a1fcd73-8c23-460d-a392-8b4afc00affc",
+      },
+    });
 
-  for await (const iModel of iModelIterator)
-    console.log(iModel.id);
+  for await (const iModel of iModelIterator) console.log(iModel.id);
 }
 
 /** Function that returns valid authorization information. */
@@ -66,23 +77,29 @@ async function getAuthorization(): Promise<Authorization> {
 ```
 
 ### Get an iModel with a specific name
+
 ```typescript
-import { EntityListIterator, IModel, IModelsClient, toArray } from "@itwin/imodels-client-management";
+import {
+  EntityListIterator,
+  IModel,
+  IModelsClient,
+  toArray,
+} from "@itwin/imodels-client-management";
 
 /** Function that queries an iModel with a specific name. Function returns `undefined` if such iModel does not exist. */
 async function getiModel(): Promise<IModel | undefined> {
   const iModelsClient: IModelsClient = new IModelsClient();
-  const iModelIterator: EntityListIterator<IModel> = iModelsClient.iModels.getRepresentationList({
-    authorization: () => getAuthorization(),
-    urlParams: {
-      projectId: "8a1fcd73-8c23-460d-a392-8b4afc00affc",
-      name: "Sun City Renewable-energy Plant",
-    }
-  });
+  const iModelIterator: EntityListIterator<IModel> =
+    iModelsClient.iModels.getRepresentationList({
+      authorization: () => getAuthorization(),
+      urlParams: {
+        projectId: "8a1fcd73-8c23-460d-a392-8b4afc00affc",
+        name: "Sun City Renewable-energy Plant",
+      },
+    });
 
   const iModelArray = await toArray(iModelIterator);
-  if (iModelArray.length === 0)
-    return undefined;
+  if (iModelArray.length === 0) return undefined;
 
   const iModel = iModelArray[0];
   return iModel;
@@ -90,25 +107,36 @@ async function getiModel(): Promise<IModel | undefined> {
 ```
 
 ### Get all iModel Changesets
+
 ```typescript
-import { Authorization, EntityListIterator, IModelsClient, MinimalChangeset } from "@itwin/imodels-client-management";
+import {
+  Authorization,
+  EntityListIterator,
+  IModelsClient,
+  MinimalChangeset,
+} from "@itwin/imodels-client-management";
 
 /** Function that queries all Changesets for a particular iModel and prints their ids to the console. */
 async function printChangesetIds(): Promise<void> {
   const iModelsClient: IModelsClient = new IModelsClient();
-  const changesetIterator: EntityListIterator<MinimalChangeset> = iModelsClient.changesets.getMinimalList({
-    authorization: () => getAuthorization(),
-    iModelId: "30c8505e-fa7a-4b53-a13f-e6a193da8ffc"
-  });
+  const changesetIterator: EntityListIterator<MinimalChangeset> =
+    iModelsClient.changesets.getMinimalList({
+      authorization: () => getAuthorization(),
+      iModelId: "30c8505e-fa7a-4b53-a13f-e6a193da8ffc",
+    });
 
-  for await (const changeset of changesetIterator)
-    console.log(changeset.id);
+  for await (const changeset of changesetIterator) console.log(changeset.id);
 }
 ```
 
 ### Create a Named Version on a Changeset
+
 ```typescript
-import { Authorization, IModelsClient, NamedVersion } from "@itwin/imodels-client-management";
+import {
+  Authorization,
+  IModelsClient,
+  NamedVersion,
+} from "@itwin/imodels-client-management";
 
 /** Function that creates a Named Version on a particular changeset and prints its id to the console. */
 async function createNamedVersion(): Promise<void> {
@@ -118,8 +146,8 @@ async function createNamedVersion(): Promise<void> {
     iModelId: "30c8505e-fa7a-4b53-a13f-e6a193da8ffc",
     namedVersionProperties: {
       name: "Milestone",
-      changesetId: "bd51c08eb44f40d49fee9a0c7d6fc018c3b5ba3f"
-    }
+      changesetId: "bd51c08eb44f40d49fee9a0c7d6fc018c3b5ba3f",
+    },
   });
 
   console.log(namedVersion.id);

--- a/clients/imodels-client-management/src/IModelsClient.ts
+++ b/clients/imodels-client-management/src/IModelsClient.ts
@@ -26,7 +26,7 @@ export interface IModelsClientOptions {
 
 /**
  * iModels API client for iModel management workflows. For more information on the API visit the
- * {@link https://developer.bentley.com/apis/imodels/ iModels API documentation page}.
+ * {@link https://developer.bentley.com/apis/imodels-v2/ iModels API documentation page}.
  */
 export class IModelsClient {
   protected _operationsOptions: OperationOptions;

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,10 @@
 # iModels API clients
 
-This is documentation for iModels API clients in `@itwin/imodels-client-management` and `@itwin/imodels-client-authoring` packages. Please visit the [iModels API documentation page](https://developer.bentley.com/apis/imodels/) on iTwin developer portal to learn more about the iModels service and its APIs. API clients contain methods that either act as a thin wrapper for sending a single request to the API or combine several requests to execute a more complex operation.
+This is documentation for iModels API clients in `@itwin/imodels-client-management` and `@itwin/imodels-client-authoring` packages. Please visit the [iModels API documentation page](https://developer.bentley.com/apis/imodels-v2/) on iTwin developer portal to learn more about the iModels service and its APIs. API clients contain methods that either act as a thin wrapper for sending a single request to the API or combine several requests to execute a more complex operation.
 
 iModels API is a part of [iTwin Platform](https://developer.bentley.com/). iTwin platform together with an open source [iTwin.js](https://www.itwinjs.org/) library provides capabilities for creating, querying, modifying, and displaying Infrastructure Digital Twins.
 
 Users can choose to use either one of the following packages that contain `IModelsClient`:
+
 - `@itwin/imodels-client-management` ([documentation](./IModelsClientManagement.md)) - client from this package exposes a subset of iModels API operations and is intended to use in iModel management applications. Such applications do not edit the iModel file itself, they allow user to perform administrative tasks - create Named Versions, view Changeset metadata and such. An example of iTwin management application is the [iTwin Demo Portal](https://itwindemo.bentley.com/).
 - `@itwin/imodels-client-authoring` ([documentation](./IModelsClientAuthoring.md)) - client from this package extends the one from `@itwin/imodels-client-management` and exposes additional API operations to facilitate iModel editing workflows. Usually it is not recommended to use the client from this package directly as the additional operations it exposes can only be used meaningfully via [iTwin.js](https://www.itwinjs.org/) library.

--- a/itwin-platform-access/imodels-access-backend/README.md
+++ b/itwin-platform-access/imodels-access-backend/README.md
@@ -4,4 +4,4 @@ Copyright © Bentley Systems, Incorporated. All rights reserved. See [LICENSE.md
 
 ## About this package
 
-This package contains an implementation of [`BackendHubAccess`](https://github.com/iTwin/itwinjs-core/blob/master/core/backend/src/BackendHubAccess.ts) interface. The implementation uses the [`@itwin/imodels-client-authoring`](../../clients/imodels-client-authoring/README.md) package and adapts it to the defined interface thus enabling the applications built using [iTwin.js](http://www.itwinjs.org) library to use [iModelHub service](https://developer.bentley.com/apis/imodels/#imodelhubservice) as a repository for iModels.
+This package contains an implementation of [`BackendHubAccess`](https://github.com/iTwin/itwinjs-core/blob/master/core/backend/src/BackendHubAccess.ts) interface. The implementation uses the [`@itwin/imodels-client-authoring`](../../clients/imodels-client-authoring/README.md) package and adapts it to the defined interface thus enabling the applications built using [iTwin.js](http://www.itwinjs.org) library to use [iModelHub service](https://developer.bentley.com/apis/imodels-v2/#imodelhubservice) as a repository for iModels.

--- a/itwin-platform-access/imodels-access-frontend/README.md
+++ b/itwin-platform-access/imodels-access-frontend/README.md
@@ -4,4 +4,4 @@ Copyright © Bentley Systems, Incorporated. All rights reserved. See [LICENSE.md
 
 ## About this package
 
-This package contains an implementation of [`FrontendHubAccess`](https://github.com/iTwin/itwinjs-core/blob/master/core/frontend/src/FrontendHubAccess.ts) interface. The implementation uses the [`@itwin/imodels-client-management`](../../clients/imodels-client-management/README.md) package and adapts it to the defined interface thus enabling the applications built using [iTwin.js](http://www.itwinjs.org) library to use [iModelHub service](https://developer.bentley.com/apis/imodels/#imodelhubservice) as a repository for iModels.
+This package contains an implementation of [`FrontendHubAccess`](https://github.com/iTwin/itwinjs-core/blob/master/core/frontend/src/FrontendHubAccess.ts) interface. The implementation uses the [`@itwin/imodels-client-management`](../../clients/imodels-client-management/README.md) package and adapts it to the defined interface thus enabling the applications built using [iTwin.js](http://www.itwinjs.org) library to use [iModelHub service](https://developer.bentley.com/apis/imodels-v2/#imodelhubservice) as a repository for iModels.


### PR DESCRIPTION
- fix remaining references to now-deprecated imodels v1 endpoint
- remove dead link in client-management README
- Markdown formatting for touched READMEs