### PR TITLE
Add iModel Clone operation

### DIFF
--- a/clients/imodels-client-authoring/src/IModelsClient.ts
+++ b/clients/imodels-client-authoring/src/IModelsClient.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import "reflect-metadata";
 
-import { AxiosRestClient } from "@itwin/imodels-client-management/lib/base/internal";
+import { AxiosHeadersAdapterFactory, AxiosRestClient } from "@itwin/imodels-client-management/lib/base/internal";
 import { AzureClientStorage, BlockBlobClientWrapperFactory } from "@itwin/object-storage-azure";
 import { ClientStorage } from "@itwin/object-storage-core";
 
@@ -100,7 +100,7 @@ export class IModelsClient extends ManagementIModelsClient {
   ): RecursiveRequired<IModelsClientOptions> {
     return {
       api: this.fillApiConfiguration(options?.api),
-      restClient: options?.restClient ?? new AxiosRestClient(IModelsErrorParser.parse),
+      restClient: options?.restClient ?? new AxiosRestClient(IModelsErrorParser.parse, new AxiosHeadersAdapterFactory()),
       localFileSystem: options?.localFileSystem ?? new NodeLocalFileSystem(),
       cloudStorage: options?.cloudStorage ?? new AzureClientStorage(new BlockBlobClientWrapperFactory()),
       headers: options?.headers ?? {}

--- a/clients/imodels-client-authoring/src/IModelsClient.ts
+++ b/clients/imodels-client-authoring/src/IModelsClient.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import "reflect-metadata";
 
-import { AxiosHeadersAdapterFactory, AxiosRestClient } from "@itwin/imodels-client-management/lib/base/internal";
+import { AxiosRestClient } from "@itwin/imodels-client-management/lib/base/internal";
 import { AzureClientStorage, BlockBlobClientWrapperFactory } from "@itwin/object-storage-azure";
 import { ClientStorage } from "@itwin/object-storage-core";
 
@@ -100,7 +100,7 @@ export class IModelsClient extends ManagementIModelsClient {
   ): RecursiveRequired<IModelsClientOptions> {
     return {
       api: this.fillApiConfiguration(options?.api),
-      restClient: options?.restClient ?? new AxiosRestClient(IModelsErrorParser.parse, new AxiosHeadersAdapterFactory()),
+      restClient: options?.restClient ?? new AxiosRestClient(IModelsErrorParser.parse),
       localFileSystem: options?.localFileSystem ?? new NodeLocalFileSystem(),
       cloudStorage: options?.cloudStorage ?? new AzureClientStorage(new BlockBlobClientWrapperFactory()),
       headers: options?.headers ?? {}

--- a/clients/imodels-client-authoring/src/base/internal/ApiResponseInterfaces.ts
+++ b/clients/imodels-client-authoring/src/base/internal/ApiResponseInterfaces.ts
@@ -2,9 +2,11 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import { CollectionResponse } from "@itwin/imodels-client-management/lib/base/internal";
+
 import { BaselineFile, Lock } from "../types";
 
-export interface LocksResponse {
+export interface LocksResponse extends CollectionResponse {
   locks: Lock[];
 }
 

--- a/clients/imodels-client-authoring/src/operations/baseline-file/BaselineFileOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/baseline-file/BaselineFileOperations.ts
@@ -24,6 +24,6 @@ export class BaselineFileOperations<TOptions extends OperationOptions> extends O
       url: this._options.urlFormatter.getBaselineUrl({ iModelId: params.iModelId }),
       headers: params.headers
     });
-    return response.baselineFile;
+    return response.data.baselineFile;
   }
 }

--- a/clients/imodels-client-authoring/src/operations/baseline-file/BaselineFileOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/baseline-file/BaselineFileOperations.ts
@@ -24,6 +24,6 @@ export class BaselineFileOperations<TOptions extends OperationOptions> extends O
       url: this._options.urlFormatter.getBaselineUrl({ iModelId: params.iModelId }),
       headers: params.headers
     });
-    return response.data.baselineFile;
+    return response.body.baselineFile;
   }
 }

--- a/clients/imodels-client-authoring/src/operations/briefcase/BriefcaseOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/briefcase/BriefcaseOperations.ts
@@ -27,7 +27,7 @@ export class BriefcaseOperations<TOptions extends OperationOptions> extends Mana
       body: acquireBriefcaseBody,
       headers: params.headers
     });
-    const result = this.appendRelatedEntityCallbacks(params.authorization, acquireBriefcaseResponse.data.briefcase, params.headers);
+    const result = this.appendRelatedEntityCallbacks(params.authorization, acquireBriefcaseResponse.body.briefcase, params.headers);
     return result;
   }
 

--- a/clients/imodels-client-authoring/src/operations/briefcase/BriefcaseOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/briefcase/BriefcaseOperations.ts
@@ -27,7 +27,7 @@ export class BriefcaseOperations<TOptions extends OperationOptions> extends Mana
       body: acquireBriefcaseBody,
       headers: params.headers
     });
-    const result = this.appendRelatedEntityCallbacks(params.authorization, acquireBriefcaseResponse.briefcase, params.headers);
+    const result = this.appendRelatedEntityCallbacks(params.authorization, acquireBriefcaseResponse.data.briefcase, params.headers);
     return result;
   }
 
@@ -36,10 +36,10 @@ export class BriefcaseOperations<TOptions extends OperationOptions> extends Mana
    * {@link https://developer.bentley.com/apis/imodels-v2/operations/release-imodel-briefcase/ Release iModel Briefcase}
    * operation from iModels API.
    * @param {ReleaseBriefcaseParams} params parameters for this operation. See {@link ReleaseBriefcaseParams}.
-   * @returns {Promise<Briefcase>} a promise that resolves after operation completes.
+   * @returns {Promise<void>} a promise that resolves after operation completes.
    */
   public async release(params: ReleaseBriefcaseParams): Promise<void> {
-    return this.sendDeleteRequest({
+    await this.sendDeleteRequest({
       authorization: params.authorization,
       url: this._options.urlFormatter.getSingleBriefcaseUrl({ iModelId: params.iModelId, briefcaseId: params.briefcaseId }),
       headers: params.headers

--- a/clients/imodels-client-authoring/src/operations/changeset-group/ChangesetGroupOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/changeset-group/ChangesetGroupOperations.ts
@@ -27,7 +27,7 @@ export class ChangesetGroupOperations<TOptions extends OperationOptions> extends
       body: createChangesetGroupBody,
       headers: params.headers
     });
-    const result = this.appendRelatedEntityCallbacks(params.authorization, createChangesetGroupResponse.changesetGroup, params.headers);
+    const result = this.appendRelatedEntityCallbacks(params.authorization, createChangesetGroupResponse.data.changesetGroup, params.headers);
     return result;
   }
 
@@ -46,7 +46,7 @@ export class ChangesetGroupOperations<TOptions extends OperationOptions> extends
       body: updateChangesetGroupBody,
       headers: params.headers
     });
-    const result = this.appendRelatedEntityCallbacks(params.authorization, updateChangesetGroupResponse.changesetGroup, params.headers);
+    const result = this.appendRelatedEntityCallbacks(params.authorization, updateChangesetGroupResponse.data.changesetGroup, params.headers);
     return result;
   }
 

--- a/clients/imodels-client-authoring/src/operations/changeset-group/ChangesetGroupOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/changeset-group/ChangesetGroupOperations.ts
@@ -27,7 +27,7 @@ export class ChangesetGroupOperations<TOptions extends OperationOptions> extends
       body: createChangesetGroupBody,
       headers: params.headers
     });
-    const result = this.appendRelatedEntityCallbacks(params.authorization, createChangesetGroupResponse.data.changesetGroup, params.headers);
+    const result = this.appendRelatedEntityCallbacks(params.authorization, createChangesetGroupResponse.body.changesetGroup, params.headers);
     return result;
   }
 
@@ -46,7 +46,7 @@ export class ChangesetGroupOperations<TOptions extends OperationOptions> extends
       body: updateChangesetGroupBody,
       headers: params.headers
     });
-    const result = this.appendRelatedEntityCallbacks(params.authorization, updateChangesetGroupResponse.data.changesetGroup, params.headers);
+    const result = this.appendRelatedEntityCallbacks(params.authorization, updateChangesetGroupResponse.body.changesetGroup, params.headers);
     return result;
   }
 

--- a/clients/imodels-client-authoring/src/operations/changeset/ChangesetOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/changeset/ChangesetOperations.ts
@@ -50,14 +50,14 @@ export class ChangesetOperations<TOptions extends OperationOptions> extends Mana
       headers: params.headers
     });
 
-    const uploadLink = createChangesetResponse.data.changeset._links.upload;
+    const uploadLink = createChangesetResponse.body.changeset._links.upload;
     assertLink(uploadLink);
     await this._options.cloudStorage.upload({
       url: uploadLink.href,
       data: params.changesetProperties.filePath
     });
 
-    const completeLink = createChangesetResponse.data.changeset._links.complete;
+    const completeLink = createChangesetResponse.body.changeset._links.complete;
     assertLink(completeLink);
     const confirmUploadBody = this.getConfirmUploadRequestBody(params.changesetProperties);
     const confirmUploadResponse = await this.sendPatchRequest<ChangesetResponse>({
@@ -67,7 +67,7 @@ export class ChangesetOperations<TOptions extends OperationOptions> extends Mana
       headers: params.headers
     });
 
-    const result = this.appendRelatedEntityCallbacks(params.authorization, confirmUploadResponse.data.changeset, params.headers);
+    const result = this.appendRelatedEntityCallbacks(params.authorization, confirmUploadResponse.body.changeset, params.headers);
     return result;
   }
 

--- a/clients/imodels-client-authoring/src/operations/changeset/ChangesetOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/changeset/ChangesetOperations.ts
@@ -50,14 +50,14 @@ export class ChangesetOperations<TOptions extends OperationOptions> extends Mana
       headers: params.headers
     });
 
-    const uploadLink = createChangesetResponse.changeset._links.upload;
+    const uploadLink = createChangesetResponse.data.changeset._links.upload;
     assertLink(uploadLink);
     await this._options.cloudStorage.upload({
       url: uploadLink.href,
       data: params.changesetProperties.filePath
     });
 
-    const completeLink = createChangesetResponse.changeset._links.complete;
+    const completeLink = createChangesetResponse.data.changeset._links.complete;
     assertLink(completeLink);
     const confirmUploadBody = this.getConfirmUploadRequestBody(params.changesetProperties);
     const confirmUploadResponse = await this.sendPatchRequest<ChangesetResponse>({
@@ -67,7 +67,7 @@ export class ChangesetOperations<TOptions extends OperationOptions> extends Mana
       headers: params.headers
     });
 
-    const result = this.appendRelatedEntityCallbacks(params.authorization, confirmUploadResponse.changeset, params.headers);
+    const result = this.appendRelatedEntityCallbacks(params.authorization, confirmUploadResponse.data.changeset, params.headers);
     return result;
   }
 

--- a/clients/imodels-client-authoring/src/operations/lock/LockOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/lock/LockOperations.ts
@@ -25,7 +25,7 @@ export class LockOperations<TOptions extends OperationOptions> extends Operation
     return new EntityListIteratorImpl(async () => this.getEntityCollectionPage<Lock, LocksResponse>({
       authorization: params.authorization,
       url: this._options.urlFormatter.getLockListUrl({ iModelId: params.iModelId, urlParams: params.urlParams }),
-      entityCollectionAccessor: (response) => response.data.locks,
+      entityCollectionAccessor: (response) => response.body.locks,
       headers: params.headers
     }));
   }
@@ -45,7 +45,7 @@ export class LockOperations<TOptions extends OperationOptions> extends Operation
       body: updateLockBody,
       headers: params.headers
     });
-    return updateLockResponse.data.lock;
+    return updateLockResponse.body.lock;
   }
 
   private getUpdateLockBody(params: UpdateLockParams): object {

--- a/clients/imodels-client-authoring/src/operations/lock/LockOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/lock/LockOperations.ts
@@ -22,10 +22,10 @@ export class LockOperations<TOptions extends OperationOptions> extends Operation
    * @returns {EntityListIterator<Lock>} iterator for Lock list. See {@link EntityListIterator}, {@link Lock}.
    */
   public getList(params: GetLockListParams): EntityListIterator<Lock> {
-    return new EntityListIteratorImpl(async () => this.getEntityCollectionPage<Lock>({
+    return new EntityListIteratorImpl(async () => this.getEntityCollectionPage<Lock, LocksResponse>({
       authorization: params.authorization,
       url: this._options.urlFormatter.getLockListUrl({ iModelId: params.iModelId, urlParams: params.urlParams }),
-      entityCollectionAccessor: (response: unknown) => (response as LocksResponse).locks,
+      entityCollectionAccessor: (response) => response.data.locks,
       headers: params.headers
     }));
   }
@@ -45,7 +45,7 @@ export class LockOperations<TOptions extends OperationOptions> extends Operation
       body: updateLockBody,
       headers: params.headers
     });
-    return updateLockResponse.lock;
+    return updateLockResponse.data.lock;
   }
 
   private getUpdateLockBody(params: UpdateLockParams): object {

--- a/clients/imodels-client-management/src/Constants.ts
+++ b/clients/imodels-client-management/src/Constants.ts
@@ -12,7 +12,8 @@ export class Constants {
     accept: "Accept",
     authorization: "Authorization",
     contentType: "Content-Type",
-    prefer: "Prefer"
+    prefer: "Prefer",
+    location: "Location"
   };
 
   public static time = {

--- a/clients/imodels-client-management/src/IModelsClient.ts
+++ b/clients/imodels-client-management/src/IModelsClient.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { AxiosRestClient, IModelsErrorParser } from "./base/internal";
+import { AxiosHeadersAdapterFactory, AxiosRestClient, IModelsErrorParser } from "./base/internal";
 import { ApiOptions, HeaderFactories, RecursiveRequired, RestClient } from "./base/types";
 import { Constants } from "./Constants";
 import { BriefcaseOperations, ChangesetOperations, IModelOperations, NamedVersionOperations, OperationOperations, ThumbnailOperations, UserOperations, UserPermissionOperations } from "./operations";
@@ -99,7 +99,7 @@ export class IModelsClient {
   ): RecursiveRequired<IModelsClientOptions> {
     return {
       api: this.fillApiConfiguration(options?.api),
-      restClient: options?.restClient ?? new AxiosRestClient(IModelsErrorParser.parse),
+      restClient: options?.restClient ?? new AxiosRestClient(IModelsErrorParser.parse, new AxiosHeadersAdapterFactory()),
       headers: options?.headers ?? {}
     };
   }

--- a/clients/imodels-client-management/src/IModelsClient.ts
+++ b/clients/imodels-client-management/src/IModelsClient.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { AxiosHeadersAdapterFactory, AxiosRestClient, IModelsErrorParser } from "./base/internal";
+import { AxiosRestClient, IModelsErrorParser } from "./base/internal";
 import { ApiOptions, HeaderFactories, RecursiveRequired, RestClient } from "./base/types";
 import { Constants } from "./Constants";
 import { BriefcaseOperations, ChangesetOperations, IModelOperations, NamedVersionOperations, OperationOperations, ThumbnailOperations, UserOperations, UserPermissionOperations } from "./operations";
@@ -99,7 +99,7 @@ export class IModelsClient {
   ): RecursiveRequired<IModelsClientOptions> {
     return {
       api: this.fillApiConfiguration(options?.api),
-      restClient: options?.restClient ?? new AxiosRestClient(IModelsErrorParser.parse, new AxiosHeadersAdapterFactory()),
+      restClient: options?.restClient ?? new AxiosRestClient(IModelsErrorParser.parse),
       headers: options?.headers ?? {}
     };
   }

--- a/clients/imodels-client-management/src/base/internal/AxiosResponseHeadersAdapter.ts
+++ b/clients/imodels-client-management/src/base/internal/AxiosResponseHeadersAdapter.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { AxiosResponse } from "axios";
+
+import { HttpResponseHeaders } from "../types/RestClient";
+import { Dictionary } from "../types/UtilityTypes";
+
+/** Default implementation for {@link HttpResponseHeaders} interface, which adapts `axios` HTTP response headers to headers expected by the iModels Client. */
+export class AxiosResponseHeadersAdapter implements HttpResponseHeaders {
+  private _response: AxiosResponse;
+
+  constructor(response: AxiosResponse) {
+    this._response = response;
+  }
+
+  public get(headerName: string): unknown {
+    // Directly manipulating headers object is deprecated.
+    // https://github.com/axios/axios?tab=readme-ov-file#-axiosheaders
+    if (this._response.headers.get instanceof Function)
+      return this._response.headers.get(headerName);
+
+    // It's most likely that header name is lowercase.
+    // https://axios-http.com/docs/res_schema
+    return this._response.headers[headerName.toLowerCase()];
+  }
+
+  public getAll(): Dictionary<unknown> {
+    return this._response.headers;
+  }
+}

--- a/clients/imodels-client-management/src/base/internal/AxiosRestClient.ts
+++ b/clients/imodels-client-management/src/base/internal/AxiosRestClient.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
 
-import { ContentType, HttpGetRequestParams, HttpRequestParams, HttpRequestWithBinaryBodyParams, HttpRequestWithJsonBodyParams, RestClient } from "../types/RestClient";
+import { ContentType, HttpGetRequestParams, HttpRequestParams, HttpRequestWithBinaryBodyParams, HttpRequestWithJsonBodyParams, HttpResponse, RestClient } from "../types/RestClient";
 
 /**
  * Function that is called if the HTTP request fails and which returns an error that will be thrown by one of the
@@ -20,25 +20,28 @@ export class AxiosRestClient implements RestClient {
     this._parseErrorFunc = parseErrorFunc;
   }
 
-  public sendGetRequest<TResponse>(params: HttpGetRequestParams & { responseType: ContentType.Json }): Promise<TResponse>;
-  public sendGetRequest(params: HttpGetRequestParams & { responseType: ContentType.Png }): Promise<Uint8Array>;
-  public async sendGetRequest<TResponse>(params: HttpGetRequestParams): Promise<TResponse | Uint8Array> {
+  public sendGetRequest<TData>(params: HttpGetRequestParams & { responseType: ContentType.Json }): Promise<HttpResponse<TData>>;
+  public sendGetRequest(params: HttpGetRequestParams & { responseType: ContentType.Png }): Promise<HttpResponse<Uint8Array>>;
+  public async sendGetRequest<TData>(params: HttpGetRequestParams): Promise<HttpResponse<TData | Uint8Array>> {
     const requestConfig: AxiosRequestConfig = {
       headers: params.headers
     };
 
     if (params.responseType === ContentType.Png) {
       requestConfig.responseType = "arraybuffer";
-      const responseData: Buffer | ArrayBuffer = await this.executeRequest(async () => axios.get(params.url, requestConfig));
-      if (responseData instanceof ArrayBuffer)
-        return new Uint8Array(responseData);
-      return responseData;
+      const response = await this.executeRequest(async () => axios.get(params.url, requestConfig));
+
+      const data: Buffer | ArrayBuffer = response.data;
+      if (data instanceof ArrayBuffer)
+        return { ...response, data: new Uint8Array(data) };
+
+      return response;
     }
 
     return this.executeRequest(async () => axios.get(params.url, requestConfig));
   }
 
-  public async sendPostRequest<TResponse>(params: HttpRequestWithJsonBodyParams): Promise<TResponse> {
+  public async sendPostRequest<TData>(params: HttpRequestWithJsonBodyParams): Promise<HttpResponse<TData>> {
     const requestConfig: AxiosRequestConfig = {
       headers: params.headers
     };
@@ -46,7 +49,7 @@ export class AxiosRestClient implements RestClient {
     return this.executeRequest(async () => axios.post(params.url, params.body.content ?? {}, requestConfig));
   }
 
-  public async sendPutRequest<TResponse>(params: HttpRequestWithBinaryBodyParams): Promise<TResponse> {
+  public async sendPutRequest<TData>(params: HttpRequestWithBinaryBodyParams): Promise<HttpResponse<TData>> {
     const requestConfig: AxiosRequestConfig = {
       headers: params.headers
     };
@@ -54,7 +57,7 @@ export class AxiosRestClient implements RestClient {
     return this.executeRequest(async () => axios.put(params.url, params.body.content, requestConfig));
   }
 
-  public async sendPatchRequest<TResponse>(params: HttpRequestWithJsonBodyParams): Promise<TResponse> {
+  public async sendPatchRequest<TData>(params: HttpRequestWithJsonBodyParams): Promise<HttpResponse<TData>> {
     const requestConfig: AxiosRequestConfig = {
       headers: params.headers
     };
@@ -62,17 +65,32 @@ export class AxiosRestClient implements RestClient {
     return this.executeRequest(async () => axios.patch(params.url, params.body.content ?? {}, requestConfig));
   }
 
-  public async sendDeleteRequest<TResponse>(params: HttpRequestParams): Promise<TResponse> {
+  public async sendDeleteRequest<TData>(params: HttpRequestParams): Promise<HttpResponse<TData>> {
     const requestConfig: AxiosRequestConfig = {
       headers: params.headers
     };
+
     return this.executeRequest(async () => axios.delete(params.url, requestConfig));
   }
 
-  private async executeRequest<TResponse>(requestFunc: () => Promise<AxiosResponse<TResponse>>): Promise<TResponse> {
+  private async executeRequest<TData>(requestFunc: () => Promise<AxiosResponse<TData>>): Promise<HttpResponse<TData>> {
     try {
       const response = await requestFunc();
-      return response.data;
+
+      return {
+        data: response.data,
+        headers: {
+          get: (headerName: string) => {
+            // Directly manipulating headers object is deprecated.
+            // https://github.com/axios/axios?tab=readme-ov-file#-axiosheaders
+            if (response.headers.get instanceof Function)
+              return response.headers.get(headerName);
+
+            // It's most likely that header name is lowercase.
+            return response.headers[headerName.toLowerCase()];
+          }
+        }
+      };
     } catch (error: unknown) {
       if (axios.isAxiosError(error)) {
         const parsedError: Error = this._parseErrorFunc({ statusCode: error.response?.status, body: error.response?.data }, error);

--- a/clients/imodels-client-management/src/base/internal/AxiosRestClient.ts
+++ b/clients/imodels-client-management/src/base/internal/AxiosRestClient.ts
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
 
-import { ContentType, HttpGetRequestParams, HttpRequestParams, HttpRequestWithBinaryBodyParams, HttpRequestWithJsonBodyParams, HttpResponse, RestClient } from "../types/RestClient";
+import { Dictionary } from "../types";
+import { ContentType, HttpGetRequestParams, HttpRequestParams, HttpRequestWithBinaryBodyParams, HttpRequestWithJsonBodyParams, HttpResponse, HttpResponseHeaders, RestClient } from "../types/RestClient";
 
 /**
  * Function that is called if the HTTP request fails and which returns an error that will be thrown by one of the
@@ -12,12 +13,19 @@ import { ContentType, HttpGetRequestParams, HttpRequestParams, HttpRequestWithBi
  */
 export type ParseErrorFunc = (response: { statusCode?: number, body?: unknown }, originalError: Error & { code?: string }) => Error;
 
+/** A factory for creating {@link HttpResponseHeaders} from {@link AxiosResponse}. */
+export interface HttpResponseHeadersFactory {
+  create(response: AxiosResponse): HttpResponseHeaders;
+}
+
 /** Default implementation for {@link RestClient} interface that uses `axios` library for sending the requests. */
 export class AxiosRestClient implements RestClient {
   private _parseErrorFunc: ParseErrorFunc;
+  private _responseHeadersFactory: HttpResponseHeadersFactory;
 
-  constructor(parseErrorFunc: ParseErrorFunc) {
+  constructor(parseErrorFunc: ParseErrorFunc, responseHeadersFactory: HttpResponseHeadersFactory) {
     this._parseErrorFunc = parseErrorFunc;
+    this._responseHeadersFactory = responseHeadersFactory;
   }
 
   public sendGetRequest<TBody>(params: HttpGetRequestParams & { responseType: ContentType.Json }): Promise<HttpResponse<TBody>>;
@@ -79,18 +87,7 @@ export class AxiosRestClient implements RestClient {
 
       return {
         body: response.data,
-        headers: {
-          get: (headerName: string) => {
-            // Directly manipulating headers object is deprecated.
-            // https://github.com/axios/axios?tab=readme-ov-file#-axiosheaders
-            if (response.headers.get instanceof Function)
-              return response.headers.get(headerName);
-
-            // It's most likely that header name is lowercase.
-            // https://axios-http.com/docs/res_schema
-            return response.headers[headerName.toLowerCase()];
-          }
-        }
+        headers: this._responseHeadersFactory.create(response)
       };
     } catch (error: unknown) {
       if (axios.isAxiosError(error)) {
@@ -99,5 +96,36 @@ export class AxiosRestClient implements RestClient {
       }
       throw error;
     }
+  }
+}
+
+/** Default implementation for {@link HttpResponseHeadersFactory}. */
+export class AxiosHeadersAdapterFactory implements HttpResponseHeadersFactory {
+  public create(response: AxiosResponse): HttpResponseHeaders {
+    return new AxiosHeadersAdapter(response);
+  }
+}
+
+/** Default implementation for {@link HttpResponseHeaders} interface, which adapts `axios` HTTP response headers to headers expected by the iModels Client. */
+export class AxiosHeadersAdapter implements HttpResponseHeaders {
+  private _response: AxiosResponse;
+
+  constructor(response: AxiosResponse) {
+    this._response = response;
+  }
+
+  public get(headerName: string): unknown {
+    // Directly manipulating headers object is deprecated.
+    // https://github.com/axios/axios?tab=readme-ov-file#-axiosheaders
+    if (this._response.headers.get instanceof Function)
+      return this._response.headers.get(headerName);
+
+    // It's most likely that header name is lowercase.
+    // https://axios-http.com/docs/res_schema
+    return this._response.headers[headerName.toLowerCase()];
+  }
+
+  public getAll(): Dictionary<unknown> {
+    return this._response.headers;
   }
 }

--- a/clients/imodels-client-management/src/base/internal/AxiosRestClient.ts
+++ b/clients/imodels-client-management/src/base/internal/AxiosRestClient.ts
@@ -87,6 +87,7 @@ export class AxiosRestClient implements RestClient {
               return response.headers.get(headerName);
 
             // It's most likely that header name is lowercase.
+            // https://axios-http.com/docs/res_schema
             return response.headers[headerName.toLowerCase()];
           }
         }

--- a/clients/imodels-client-management/src/base/internal/AxiosRestClient.ts
+++ b/clients/imodels-client-management/src/base/internal/AxiosRestClient.ts
@@ -20,9 +20,9 @@ export class AxiosRestClient implements RestClient {
     this._parseErrorFunc = parseErrorFunc;
   }
 
-  public sendGetRequest<TData>(params: HttpGetRequestParams & { responseType: ContentType.Json }): Promise<HttpResponse<TData>>;
+  public sendGetRequest<TBody>(params: HttpGetRequestParams & { responseType: ContentType.Json }): Promise<HttpResponse<TBody>>;
   public sendGetRequest(params: HttpGetRequestParams & { responseType: ContentType.Png }): Promise<HttpResponse<Uint8Array>>;
-  public async sendGetRequest<TData>(params: HttpGetRequestParams): Promise<HttpResponse<TData | Uint8Array>> {
+  public async sendGetRequest<TBody>(params: HttpGetRequestParams): Promise<HttpResponse<TBody | Uint8Array>> {
     const requestConfig: AxiosRequestConfig = {
       headers: params.headers
     };
@@ -31,9 +31,9 @@ export class AxiosRestClient implements RestClient {
       requestConfig.responseType = "arraybuffer";
       const response = await this.executeRequest(async () => axios.get(params.url, requestConfig));
 
-      const data: Buffer | ArrayBuffer = response.data;
+      const data: Buffer | ArrayBuffer = response.body;
       if (data instanceof ArrayBuffer)
-        return { ...response, data: new Uint8Array(data) };
+        return { ...response, body: new Uint8Array(data) };
 
       return response;
     }
@@ -41,7 +41,7 @@ export class AxiosRestClient implements RestClient {
     return this.executeRequest(async () => axios.get(params.url, requestConfig));
   }
 
-  public async sendPostRequest<TData>(params: HttpRequestWithJsonBodyParams): Promise<HttpResponse<TData>> {
+  public async sendPostRequest<TBody>(params: HttpRequestWithJsonBodyParams): Promise<HttpResponse<TBody>> {
     const requestConfig: AxiosRequestConfig = {
       headers: params.headers
     };
@@ -49,7 +49,7 @@ export class AxiosRestClient implements RestClient {
     return this.executeRequest(async () => axios.post(params.url, params.body.content ?? {}, requestConfig));
   }
 
-  public async sendPutRequest<TData>(params: HttpRequestWithBinaryBodyParams): Promise<HttpResponse<TData>> {
+  public async sendPutRequest<TBody>(params: HttpRequestWithBinaryBodyParams): Promise<HttpResponse<TBody>> {
     const requestConfig: AxiosRequestConfig = {
       headers: params.headers
     };
@@ -57,7 +57,7 @@ export class AxiosRestClient implements RestClient {
     return this.executeRequest(async () => axios.put(params.url, params.body.content, requestConfig));
   }
 
-  public async sendPatchRequest<TData>(params: HttpRequestWithJsonBodyParams): Promise<HttpResponse<TData>> {
+  public async sendPatchRequest<TBody>(params: HttpRequestWithJsonBodyParams): Promise<HttpResponse<TBody>> {
     const requestConfig: AxiosRequestConfig = {
       headers: params.headers
     };
@@ -65,7 +65,7 @@ export class AxiosRestClient implements RestClient {
     return this.executeRequest(async () => axios.patch(params.url, params.body.content ?? {}, requestConfig));
   }
 
-  public async sendDeleteRequest<TData>(params: HttpRequestParams): Promise<HttpResponse<TData>> {
+  public async sendDeleteRequest<TBody>(params: HttpRequestParams): Promise<HttpResponse<TBody>> {
     const requestConfig: AxiosRequestConfig = {
       headers: params.headers
     };
@@ -73,12 +73,12 @@ export class AxiosRestClient implements RestClient {
     return this.executeRequest(async () => axios.delete(params.url, requestConfig));
   }
 
-  private async executeRequest<TData>(requestFunc: () => Promise<AxiosResponse<TData>>): Promise<HttpResponse<TData>> {
+  private async executeRequest<TBody>(requestFunc: () => Promise<AxiosResponse<TBody>>): Promise<HttpResponse<TBody>> {
     try {
       const response = await requestFunc();
 
       return {
-        data: response.data,
+        body: response.data,
         headers: {
           get: (headerName: string) => {
             // Directly manipulating headers object is deprecated.

--- a/clients/imodels-client-management/src/base/internal/OperationsBase.ts
+++ b/clients/imodels-client-management/src/base/internal/OperationsBase.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { Constants } from "../../Constants";
-import { AuthorizationParam, BinaryContentType, ContentType, Dictionary, HeaderFactories, HeadersParam, PreferReturn, RestClient, SupportedGetResponseTypes } from "../types";
+import { AuthorizationParam, BinaryContentType, ContentType, Dictionary, HeaderFactories, HeadersParam, HttpResponse, PreferReturn, RestClient, SupportedGetResponseTypes } from "../types";
 
 import { CollectionResponse } from "./ApiResponseInterfaces";
 import { EntityCollectionPage } from "./UtilityTypes";
@@ -24,9 +24,9 @@ export class OperationsBase<TOptions extends OperationsBaseOptions> {
   constructor(protected _options: TOptions) {
   }
 
-  protected async sendGetRequest<TResponse>(params: SendGetRequestParams & { responseType?: ContentType.Json }): Promise<TResponse>;
-  protected async sendGetRequest(params: SendGetRequestParams & { responseType: ContentType.Png }): Promise<Uint8Array>;
-  protected async sendGetRequest<TResponse>(params: SendGetRequestParams): Promise<TResponse | Uint8Array> {
+  protected async sendGetRequest<TData>(params: SendGetRequestParams & { responseType?: ContentType.Json }): Promise<HttpResponse<TData>>;
+  protected async sendGetRequest(params: SendGetRequestParams & { responseType: ContentType.Png }): Promise<HttpResponse<Uint8Array>>;
+  protected async sendGetRequest<TData>(params: SendGetRequestParams): Promise<HttpResponse<TData | Uint8Array>> {
     const urlAndHeaders = {
       url: params.url,
       headers: await this.formHeaders(params)
@@ -38,14 +38,14 @@ export class OperationsBase<TOptions extends OperationsBaseOptions> {
         ...urlAndHeaders
       });
 
-    return this._options.restClient.sendGetRequest<TResponse>({
+    return this._options.restClient.sendGetRequest<TData>({
       responseType: params.responseType ?? ContentType.Json,
       ...urlAndHeaders
     });
   }
 
-  protected async sendPostRequest<TResponse>(params: SendPostRequestParams): Promise<TResponse> {
-    return this._options.restClient.sendPostRequest<TResponse>({
+  protected async sendPostRequest<TData>(params: SendPostRequestParams): Promise<HttpResponse<TData>> {
+    return this._options.restClient.sendPostRequest<TData>({
       url: params.url,
       body: {
         contentType: ContentType.Json,
@@ -55,8 +55,8 @@ export class OperationsBase<TOptions extends OperationsBaseOptions> {
     });
   }
 
-  protected async sendPutRequest<TResponse>(params: SendPutRequestParams): Promise<TResponse> {
-    return this._options.restClient.sendPutRequest<TResponse>({
+  protected async sendPutRequest<TData>(params: SendPutRequestParams): Promise<HttpResponse<TData>> {
+    return this._options.restClient.sendPutRequest<TData>({
       url: params.url,
       body: {
         contentType: params.contentType,
@@ -66,8 +66,8 @@ export class OperationsBase<TOptions extends OperationsBaseOptions> {
     });
   }
 
-  protected async sendPatchRequest<TResponse>(params: SendPatchRequestParams): Promise<TResponse> {
-    return this._options.restClient.sendPatchRequest<TResponse>({
+  protected async sendPatchRequest<TData>(params: SendPatchRequestParams): Promise<HttpResponse<TData>> {
+    return this._options.restClient.sendPatchRequest<TData>({
       url: params.url,
       body: {
         contentType: ContentType.Json,
@@ -77,23 +77,23 @@ export class OperationsBase<TOptions extends OperationsBaseOptions> {
     });
   }
 
-  protected async sendDeleteRequest<TResponse>(params: SendDeleteRequestParams): Promise<TResponse> {
-    return this._options.restClient.sendDeleteRequest<TResponse>({
+  protected async sendDeleteRequest<TData>(params: SendDeleteRequestParams): Promise<HttpResponse<TData>> {
+    return this._options.restClient.sendDeleteRequest<TData>({
       url: params.url,
       headers: await this.formHeaders(params)
     });
   }
 
-  protected async getEntityCollectionPage<TEntity>(params: CommonRequestParams & {
+  protected async getEntityCollectionPage<TEntity, TResponse extends CollectionResponse>(params: CommonRequestParams & {
     url: string;
     preferReturn?: PreferReturn;
-    entityCollectionAccessor: (response: unknown) => TEntity[];
+    entityCollectionAccessor: (response: HttpResponse<TResponse>) => TEntity[];
   }): Promise<EntityCollectionPage<TEntity>> {
-    const response = await this.sendGetRequest<CollectionResponse>(params);
+    const response = await this.sendGetRequest<TResponse>(params);
     return {
       entities: params.entityCollectionAccessor(response),
-      next: response._links.next
-        ? async () => this.getEntityCollectionPage({ ...params, url: response._links.next!.href })
+      next: response.data._links.next
+        ? async () => this.getEntityCollectionPage({ ...params, url: response.data._links.next!.href })
         : undefined
     };
   }

--- a/clients/imodels-client-management/src/base/internal/OperationsBase.ts
+++ b/clients/imodels-client-management/src/base/internal/OperationsBase.ts
@@ -24,9 +24,9 @@ export class OperationsBase<TOptions extends OperationsBaseOptions> {
   constructor(protected _options: TOptions) {
   }
 
-  protected async sendGetRequest<TData>(params: SendGetRequestParams & { responseType?: ContentType.Json }): Promise<HttpResponse<TData>>;
+  protected async sendGetRequest<TBody>(params: SendGetRequestParams & { responseType?: ContentType.Json }): Promise<HttpResponse<TBody>>;
   protected async sendGetRequest(params: SendGetRequestParams & { responseType: ContentType.Png }): Promise<HttpResponse<Uint8Array>>;
-  protected async sendGetRequest<TData>(params: SendGetRequestParams): Promise<HttpResponse<TData | Uint8Array>> {
+  protected async sendGetRequest<TBody>(params: SendGetRequestParams): Promise<HttpResponse<TBody | Uint8Array>> {
     const urlAndHeaders = {
       url: params.url,
       headers: await this.formHeaders(params)
@@ -38,14 +38,14 @@ export class OperationsBase<TOptions extends OperationsBaseOptions> {
         ...urlAndHeaders
       });
 
-    return this._options.restClient.sendGetRequest<TData>({
+    return this._options.restClient.sendGetRequest<TBody>({
       responseType: params.responseType ?? ContentType.Json,
       ...urlAndHeaders
     });
   }
 
-  protected async sendPostRequest<TData>(params: SendPostRequestParams): Promise<HttpResponse<TData>> {
-    return this._options.restClient.sendPostRequest<TData>({
+  protected async sendPostRequest<TBody>(params: SendPostRequestParams): Promise<HttpResponse<TBody>> {
+    return this._options.restClient.sendPostRequest<TBody>({
       url: params.url,
       body: {
         contentType: ContentType.Json,
@@ -55,8 +55,8 @@ export class OperationsBase<TOptions extends OperationsBaseOptions> {
     });
   }
 
-  protected async sendPutRequest<TData>(params: SendPutRequestParams): Promise<HttpResponse<TData>> {
-    return this._options.restClient.sendPutRequest<TData>({
+  protected async sendPutRequest<TBody>(params: SendPutRequestParams): Promise<HttpResponse<TBody>> {
+    return this._options.restClient.sendPutRequest<TBody>({
       url: params.url,
       body: {
         contentType: params.contentType,
@@ -66,8 +66,8 @@ export class OperationsBase<TOptions extends OperationsBaseOptions> {
     });
   }
 
-  protected async sendPatchRequest<TData>(params: SendPatchRequestParams): Promise<HttpResponse<TData>> {
-    return this._options.restClient.sendPatchRequest<TData>({
+  protected async sendPatchRequest<TBody>(params: SendPatchRequestParams): Promise<HttpResponse<TBody>> {
+    return this._options.restClient.sendPatchRequest<TBody>({
       url: params.url,
       body: {
         contentType: ContentType.Json,
@@ -77,8 +77,8 @@ export class OperationsBase<TOptions extends OperationsBaseOptions> {
     });
   }
 
-  protected async sendDeleteRequest<TData>(params: SendDeleteRequestParams): Promise<HttpResponse<TData>> {
-    return this._options.restClient.sendDeleteRequest<TData>({
+  protected async sendDeleteRequest<TBody>(params: SendDeleteRequestParams): Promise<HttpResponse<TBody>> {
+    return this._options.restClient.sendDeleteRequest<TBody>({
       url: params.url,
       headers: await this.formHeaders(params)
     });
@@ -92,8 +92,8 @@ export class OperationsBase<TOptions extends OperationsBaseOptions> {
     const response = await this.sendGetRequest<TResponse>(params);
     return {
       entities: params.entityCollectionAccessor(response),
-      next: response.data._links.next
-        ? async () => this.getEntityCollectionPage({ ...params, url: response.data._links.next!.href })
+      next: response.body._links.next
+        ? async () => this.getEntityCollectionPage({ ...params, url: response.body._links.next!.href })
         : undefined
     };
   }

--- a/clients/imodels-client-management/src/base/types/IModelsErrorInterfaces.ts
+++ b/clients/imodels-client-management/src/base/types/IModelsErrorInterfaces.ts
@@ -48,6 +48,7 @@ export enum IModelsErrorCode {
   BaselineFileInitializationFailed = "BaselineFileInitializationFailed",
   BaselineFileInitializationTimedOut = "BaselineFileInitializationTimedOut",
   IModelFromTemplateInitializationFailed = "IModelFromTemplateInitializationFailed",
+  IModelFromTemplateInitializationTimedOut = "IModelFromTemplateInitializationTimedOut",
   ClonedIModelInitializationFailed = "ClonedIModelInitializationFailed",
   ClonedIModelInitializationTimedOut = "ClonedIModelInitializationTimedOut",
   ChangesetDownloadFailed = "ChangesetDownloadFailed",

--- a/clients/imodels-client-management/src/base/types/IModelsErrorInterfaces.ts
+++ b/clients/imodels-client-management/src/base/types/IModelsErrorInterfaces.ts
@@ -48,6 +48,8 @@ export enum IModelsErrorCode {
   BaselineFileInitializationFailed = "BaselineFileInitializationFailed",
   BaselineFileInitializationTimedOut = "BaselineFileInitializationTimedOut",
   IModelFromTemplateInitializationFailed = "IModelFromTemplateInitializationFailed",
+  ClonedIModelInitializationFailed = "ClonedIModelInitializationFailed",
+  ClonedIModelInitializationTimedOut = "ClonedIModelInitializationTimedOut",
   ChangesetDownloadFailed = "ChangesetDownloadFailed",
   DownloadAborted = "DownloadAborted"
 }

--- a/clients/imodels-client-management/src/base/types/RestClient.ts
+++ b/clients/imodels-client-management/src/base/types/RestClient.ts
@@ -50,9 +50,9 @@ export interface HttpResponseHeaders {
 }
 
 /** HTTP response. */
-export interface HttpResponse<TData> {
-  /** Response data that was provided by the server. */
-  data: TData;
+export interface HttpResponse<TBody> {
+  /** Response body that was provided by the server. */
+  body: TBody;
   /** Headers that the server responded with. */
   headers: HttpResponseHeaders;
 }
@@ -88,7 +88,7 @@ export interface RestClient {
    * @param {HttpGetRequestParams} params parameters for this operation. See {@link HttpGetRequestParams}.
    * @throws an error if the request fails.
    */
-  sendGetRequest<TData>(params: HttpGetRequestParams & { responseType: ContentType.Json }): Promise<HttpResponse<TData>>;
+  sendGetRequest<TBody>(params: HttpGetRequestParams & { responseType: ContentType.Json }): Promise<HttpResponse<TBody>>;
 
   /**
    * Sends GET HTTP request to get binary response.
@@ -102,26 +102,26 @@ export interface RestClient {
    * @param {HttpRequestWithBodyParams} params parameters for this operation. See {@link HttpRequestWithBodyParams}.
    * @throws an error if the request fails.
    */
-  sendPostRequest<TData>(params: HttpRequestWithJsonBodyParams): Promise<HttpResponse<TData>>;
+  sendPostRequest<TBody>(params: HttpRequestWithJsonBodyParams): Promise<HttpResponse<TBody>>;
 
   /**
    * Sends PUT HTTP request.
    * @param {HttpPutRequestParams} params parameters for this operation. See {@link HttpRequestWithBodyParams}.
    * @throws an error if the request fails.
    */
-  sendPutRequest<TData>(params: HttpRequestWithBinaryBodyParams): Promise<HttpResponse<TData>>;
+  sendPutRequest<TBody>(params: HttpRequestWithBinaryBodyParams): Promise<HttpResponse<TBody>>;
 
   /**
    * Sends PATCH HTTP request.
    * @param {HttpRequestWithBodyParams} params parameters for this operation. See {@link HttpRequestWithBodyParams}.
    * @throws an error if the request fails.
    */
-  sendPatchRequest<TData>(params: HttpRequestWithJsonBodyParams): Promise<HttpResponse<TData>>;
+  sendPatchRequest<TBody>(params: HttpRequestWithJsonBodyParams): Promise<HttpResponse<TBody>>;
 
   /**
    * Sends DELETE HTTP request.
    * @param {HttpRequestParams} params parameters for this operation. See {@link HttpRequestParams}.
    * @throws an error if the request fails.
    */
-  sendDeleteRequest<TData>(params: HttpRequestParams): Promise<HttpResponse<TData>>;
+  sendDeleteRequest<TBody>(params: HttpRequestParams): Promise<HttpResponse<TBody>>;
 }

--- a/clients/imodels-client-management/src/base/types/RestClient.ts
+++ b/clients/imodels-client-management/src/base/types/RestClient.ts
@@ -45,8 +45,13 @@ export interface HttpRequestParams {
 
 /** Abstraction for accessing HTTP response headers that the server responded with. */
 export interface HttpResponseHeaders {
-  /** Gets HTTP response header's value by the specified {@link headerName}. */
+  /**
+   * Gets HTTP response header's value by the specified {@link headerName}.
+   * It is expected that the header name matcher is case-insensitive.
+   */
   get(headerName: string): unknown;
+  /** Gets all HTTP response headers. */
+  getAll(): Dictionary<unknown>;
 }
 
 /** HTTP response. */

--- a/clients/imodels-client-management/src/base/types/RestClient.ts
+++ b/clients/imodels-client-management/src/base/types/RestClient.ts
@@ -43,6 +43,20 @@ export interface HttpRequestParams {
   headers: Dictionary<string>;
 }
 
+/** Abstraction for accessing HTTP response headers that the server responded with. */
+export interface HttpResponseHeaders {
+  /** Gets HTTP response header's value by the specified {@link headerName}. */
+  get(headerName: string): unknown;
+}
+
+/**  */
+export interface HttpResponse<TData> {
+  /** Response data that was provided by the server. */
+  data: TData;
+  /** Headers that the server responded with. */
+  headers: HttpResponseHeaders;
+}
+
 /** Common parameters for HTTP GET request operation. */
 export interface HttpGetRequestParams extends HttpRequestParams {
   /**
@@ -74,40 +88,40 @@ export interface RestClient {
    * @param {HttpGetRequestParams} params parameters for this operation. See {@link HttpGetRequestParams}.
    * @throws an error if the request fails.
    */
-  sendGetRequest<TResponse>(params: HttpGetRequestParams & { responseType: ContentType.Json }): Promise<TResponse>;
+  sendGetRequest<TData>(params: HttpGetRequestParams & { responseType: ContentType.Json }): Promise<HttpResponse<TData>>;
 
   /**
    * Sends GET HTTP request to get binary response.
    * @param {HttpGetRequestParams} params parameters for this operation. See {@link HttpGetRequestParams}.
    * @throws an error if the request fails.
    */
-  sendGetRequest(params: HttpGetRequestParams & { responseType: ContentType.Png }): Promise<Uint8Array>;
+  sendGetRequest(params: HttpGetRequestParams & { responseType: ContentType.Png }): Promise<HttpResponse<Uint8Array>>;
 
   /**
    * Sends POST HTTP request.
    * @param {HttpRequestWithBodyParams} params parameters for this operation. See {@link HttpRequestWithBodyParams}.
    * @throws an error if the request fails.
    */
-  sendPostRequest<TResponse>(params: HttpRequestWithJsonBodyParams): Promise<TResponse>;
+  sendPostRequest<TData>(params: HttpRequestWithJsonBodyParams): Promise<HttpResponse<TData>>;
 
   /**
    * Sends PUT HTTP request.
    * @param {HttpPutRequestParams} params parameters for this operation. See {@link HttpRequestWithBodyParams}.
    * @throws an error if the request fails.
    */
-  sendPutRequest<TResponse>(params: HttpRequestWithBinaryBodyParams): Promise<TResponse>;
+  sendPutRequest<TData>(params: HttpRequestWithBinaryBodyParams): Promise<HttpResponse<TData>>;
 
   /**
    * Sends PATCH HTTP request.
    * @param {HttpRequestWithBodyParams} params parameters for this operation. See {@link HttpRequestWithBodyParams}.
    * @throws an error if the request fails.
    */
-  sendPatchRequest<TResponse>(params: HttpRequestWithJsonBodyParams): Promise<TResponse>;
+  sendPatchRequest<TData>(params: HttpRequestWithJsonBodyParams): Promise<HttpResponse<TData>>;
 
   /**
    * Sends DELETE HTTP request.
    * @param {HttpRequestParams} params parameters for this operation. See {@link HttpRequestParams}.
    * @throws an error if the request fails.
    */
-  sendDeleteRequest<TResponse>(params: HttpRequestParams): Promise<TResponse>;
+  sendDeleteRequest<TData>(params: HttpRequestParams): Promise<HttpResponse<TData>>;
 }

--- a/clients/imodels-client-management/src/base/types/RestClient.ts
+++ b/clients/imodels-client-management/src/base/types/RestClient.ts
@@ -49,7 +49,7 @@ export interface HttpResponseHeaders {
   get(headerName: string): unknown;
 }
 
-/**  */
+/** HTTP response. */
 export interface HttpResponse<TData> {
   /** Response data that was provided by the server. */
   data: TData;

--- a/clients/imodels-client-management/src/operations/IModelsApiUrlFormatter.ts
+++ b/clients/imodels-client-management/src/operations/IModelsApiUrlFormatter.ts
@@ -28,12 +28,17 @@ export class IModelsApiUrlFormatter {
   private readonly _checkpointUrlRegex = new RegExp(`/iModels/(?<${this._groupNames.iModelId}>.*)/changesets/(?<${this._groupNames.changesetIdOrIndex}>.*)/checkpoint`, this._regexIgnoreCaseOption);
   private readonly _namedVersionUrlRegex = new RegExp(`/iModels/(?<${this._groupNames.iModelId}>.*)/namedversions/(?<${this._groupNames.namedVersionId}>[^/]*)`, this._regexIgnoreCaseOption);
   private readonly _userUrlRegex = new RegExp(`/iModels/(?<${this._groupNames.iModelId}>.*)/users/(?<${this._groupNames.userId}>[^/]*)`, this._regexIgnoreCaseOption);
+  private readonly _iModelUrlRegex = new RegExp(`/iModels/(?<${this._groupNames.iModelId}>[^/]*)`, this._regexIgnoreCaseOption);
 
   constructor(protected readonly baseUrl: string) {
   }
 
   public getCreateIModelUrl(): string {
     return this.baseUrl;
+  }
+
+  public getCloneIModelUrl(params: { iModelId: string }): string {
+    return `${this.baseUrl}/${params.iModelId}/clone`;
   }
 
   public getSingleIModelUrl(params: { iModelId: string }): string {
@@ -133,6 +138,13 @@ export class IModelsApiUrlFormatter {
     return {
       iModelId: matchedGroups[this._groupNames.iModelId],
       userId: matchedGroups[this._groupNames.userId]
+    };
+  }
+
+  public parseIModelUrl(url: string): { iModelId: string } {
+    const matchedGroups: Dictionary<string> = this._iModelUrlRegex.exec(url)!.groups!;
+    return {
+      iModelId: matchedGroups[this._groupNames.iModelId]
     };
   }
 

--- a/clients/imodels-client-management/src/operations/SharedFunctions.ts
+++ b/clients/imodels-client-management/src/operations/SharedFunctions.ts
@@ -26,3 +26,9 @@ export async function getUser(
     headers
   });
 }
+
+export function assertStringHeaderValue(headerName: string, headerValue: unknown): asserts headerValue is string {
+  const isString = typeof headerValue === "string" || headerValue instanceof String;
+  if (!isString)
+    throw new Error(`Assertion failed: header's ${headerName} value is not a string.`);
+}

--- a/clients/imodels-client-management/src/operations/briefcase/BriefcaseOperations.ts
+++ b/clients/imodels-client-management/src/operations/briefcase/BriefcaseOperations.ts
@@ -32,7 +32,7 @@ export class BriefcaseOperations<TOptions extends OperationOptions> extends Oper
       authorization: params.authorization,
       url: this._options.urlFormatter.getBriefcaseListUrl({ iModelId: params.iModelId, urlParams: params.urlParams }),
       preferReturn: PreferReturn.Minimal,
-      entityCollectionAccessor: (response) => response.data.briefcases,
+      entityCollectionAccessor: (response) => response.body.briefcases,
       headers: params.headers
     }));
   }
@@ -47,7 +47,7 @@ export class BriefcaseOperations<TOptions extends OperationOptions> extends Oper
    */
   public getRepresentationList(params: GetBriefcaseListParams): EntityListIterator<Briefcase> {
     const entityCollectionAccessor = (response: HttpResponse<BriefcasesResponse<Briefcase>>) => {
-      const briefcases = response.data.briefcases;
+      const briefcases = response.body.briefcases;
       const mappedBriefcases = briefcases.map((briefcase) => this.appendRelatedEntityCallbacks(params.authorization, briefcase, params.headers));
       return mappedBriefcases;
     };
@@ -74,7 +74,7 @@ export class BriefcaseOperations<TOptions extends OperationOptions> extends Oper
       url: this._options.urlFormatter.getSingleBriefcaseUrl({ iModelId: params.iModelId, briefcaseId: params.briefcaseId }),
       headers: params.headers
     });
-    const result: Briefcase = this.appendRelatedEntityCallbacks(params.authorization, response.data.briefcase, params.headers);
+    const result: Briefcase = this.appendRelatedEntityCallbacks(params.authorization, response.body.briefcase, params.headers);
     return result;
   }
 

--- a/clients/imodels-client-management/src/operations/briefcase/BriefcaseOperations.ts
+++ b/clients/imodels-client-management/src/operations/briefcase/BriefcaseOperations.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { BriefcaseResponse, BriefcasesResponse, EntityListIteratorImpl, OperationsBase } from "../../base/internal";
-import { AuthorizationCallback, Briefcase, EntityListIterator, HeaderFactories, MinimalBriefcase, PreferReturn } from "../../base/types";
+import { AuthorizationCallback, Briefcase, EntityListIterator, HeaderFactories, HttpResponse, MinimalBriefcase, PreferReturn } from "../../base/types";
 import { IModelsClient } from "../../IModelsClient";
 import { OperationOptions } from "../OperationOptions";
 import { getUser } from "../SharedFunctions";
@@ -28,11 +28,11 @@ export class BriefcaseOperations<TOptions extends OperationOptions> extends Oper
    * {@link MinimalBriefcase}.
    */
   public getMinimalList(params: GetBriefcaseListParams): EntityListIterator<MinimalBriefcase> {
-    return new EntityListIteratorImpl(async () => this.getEntityCollectionPage<MinimalBriefcase>({
+    return new EntityListIteratorImpl(async () => this.getEntityCollectionPage<MinimalBriefcase, BriefcasesResponse<MinimalBriefcase>>({
       authorization: params.authorization,
       url: this._options.urlFormatter.getBriefcaseListUrl({ iModelId: params.iModelId, urlParams: params.urlParams }),
       preferReturn: PreferReturn.Minimal,
-      entityCollectionAccessor: (response: unknown) => (response as BriefcasesResponse<MinimalBriefcase>).briefcases,
+      entityCollectionAccessor: (response) => response.data.briefcases,
       headers: params.headers
     }));
   }
@@ -46,13 +46,13 @@ export class BriefcaseOperations<TOptions extends OperationOptions> extends Oper
    * @returns {EntityListIterator<Briefcase>} iterator for Briefcase list. See {@link EntityListIterator}, {@link Briefcase}.
    */
   public getRepresentationList(params: GetBriefcaseListParams): EntityListIterator<Briefcase> {
-    const entityCollectionAccessor = (response: unknown) => {
-      const briefcases = (response as BriefcasesResponse<Briefcase>).briefcases;
+    const entityCollectionAccessor = (response: HttpResponse<BriefcasesResponse<Briefcase>>) => {
+      const briefcases = response.data.briefcases;
       const mappedBriefcases = briefcases.map((briefcase) => this.appendRelatedEntityCallbacks(params.authorization, briefcase, params.headers));
       return mappedBriefcases;
     };
 
-    return new EntityListIteratorImpl(async () => this.getEntityCollectionPage<Briefcase>({
+    return new EntityListIteratorImpl(async () => this.getEntityCollectionPage<Briefcase, BriefcasesResponse<Briefcase>>({
       authorization: params.authorization,
       url: this._options.urlFormatter.getBriefcaseListUrl({ iModelId: params.iModelId, urlParams: params.urlParams }),
       preferReturn: PreferReturn.Representation,
@@ -74,7 +74,7 @@ export class BriefcaseOperations<TOptions extends OperationOptions> extends Oper
       url: this._options.urlFormatter.getSingleBriefcaseUrl({ iModelId: params.iModelId, briefcaseId: params.briefcaseId }),
       headers: params.headers
     });
-    const result: Briefcase = this.appendRelatedEntityCallbacks(params.authorization, response.briefcase, params.headers);
+    const result: Briefcase = this.appendRelatedEntityCallbacks(params.authorization, response.data.briefcase, params.headers);
     return result;
   }
 

--- a/clients/imodels-client-management/src/operations/changeset-group/ChangesetGroupOperations.ts
+++ b/clients/imodels-client-management/src/operations/changeset-group/ChangesetGroupOperations.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { ChangesetGroupResponse, ChangesetGroupsResponse, EntityListIteratorImpl, OperationsBase } from "../../base/internal";
-import { AuthorizationCallback, EntityListIterator, HeaderFactories } from "../../base/types";
+import { AuthorizationCallback, EntityListIterator, HeaderFactories, HttpResponse } from "../../base/types";
 import { ChangesetGroup } from "../../base/types/apiEntities/ChangesetGroupInterfaces";
 import { IModelsClient } from "../../IModelsClient";
 import { OperationOptions } from "../OperationOptions";
@@ -28,14 +28,14 @@ export class ChangesetGroupOperations<TOptions extends OperationOptions> extends
    * See {@link EntityListIterator}, {@link ChangesetGroup}.
    */
   public getList(params: GetChangesetGroupListParams): EntityListIterator<ChangesetGroup> {
-    const entityCollectionAccessor = (response: unknown) => {
-      const changesetGroups = (response as ChangesetGroupsResponse).changesetGroups;
+    const entityCollectionAccessor = (response: HttpResponse<ChangesetGroupsResponse>) => {
+      const changesetGroups = response.data.changesetGroups;
       const mappedChangesetGroups = changesetGroups.map((changesetGroup) =>
         this.appendRelatedEntityCallbacks(params.authorization, changesetGroup, params.headers));
       return mappedChangesetGroups;
     };
 
-    return new EntityListIteratorImpl(async () => this.getEntityCollectionPage<ChangesetGroup>({
+    return new EntityListIteratorImpl(async () => this.getEntityCollectionPage<ChangesetGroup, ChangesetGroupsResponse>({
       authorization: params.authorization,
       url: this._options.urlFormatter.getChangesetGroupListUrl({ iModelId: params.iModelId, urlParams: params.urlParams }),
       entityCollectionAccessor,
@@ -59,7 +59,7 @@ export class ChangesetGroupOperations<TOptions extends OperationOptions> extends
 
     const result: ChangesetGroup = this.appendRelatedEntityCallbacks(
       params.authorization,
-      response.changesetGroup,
+      response.data.changesetGroup,
       params.headers
     );
 

--- a/clients/imodels-client-management/src/operations/changeset-group/ChangesetGroupOperations.ts
+++ b/clients/imodels-client-management/src/operations/changeset-group/ChangesetGroupOperations.ts
@@ -29,7 +29,7 @@ export class ChangesetGroupOperations<TOptions extends OperationOptions> extends
    */
   public getList(params: GetChangesetGroupListParams): EntityListIterator<ChangesetGroup> {
     const entityCollectionAccessor = (response: HttpResponse<ChangesetGroupsResponse>) => {
-      const changesetGroups = response.data.changesetGroups;
+      const changesetGroups = response.body.changesetGroups;
       const mappedChangesetGroups = changesetGroups.map((changesetGroup) =>
         this.appendRelatedEntityCallbacks(params.authorization, changesetGroup, params.headers));
       return mappedChangesetGroups;
@@ -59,7 +59,7 @@ export class ChangesetGroupOperations<TOptions extends OperationOptions> extends
 
     const result: ChangesetGroup = this.appendRelatedEntityCallbacks(
       params.authorization,
-      response.data.changesetGroup,
+      response.body.changesetGroup,
       params.headers
     );
 

--- a/clients/imodels-client-management/src/operations/changeset/ChangesetOperations.ts
+++ b/clients/imodels-client-management/src/operations/changeset/ChangesetOperations.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { ChangesetResponse, ChangesetsResponse, EntityListIteratorImpl, OperationsBase } from "../../base/internal";
-import { AuthorizationCallback, Changeset, Checkpoint, EntityListIterator, HeaderFactories, MinimalChangeset, NamedVersion, PreferReturn } from "../../base/types";
+import { AuthorizationCallback, Changeset, Checkpoint, EntityListIterator, HeaderFactories, HttpResponse, MinimalChangeset, NamedVersion, PreferReturn } from "../../base/types";
 import { IModelsClient } from "../../IModelsClient";
 import { OperationOptions } from "../OperationOptions";
 import { getUser } from "../SharedFunctions";
@@ -28,13 +28,13 @@ export class ChangesetOperations<TOptions extends OperationOptions> extends Oper
    * {@link MinimalChangeset}.
    */
   public getMinimalList(params: GetChangesetListParams): EntityListIterator<MinimalChangeset> {
-    const entityCollectionAccessor = (response: unknown) => {
-      const changesets = (response as ChangesetsResponse<MinimalChangeset>).changesets;
+    const entityCollectionAccessor = (response: HttpResponse<ChangesetsResponse<MinimalChangeset>>) => {
+      const changesets = response.data.changesets;
       const mappedChangesets = changesets.map((changeset) => this.appendRelatedMinimalEntityCallbacks(params.authorization, changeset, params.headers));
       return mappedChangesets;
     };
 
-    return new EntityListIteratorImpl(async () => this.getEntityCollectionPage<MinimalChangeset>({
+    return new EntityListIteratorImpl(async () => this.getEntityCollectionPage<MinimalChangeset, ChangesetsResponse<MinimalChangeset>>({
       authorization: params.authorization,
       url: this._options.urlFormatter.getChangesetListUrl({ iModelId: params.iModelId, urlParams: params.urlParams }),
       preferReturn: PreferReturn.Minimal,
@@ -53,13 +53,13 @@ export class ChangesetOperations<TOptions extends OperationOptions> extends Oper
    * {@link Changeset}.
    */
   public getRepresentationList(params: GetChangesetListParams): EntityListIterator<Changeset> {
-    const entityCollectionAccessor = (response: unknown) => {
-      const changesets = (response as ChangesetsResponse<Changeset>).changesets;
+    const entityCollectionAccessor = (response: HttpResponse<ChangesetsResponse<Changeset>>) => {
+      const changesets = response.data.changesets;
       const mappedChangesets = changesets.map((changeset) => this.appendRelatedEntityCallbacks(params.authorization, changeset, params.headers));
       return mappedChangesets;
     };
 
-    return new EntityListIteratorImpl(async () => this.getEntityCollectionPage<Changeset>({
+    return new EntityListIteratorImpl(async () => this.getEntityCollectionPage<Changeset, ChangesetsResponse<Changeset>>({
       authorization: params.authorization,
       url: this._options.urlFormatter.getChangesetListUrl({ iModelId: params.iModelId, urlParams: params.urlParams }),
       preferReturn: PreferReturn.Representation,
@@ -88,7 +88,7 @@ export class ChangesetOperations<TOptions extends OperationOptions> extends Oper
       url: this._options.urlFormatter.getSingleChangesetUrl({ iModelId, ...changesetIdOrIndex }),
       headers
     });
-    const result: Changeset = this.appendRelatedEntityCallbacks(params.authorization, response.changeset, params.headers);
+    const result: Changeset = this.appendRelatedEntityCallbacks(params.authorization, response.data.changeset, params.headers);
     return result;
   }
 

--- a/clients/imodels-client-management/src/operations/changeset/ChangesetOperations.ts
+++ b/clients/imodels-client-management/src/operations/changeset/ChangesetOperations.ts
@@ -29,7 +29,7 @@ export class ChangesetOperations<TOptions extends OperationOptions> extends Oper
    */
   public getMinimalList(params: GetChangesetListParams): EntityListIterator<MinimalChangeset> {
     const entityCollectionAccessor = (response: HttpResponse<ChangesetsResponse<MinimalChangeset>>) => {
-      const changesets = response.data.changesets;
+      const changesets = response.body.changesets;
       const mappedChangesets = changesets.map((changeset) => this.appendRelatedMinimalEntityCallbacks(params.authorization, changeset, params.headers));
       return mappedChangesets;
     };
@@ -54,7 +54,7 @@ export class ChangesetOperations<TOptions extends OperationOptions> extends Oper
    */
   public getRepresentationList(params: GetChangesetListParams): EntityListIterator<Changeset> {
     const entityCollectionAccessor = (response: HttpResponse<ChangesetsResponse<Changeset>>) => {
-      const changesets = response.data.changesets;
+      const changesets = response.body.changesets;
       const mappedChangesets = changesets.map((changeset) => this.appendRelatedEntityCallbacks(params.authorization, changeset, params.headers));
       return mappedChangesets;
     };
@@ -88,7 +88,7 @@ export class ChangesetOperations<TOptions extends OperationOptions> extends Oper
       url: this._options.urlFormatter.getSingleChangesetUrl({ iModelId, ...changesetIdOrIndex }),
       headers
     });
-    const result: Changeset = this.appendRelatedEntityCallbacks(params.authorization, response.data.changeset, params.headers);
+    const result: Changeset = this.appendRelatedEntityCallbacks(params.authorization, response.body.changeset, params.headers);
     return result;
   }
 

--- a/clients/imodels-client-management/src/operations/checkpoint/CheckpointOperations.ts
+++ b/clients/imodels-client-management/src/operations/checkpoint/CheckpointOperations.ts
@@ -25,6 +25,6 @@ export class CheckpointOperations<TOptions extends OperationOptions> extends Ope
       url: this._options.urlFormatter.getCheckpointUrl({ iModelId, ...parentEntityId }),
       headers
     });
-    return response.data.checkpoint;
+    return response.body.checkpoint;
   }
 }

--- a/clients/imodels-client-management/src/operations/checkpoint/CheckpointOperations.ts
+++ b/clients/imodels-client-management/src/operations/checkpoint/CheckpointOperations.ts
@@ -25,6 +25,6 @@ export class CheckpointOperations<TOptions extends OperationOptions> extends Ope
       url: this._options.urlFormatter.getCheckpointUrl({ iModelId, ...parentEntityId }),
       headers
     });
-    return response.checkpoint;
+    return response.data.checkpoint;
   }
 }

--- a/clients/imodels-client-management/src/operations/imodel/IModelOperationParams.ts
+++ b/clients/imodels-client-management/src/operations/imodel/IModelOperationParams.ts
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { AtLeastOneProperty, AuthorizationParam, CollectionRequestParams, Extent, HeadersParam, IModel, IModelScopedOperationParams, OrderBy } from "../../base/types";
+import { ChangesetIdOrIndex } from "../OperationParamExports";
 
 /**
  * iModel entity properties that are supported in $orderBy url parameter which specifies by what property
@@ -74,6 +75,32 @@ export interface IModelPropertiesForCreateFromTemplate extends IModelProperties 
 export interface CreateIModelFromTemplateParams extends AuthorizationParam, HeadersParam {
   /** Properties of the new iModel. See {@link IModelPropertiesForCreateFromTemplate}. */
   iModelProperties: IModelPropertiesForCreateFromTemplate;
+  /** Time period to wait until the iModel is initialized. Default value is 300,000 ms (5 minutes). */
+  timeOutInMs?: number;
+}
+
+/** Base properties for clone iModel operation. */
+interface IModelPropertiesForCloneBase {
+  /** Id of the iTwin in which the new iModel will be created. */
+  iTwinId: string;
+  /** Name of the new iModel that will be created. If name is not provided, original iModel name will be used. */
+  name?: string;
+  /** Description of the new iModel that will be created. If description is not provided, original iModel description will be used. */
+  description?: string;
+}
+
+/**
+ * Properties that should be specified when cloning an iModel.
+ * - The provided `changesetId` or `changesetIndex` specifies the latest source iModel Changeset that should be copied to the target iModel.
+ * - If neither `changesetId` nor `changesetIndex` is provided, all existing source iModel Changesets are copied to the target iModel.
+ * - If `changesetId: ""` or `changesetIndex: 0` is provided, no Changesets are copied to the target iModel, only the source iModel's Baseline.
+ */
+export type IModelPropertiesForClone = IModelPropertiesForCloneBase & Partial<ChangesetIdOrIndex>;
+
+/** Parameters for clone iModel operation. */
+export interface CloneIModelParams extends IModelScopedOperationParams, HeadersParam {
+  /** Properties of the new iModel. See {@link IModelPropertiesForClone}. */
+  iModelProperties: IModelPropertiesForClone;
   /** Time period to wait until the iModel is initialized. Default value is 300,000 ms (5 minutes). */
   timeOutInMs?: number;
 }

--- a/clients/imodels-client-management/src/operations/imodel/IModelOperations.ts
+++ b/clients/imodels-client-management/src/operations/imodel/IModelOperations.ts
@@ -292,7 +292,7 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
         headers: params.headers
       }),
       timeoutErrorFactory: () => new IModelsErrorImpl({
-        code: IModelsErrorCode.IModelFromTemplateInitializationFailed,
+        code: IModelsErrorCode.IModelFromTemplateInitializationTimedOut,
         message: "Timed out waiting for Baseline File initialization."
       }),
       timeOutInMs: params.timeOutInMs

--- a/clients/imodels-client-management/src/operations/imodel/IModelOperations.ts
+++ b/clients/imodels-client-management/src/operations/imodel/IModelOperations.ts
@@ -3,11 +3,13 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { EntityListIteratorImpl, IModelResponse, IModelsErrorImpl, IModelsResponse, OperationsBase, waitForCondition } from "../../base/internal";
-import { AuthorizationCallback, EntityListIterator, HeaderFactories, IModel, IModelState, IModelsErrorCode, MinimalIModel, PreferReturn, User } from "../../base/types";
+import { AuthorizationCallback, EntityListIterator, HeaderFactories, HttpResponse, IModel, IModelCreationState, IModelsErrorCode, MinimalIModel, PreferReturn, User } from "../../base/types";
+import { Constants } from "../../Constants";
 import { IModelsClient } from "../../IModelsClient";
 import { OperationOptions } from "../OperationOptions";
+import { assertStringHeaderValue } from "../SharedFunctions";
 
-import { CreateEmptyIModelParams, CreateIModelFromTemplateParams, DeleteIModelParams, GetIModelListParams, GetSingleIModelParams, IModelProperties, IModelPropertiesForCreateFromTemplate, IModelPropertiesForUpdate, UpdateIModelParams } from "./IModelOperationParams";
+import { CloneIModelParams, CreateEmptyIModelParams, CreateIModelFromTemplateParams, DeleteIModelParams, GetIModelListParams, GetSingleIModelParams, IModelProperties, IModelPropertiesForClone, IModelPropertiesForCreateFromTemplate, IModelPropertiesForUpdate, UpdateIModelParams } from "./IModelOperationParams";
 
 export class IModelOperations<TOptions extends OperationOptions> extends OperationsBase<TOptions> {
   constructor(
@@ -20,15 +22,15 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
    * Gets iModels for a specific iTwin. This method returns iModels in their minimal representation. The returned iterator
    * internally queries entities in pages. Wraps the {@link https://developer.bentley.com/apis/imodels-v2/operations/get-itwin-imodels/ Get iTwin iModels}
    * operation from iModels API.
-   * @param {GetiModelListParams} params parameters for this operation. See {@link GetiModelListParams}.
-   * @returns {EntityListIterator<MinimaliModel>} iterator for iModel list. See {@link EntityListIterator}, {@link MinimaliModel}.
+   * @param {GetIModelListParams} params parameters for this operation. See {@link GetIModelListParams}.
+   * @returns {EntityListIterator<MinimalIModel>} iterator for iModel list. See {@link EntityListIterator}, {@link MinimalIModel}.
    */
   public getMinimalList(params: GetIModelListParams): EntityListIterator<MinimalIModel> {
-    return new EntityListIteratorImpl(async () => this.getEntityCollectionPage<MinimalIModel>({
+    return new EntityListIteratorImpl(async () => this.getEntityCollectionPage<MinimalIModel, IModelsResponse<MinimalIModel>>({
       authorization: params.authorization,
       url: this._options.urlFormatter.getIModelListUrl({ urlParams: params.urlParams }),
       preferReturn: PreferReturn.Minimal,
-      entityCollectionAccessor: (response: unknown) => (response as IModelsResponse<MinimalIModel>).iModels,
+      entityCollectionAccessor: (response) => response.data.iModels,
       headers: params.headers
     }));
   }
@@ -37,17 +39,17 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
    * Gets iModels for a specific iTwin. This method returns iModels in their full representation. The returned iterator
    * internally queries entities in pages. Wraps the {@link https://developer.bentley.com/apis/imodels-v2/operations/get-itwin-imodels/ Get iTwin iModels}
    * operation from iModels API.
-   * @param {GetiModelListParams} params parameters for this operation. See {@link GetiModelListParams}.
-   * @returns {EntityListIterator<iModel>} iterator for iModel list. See {@link EntityListIterator}, {@link iModel}.
+   * @param {GetIModelListParams} params parameters for this operation. See {@link GetIModelListParams}.
+   * @returns {EntityListIterator<IModel>} iterator for iModel list. See {@link EntityListIterator}, {@link IModel}.
    */
   public getRepresentationList(params: GetIModelListParams): EntityListIterator<IModel> {
-    const entityCollectionAccessor = (response: unknown) => {
-      const iModels = (response as IModelsResponse<IModel>).iModels;
+    const entityCollectionAccessor = (response: HttpResponse<IModelsResponse<IModel>>) => {
+      const iModels = response.data.iModels;
       const mappedIModels = iModels.map((iModel) => this.appendRelatedEntityCallbacks(params.authorization, iModel, params.headers));
       return mappedIModels;
     };
 
-    return new EntityListIteratorImpl(async () => this.getEntityCollectionPage<IModel>({
+    return new EntityListIteratorImpl(async () => this.getEntityCollectionPage<IModel, IModelsResponse<IModel>>({
       authorization: params.authorization,
       url: this._options.urlFormatter.getIModelListUrl({ urlParams: params.urlParams }),
       preferReturn: PreferReturn.Representation,
@@ -59,8 +61,8 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
   /**
    * Gets a single iModel by its id. This method returns an iModel in its full representation. Wraps the
    * {@link https://developer.bentley.com/apis/imodels-v2/operations/get-imodel-details/ Get iModel} operation from iModels API.
-   * @param {GetSingleiModelParams} params parameters for this operation. See {@link GetSingleiModelParams}.
-   * @returns {Promise<iModel>} an iModel with specified id. See {@link iModel}.
+   * @param {GetSingleIModelParams} params parameters for this operation. See {@link GetSingleIModelParams}.
+   * @returns {Promise<iModel>} an iModel with specified id. See {@link IModel}.
    */
   public async getSingle(params: GetSingleIModelParams): Promise<IModel> {
     const response = await this.sendGetRequest<IModelResponse>({
@@ -68,15 +70,15 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
       url: this._options.urlFormatter.getSingleIModelUrl({ iModelId: params.iModelId }),
       headers: params.headers
     });
-    const result: IModel = this.appendRelatedEntityCallbacks(params.authorization, response.iModel, params.headers);
+    const result: IModel = this.appendRelatedEntityCallbacks(params.authorization, response.data.iModel, params.headers);
     return result;
   }
 
   /**
    * Creates an empty iModel with specified properties. Wraps the
    * {@link https://developer.bentley.com/apis/imodels-v2/operations/create-imodel/ Create iModel} operation from iModels API.
-   * @param {CreateEmptyiModelParams} params parameters for this operation. See {@link CreateEmptyiModelParams}.
-   * @returns {Promise<iModel>} newly created iModel. See {@link iModel}.
+   * @param {CreateEmptyIModelParams} params parameters for this operation. See {@link CreateEmptyIModelParams}.
+   * @returns {Promise<iModel>} newly created iModel. See {@link IModel}.
    */
   public async createEmpty(params: CreateEmptyIModelParams): Promise<IModel> {
     const createIModelBody = this.getCreateEmptyIModelRequestBody(params.iModelProperties);
@@ -92,9 +94,9 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
    * this method creates the iModel instance and then repeatedly queries the iModel state until the iModel is initialized.
    * The execution of this method can take up to several minutes due to waiting for initialization to complete.
    * @param {CreateIModelFromTemplateParams} params parameters for this operation. See {@link CreateIModelFromTemplateParams}.
-   * @returns {Promise<iModel>} newly created iModel. See {@link iModel}.
-   * @throws an error that implements `iModelsError` interface with code `iModelsErrorCode.IModelFromTemplateInitializationFailed`
-   * if iModel initialization failed or did not complete in time. See {@link iModelsErrorCode}.
+   * @returns {Promise<iModel>} newly created iModel. See {@link IModel}.
+   * @throws an error that implements `iModelsError` interface with code {@link IModelsErrorCode.IModelFromTemplateInitializationFailed} if
+   * iModel initialization failed or did not complete in time. See {@link IModelsErrorCode}.
    */
   public async createFromTemplate(params: CreateIModelFromTemplateParams): Promise<IModel> {
     const createIModelBody = this.getCreateIModelFromTemplateRequestBody(params.iModelProperties);
@@ -115,6 +117,41 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
   }
 
   /**
+   * Clones the specified iModel. Wraps the
+   * {@link https://developer.bentley.com/apis/imodels-v2/operations/clone-imodel/ Clone iModel} operation from iModels API.
+   * Internally this method clones the iModel and then repeatedly queries the new iModel's state until it is initialized.
+   * The execution of this method can take up to several minutes due to waiting for initialization to complete.
+   * @param {CloneIModelParams} params parameters for this operation. See {@link CloneIModelParams}.
+   * @returns {Promise<IModel>} newly created iModel. See {@link IModel}.
+   * @throws an error that implements `iModelsError` interface with code {@link IModelsErrorCode.ClonedIModelInitializationFailed} if
+   * iModel initialization failed or {@link IModelsErrorCode.ClonedIModelInitializationTimedOut} if operation did not complete in time.
+   * See {@link IModelsErrorCode}.
+   */
+  public async clone(params: CloneIModelParams): Promise<IModel> {
+    const cloneIModelBody = this.getCloneIModelRequestBody(params.iModelProperties);
+    const cloneIModelResponse = await this.sendPostRequest<void>({
+      authorization: params.authorization,
+      url: this._options.urlFormatter.getCloneIModelUrl({ iModelId: params.iModelId }),
+      body: cloneIModelBody,
+      headers: params.headers
+    });
+
+    const locationHeaderValue = cloneIModelResponse.headers.get(Constants.headers.location);
+    assertStringHeaderValue(Constants.headers.location, locationHeaderValue);
+    const { iModelId: clonedIModelId } = this._options.urlFormatter.parseIModelUrl(locationHeaderValue);
+
+    await this.waitForClonedIModelInitialization({
+      authorization: params.authorization,
+      iModelId: clonedIModelId
+    });
+
+    return this.getSingle({
+      authorization: params.authorization,
+      iModelId: clonedIModelId
+    });
+  }
+
+  /**
    * Updates iModel properties. Wraps the
    * {@link https://developer.bentley.com/apis/imodels-v2/operations/update-imodel/ Update iModel} operation from iModels API.
    * @param {UpdateIModelParams} params parameters for this operation. See {@link UpdateIModelParams}.
@@ -128,18 +165,18 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
       body: updateIModelBody,
       headers: params.headers
     });
-    const result: IModel = this.appendRelatedEntityCallbacks(params.authorization, updateIModelResponse.iModel, params.headers);
+    const result: IModel = this.appendRelatedEntityCallbacks(params.authorization, updateIModelResponse.data.iModel, params.headers);
     return result;
   }
 
   /**
    * Deletes an iModel with specified id. Wraps the {@link https://developer.bentley.com/apis/imodels-v2/operations/delete-imodel/ Delete iModel}
    * operation from iModels API.
-   * @param {DeleteiModelParams} params parameters for this operation. See {@link DeleteiModelParams}.
+   * @param {DeleteIModelParams} params parameters for this operation. See {@link DeleteIModelParams}.
    * @returns {Promise<void>} a promise that resolves after operation completes.
    */
   public async delete(params: DeleteIModelParams): Promise<void> {
-    return this.sendDeleteRequest({
+    await this.sendDeleteRequest({
       authorization: params.authorization,
       url: this._options.urlFormatter.getSingleIModelUrl({ iModelId: params.iModelId }),
       headers: params.headers
@@ -173,7 +210,7 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
       body: createIModelBody,
       headers
     });
-    return createIModelResponse.iModel;
+    return createIModelResponse.data.iModel;
   }
 
   private async getCreator(authorization: AuthorizationCallback, creatorLink: string | undefined, headers?: HeaderFactories): Promise<User | undefined> {
@@ -199,6 +236,16 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
     };
   }
 
+  private getCloneIModelRequestBody(iModelProperties: IModelPropertiesForClone): object {
+    return {
+      iTwinId: iModelProperties.iTwinId,
+      name: iModelProperties.name,
+      description: iModelProperties.description,
+      changesetId: iModelProperties.changesetId,
+      changesetIndex: iModelProperties.changesetIndex
+    };
+  }
+
   private getUpdateIModelRequestBody(iModelProperties: IModelPropertiesForUpdate): object {
     return {
       name: iModelProperties.name,
@@ -207,26 +254,67 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
     };
   }
 
+  private async isIModelInitialized(params: {
+    authorization: AuthorizationCallback;
+    iModelId: string;
+    errorCodeOnFailure: IModelsErrorCode;
+    headers?: HeaderFactories;
+  }): Promise<boolean> {
+    const { state } = await this._iModelsClient.operations.getCreateIModelDetails({
+      authorization: params.authorization,
+      iModelId: params.iModelId,
+      headers: params.headers
+    });
+
+    if (state !== IModelCreationState.Scheduled &&
+      state !== IModelCreationState.WaitingForFile &&
+      state !== IModelCreationState.Successful
+    )
+      throw new IModelsErrorImpl({
+        code: params.errorCodeOnFailure,
+        message: `iModel initialization failed with state '${state}'`
+      });
+
+    return state === IModelCreationState.Successful;
+  }
+
   private async waitForTemplatedIModelInitialization(params: {
     authorization: AuthorizationCallback;
     iModelId: string;
     timeOutInMs?: number;
     headers?: HeaderFactories;
   }): Promise<void> {
-    const isIModelInitialized: () => Promise<boolean> = async () => {
-      const iModel: IModel = await this.getSingle({
+    return waitForCondition({
+      conditionToSatisfy: async () => this.isIModelInitialized({
         authorization: params.authorization,
         iModelId: params.iModelId,
+        errorCodeOnFailure: IModelsErrorCode.IModelFromTemplateInitializationFailed,
         headers: params.headers
-      });
-      return iModel.state === IModelState.Initialized;
-    };
-
-    return waitForCondition({
-      conditionToSatisfy: isIModelInitialized,
+      }),
       timeoutErrorFactory: () => new IModelsErrorImpl({
         code: IModelsErrorCode.IModelFromTemplateInitializationFailed,
         message: "Timed out waiting for Baseline File initialization."
+      }),
+      timeOutInMs: params.timeOutInMs
+    });
+  }
+
+  private async waitForClonedIModelInitialization(params: {
+    authorization: AuthorizationCallback;
+    iModelId: string;
+    timeOutInMs?: number;
+    headers?: HeaderFactories;
+  }): Promise<void> {
+    return waitForCondition({
+      conditionToSatisfy: async () => this.isIModelInitialized({
+        authorization: params.authorization,
+        iModelId: params.iModelId,
+        errorCodeOnFailure: IModelsErrorCode.ClonedIModelInitializationFailed,
+        headers: params.headers
+      }),
+      timeoutErrorFactory: () => new IModelsErrorImpl({
+        code: IModelsErrorCode.ClonedIModelInitializationTimedOut,
+        message: "Timed out waiting for Cloned iModel initialization."
       }),
       timeOutInMs: params.timeOutInMs
     });

--- a/clients/imodels-client-management/src/operations/imodel/IModelOperations.ts
+++ b/clients/imodels-client-management/src/operations/imodel/IModelOperations.ts
@@ -30,7 +30,7 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
       authorization: params.authorization,
       url: this._options.urlFormatter.getIModelListUrl({ urlParams: params.urlParams }),
       preferReturn: PreferReturn.Minimal,
-      entityCollectionAccessor: (response) => response.data.iModels,
+      entityCollectionAccessor: (response) => response.body.iModels,
       headers: params.headers
     }));
   }
@@ -44,7 +44,7 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
    */
   public getRepresentationList(params: GetIModelListParams): EntityListIterator<IModel> {
     const entityCollectionAccessor = (response: HttpResponse<IModelsResponse<IModel>>) => {
-      const iModels = response.data.iModels;
+      const iModels = response.body.iModels;
       const mappedIModels = iModels.map((iModel) => this.appendRelatedEntityCallbacks(params.authorization, iModel, params.headers));
       return mappedIModels;
     };
@@ -70,7 +70,7 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
       url: this._options.urlFormatter.getSingleIModelUrl({ iModelId: params.iModelId }),
       headers: params.headers
     });
-    const result: IModel = this.appendRelatedEntityCallbacks(params.authorization, response.data.iModel, params.headers);
+    const result: IModel = this.appendRelatedEntityCallbacks(params.authorization, response.body.iModel, params.headers);
     return result;
   }
 
@@ -165,7 +165,7 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
       body: updateIModelBody,
       headers: params.headers
     });
-    const result: IModel = this.appendRelatedEntityCallbacks(params.authorization, updateIModelResponse.data.iModel, params.headers);
+    const result: IModel = this.appendRelatedEntityCallbacks(params.authorization, updateIModelResponse.body.iModel, params.headers);
     return result;
   }
 
@@ -210,7 +210,7 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
       body: createIModelBody,
       headers
     });
-    return createIModelResponse.data.iModel;
+    return createIModelResponse.body.iModel;
   }
 
   private async getCreator(authorization: AuthorizationCallback, creatorLink: string | undefined, headers?: HeaderFactories): Promise<User | undefined> {

--- a/clients/imodels-client-management/src/operations/named-version/NamedVersionOperations.ts
+++ b/clients/imodels-client-management/src/operations/named-version/NamedVersionOperations.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { EntityListIteratorImpl, NamedVersionResponse, NamedVersionsResponse, OperationsBase } from "../../base/internal";
-import { AuthorizationCallback, Changeset, EntityListIterator, HeaderFactories, MinimalNamedVersion, NamedVersion, PreferReturn } from "../../base/types";
+import { AuthorizationCallback, Changeset, EntityListIterator, HeaderFactories, HttpResponse, MinimalNamedVersion, NamedVersion, PreferReturn } from "../../base/types";
 import { IModelsClient } from "../../IModelsClient";
 import { OperationOptions } from "../OperationOptions";
 import { getUser } from "../SharedFunctions";
@@ -28,11 +28,11 @@ export class NamedVersionOperations<TOptions extends OperationOptions> extends O
    * {@link MinimalNamedVersion}.
    */
   public getMinimalList(params: GetNamedVersionListParams): EntityListIterator<MinimalNamedVersion> {
-    return new EntityListIteratorImpl(async () => this.getEntityCollectionPage<MinimalNamedVersion>({
+    return new EntityListIteratorImpl(async () => this.getEntityCollectionPage<MinimalNamedVersion, NamedVersionsResponse<MinimalNamedVersion>>({
       authorization: params.authorization,
       url: this._options.urlFormatter.getNamedVersionListUrl({ iModelId: params.iModelId, urlParams: params.urlParams }),
       preferReturn: PreferReturn.Minimal,
-      entityCollectionAccessor: (response: unknown) => (response as NamedVersionsResponse<MinimalNamedVersion>).namedVersions,
+      entityCollectionAccessor: (response) => response.data.namedVersions,
       headers: params.headers
     }));
   }
@@ -47,13 +47,13 @@ export class NamedVersionOperations<TOptions extends OperationOptions> extends O
    * {@link NamedVersion}.
    */
   public getRepresentationList(params: GetNamedVersionListParams): EntityListIterator<NamedVersion> {
-    const entityCollectionAccessor = (response: unknown) => {
-      const namedVersions = (response as NamedVersionsResponse<NamedVersion>).namedVersions;
+    const entityCollectionAccessor = (response: HttpResponse<NamedVersionsResponse<NamedVersion>>) => {
+      const namedVersions = response.data.namedVersions;
       const mappedNamedVersions = namedVersions.map((namedVersion) => this.appendRelatedEntityCallbacks(params.authorization, namedVersion, params.headers));
       return mappedNamedVersions;
     };
 
-    return new EntityListIteratorImpl(async () => this.getEntityCollectionPage<NamedVersion>({
+    return new EntityListIteratorImpl(async () => this.getEntityCollectionPage<NamedVersion, NamedVersionsResponse<NamedVersion>>({
       authorization: params.authorization,
       url: this._options.urlFormatter.getNamedVersionListUrl({ iModelId: params.iModelId, urlParams: params.urlParams }),
       preferReturn: PreferReturn.Representation,
@@ -75,7 +75,7 @@ export class NamedVersionOperations<TOptions extends OperationOptions> extends O
       url: this._options.urlFormatter.getSingleNamedVersionUrl({ iModelId: params.iModelId, namedVersionId: params.namedVersionId }),
       headers: params.headers
     });
-    const result: NamedVersion = this.appendRelatedEntityCallbacks(params.authorization, response.namedVersion, params.headers);
+    const result: NamedVersion = this.appendRelatedEntityCallbacks(params.authorization, response.data.namedVersion, params.headers);
     return result;
   }
 
@@ -94,7 +94,7 @@ export class NamedVersionOperations<TOptions extends OperationOptions> extends O
       body: createNamedVersionBody,
       headers: params.headers
     });
-    const result: NamedVersion = this.appendRelatedEntityCallbacks(params.authorization, createNamedVersionResponse.namedVersion, params.headers);
+    const result: NamedVersion = this.appendRelatedEntityCallbacks(params.authorization, createNamedVersionResponse.data.namedVersion, params.headers);
     return result;
   }
 
@@ -113,7 +113,7 @@ export class NamedVersionOperations<TOptions extends OperationOptions> extends O
       body: updateNamedVersionBody,
       headers: params.headers
     });
-    const result: NamedVersion = this.appendRelatedEntityCallbacks(params.authorization, updateNamedVersionResponse.namedVersion, params.headers);
+    const result: NamedVersion = this.appendRelatedEntityCallbacks(params.authorization, updateNamedVersionResponse.data.namedVersion, params.headers);
     return result;
   }
 

--- a/clients/imodels-client-management/src/operations/named-version/NamedVersionOperations.ts
+++ b/clients/imodels-client-management/src/operations/named-version/NamedVersionOperations.ts
@@ -32,7 +32,7 @@ export class NamedVersionOperations<TOptions extends OperationOptions> extends O
       authorization: params.authorization,
       url: this._options.urlFormatter.getNamedVersionListUrl({ iModelId: params.iModelId, urlParams: params.urlParams }),
       preferReturn: PreferReturn.Minimal,
-      entityCollectionAccessor: (response) => response.data.namedVersions,
+      entityCollectionAccessor: (response) => response.body.namedVersions,
       headers: params.headers
     }));
   }
@@ -48,7 +48,7 @@ export class NamedVersionOperations<TOptions extends OperationOptions> extends O
    */
   public getRepresentationList(params: GetNamedVersionListParams): EntityListIterator<NamedVersion> {
     const entityCollectionAccessor = (response: HttpResponse<NamedVersionsResponse<NamedVersion>>) => {
-      const namedVersions = response.data.namedVersions;
+      const namedVersions = response.body.namedVersions;
       const mappedNamedVersions = namedVersions.map((namedVersion) => this.appendRelatedEntityCallbacks(params.authorization, namedVersion, params.headers));
       return mappedNamedVersions;
     };
@@ -75,7 +75,7 @@ export class NamedVersionOperations<TOptions extends OperationOptions> extends O
       url: this._options.urlFormatter.getSingleNamedVersionUrl({ iModelId: params.iModelId, namedVersionId: params.namedVersionId }),
       headers: params.headers
     });
-    const result: NamedVersion = this.appendRelatedEntityCallbacks(params.authorization, response.data.namedVersion, params.headers);
+    const result: NamedVersion = this.appendRelatedEntityCallbacks(params.authorization, response.body.namedVersion, params.headers);
     return result;
   }
 
@@ -94,7 +94,7 @@ export class NamedVersionOperations<TOptions extends OperationOptions> extends O
       body: createNamedVersionBody,
       headers: params.headers
     });
-    const result: NamedVersion = this.appendRelatedEntityCallbacks(params.authorization, createNamedVersionResponse.data.namedVersion, params.headers);
+    const result: NamedVersion = this.appendRelatedEntityCallbacks(params.authorization, createNamedVersionResponse.body.namedVersion, params.headers);
     return result;
   }
 
@@ -113,7 +113,7 @@ export class NamedVersionOperations<TOptions extends OperationOptions> extends O
       body: updateNamedVersionBody,
       headers: params.headers
     });
-    const result: NamedVersion = this.appendRelatedEntityCallbacks(params.authorization, updateNamedVersionResponse.data.namedVersion, params.headers);
+    const result: NamedVersion = this.appendRelatedEntityCallbacks(params.authorization, updateNamedVersionResponse.body.namedVersion, params.headers);
     return result;
   }
 

--- a/clients/imodels-client-management/src/operations/operation/OperationOperations.ts
+++ b/clients/imodels-client-management/src/operations/operation/OperationOperations.ts
@@ -26,6 +26,6 @@ export class OperationOperations<TOptions extends OperationOptions> extends Oper
       url: this._options.urlFormatter.getCreateIModelOperationDetailsUrl({ iModelId: params.iModelId }),
       headers: params.headers
     });
-    return response.createOperation;
+    return response.data.createOperation;
   }
 }

--- a/clients/imodels-client-management/src/operations/operation/OperationOperations.ts
+++ b/clients/imodels-client-management/src/operations/operation/OperationOperations.ts
@@ -26,6 +26,6 @@ export class OperationOperations<TOptions extends OperationOptions> extends Oper
       url: this._options.urlFormatter.getCreateIModelOperationDetailsUrl({ iModelId: params.iModelId }),
       headers: params.headers
     });
-    return response.data.createOperation;
+    return response.body.createOperation;
   }
 }

--- a/clients/imodels-client-management/src/operations/thumbnail/ThumbnailOperations.ts
+++ b/clients/imodels-client-management/src/operations/thumbnail/ThumbnailOperations.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { OperationsBase } from "../../base/internal";
-import { ContentType, Thumbnail, ThumbnailSize } from "../../base/types";
+import { ContentType, HttpResponse, Thumbnail, ThumbnailSize } from "../../base/types";
 import { OperationOptions } from "../OperationOptions";
 
 import { DownloadThumbnailParams, UploadThumbnailParams } from "./ThumbnailOperationParams";
@@ -32,7 +32,7 @@ export class ThumbnailOperations<TOptions extends OperationOptions> extends Oper
       size: params.urlParams?.size ?? ThumbnailSize.Small
     };
     const url = this._options.urlFormatter.getThumbnailUrl({ iModelId: params.iModelId, urlParams });
-    const response: Uint8Array = await this.sendGetRequest({
+    const response: HttpResponse<Uint8Array> = await this.sendGetRequest({
       authorization: params.authorization,
       url,
       responseType: ContentType.Png,
@@ -42,7 +42,7 @@ export class ThumbnailOperations<TOptions extends OperationOptions> extends Oper
     return {
       size: urlParams.size,
       imageType: ContentType.Png,
-      image: response
+      image: response.data
     };
   }
 

--- a/clients/imodels-client-management/src/operations/thumbnail/ThumbnailOperations.ts
+++ b/clients/imodels-client-management/src/operations/thumbnail/ThumbnailOperations.ts
@@ -42,7 +42,7 @@ export class ThumbnailOperations<TOptions extends OperationOptions> extends Oper
     return {
       size: urlParams.size,
       imageType: ContentType.Png,
-      image: response.data
+      image: response.body
     };
   }
 

--- a/clients/imodels-client-management/src/operations/user-permission/UserPermissionOperations.ts
+++ b/clients/imodels-client-management/src/operations/user-permission/UserPermissionOperations.ts
@@ -25,6 +25,6 @@ export class UserPermissionOperations<TOptions extends OperationOptions> extends
       url: this._options.urlFormatter.getUserPermissionsUrl({ iModelId: params.iModelId }),
       headers: params.headers
     });
-    return response.data;
+    return response.body;
   }
 }

--- a/clients/imodels-client-management/src/operations/user-permission/UserPermissionOperations.ts
+++ b/clients/imodels-client-management/src/operations/user-permission/UserPermissionOperations.ts
@@ -25,6 +25,6 @@ export class UserPermissionOperations<TOptions extends OperationOptions> extends
       url: this._options.urlFormatter.getUserPermissionsUrl({ iModelId: params.iModelId }),
       headers: params.headers
     });
-    return response;
+    return response.data;
   }
 }

--- a/clients/imodels-client-management/src/operations/user/UserOperations.ts
+++ b/clients/imodels-client-management/src/operations/user/UserOperations.ts
@@ -17,11 +17,11 @@ export class UserOperations<TOptions extends OperationOptions> extends Operation
    * @returns {EntityListIterator<MinimalUser>} iterator for User list. See {@link EntityListIterator}, {@link MinimalUser}.
    */
   public getMinimalList(params: GetUserListParams): EntityListIterator<MinimalUser> {
-    return new EntityListIteratorImpl(async () => this.getEntityCollectionPage<MinimalUser>({
+    return new EntityListIteratorImpl(async () => this.getEntityCollectionPage<MinimalUser, UsersResponse<MinimalUser>>({
       authorization: params.authorization,
       url: this._options.urlFormatter.getUserListUrl({ iModelId: params.iModelId, urlParams: params.urlParams }),
       preferReturn: PreferReturn.Minimal,
-      entityCollectionAccessor: (response: unknown) => (response as UsersResponse<MinimalUser>).users,
+      entityCollectionAccessor: (response) => response.data.users,
       headers: params.headers
     }));
   }
@@ -35,11 +35,11 @@ export class UserOperations<TOptions extends OperationOptions> extends Operation
    * @returns {EntityListIterator<User>} iterator for User list. See {@link EntityListIterator}, {@link User}.
    */
   public getRepresentationList(params: GetUserListParams): EntityListIterator<User> {
-    return new EntityListIteratorImpl(async () => this.getEntityCollectionPage<User>({
+    return new EntityListIteratorImpl(async () => this.getEntityCollectionPage<User, UsersResponse<User>>({
       authorization: params.authorization,
       url: this._options.urlFormatter.getUserListUrl({ iModelId: params.iModelId, urlParams: params.urlParams }),
       preferReturn: PreferReturn.Representation,
-      entityCollectionAccessor: (response: unknown) => (response as UsersResponse<User>).users,
+      entityCollectionAccessor: (response) => response.data.users,
       headers: params.headers
     }));
   }
@@ -57,6 +57,6 @@ export class UserOperations<TOptions extends OperationOptions> extends Operation
       url: this._options.urlFormatter.getSingleUserUrl({ iModelId: params.iModelId, userId: params.userId }),
       headers: params.headers
     });
-    return response.user;
+    return response.data.user;
   }
 }

--- a/clients/imodels-client-management/src/operations/user/UserOperations.ts
+++ b/clients/imodels-client-management/src/operations/user/UserOperations.ts
@@ -21,7 +21,7 @@ export class UserOperations<TOptions extends OperationOptions> extends Operation
       authorization: params.authorization,
       url: this._options.urlFormatter.getUserListUrl({ iModelId: params.iModelId, urlParams: params.urlParams }),
       preferReturn: PreferReturn.Minimal,
-      entityCollectionAccessor: (response) => response.data.users,
+      entityCollectionAccessor: (response) => response.body.users,
       headers: params.headers
     }));
   }
@@ -39,7 +39,7 @@ export class UserOperations<TOptions extends OperationOptions> extends Operation
       authorization: params.authorization,
       url: this._options.urlFormatter.getUserListUrl({ iModelId: params.iModelId, urlParams: params.urlParams }),
       preferReturn: PreferReturn.Representation,
-      entityCollectionAccessor: (response) => response.data.users,
+      entityCollectionAccessor: (response) => response.body.users,
       headers: params.headers
     }));
   }
@@ -57,6 +57,6 @@ export class UserOperations<TOptions extends OperationOptions> extends Operation
       url: this._options.urlFormatter.getSingleUserUrl({ iModelId: params.iModelId, userId: params.userId }),
       headers: params.headers
     });
-    return response.data.user;
+    return response.body.user;
   }
 }

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -325,6 +325,7 @@ importers:
       '@types/sinon': ^10.0.15
       '@types/sinon-chai': ^3.2.9
       axios: ~1.6.4
+      axios-mock-adapter: ~1.22.0
       chai: ~4.3.10
       chai-as-promised: ~7.1.1
       cpx2: 4.2.0
@@ -363,6 +364,7 @@ importers:
       '@types/node': 18.19.3
       '@types/sinon': 10.0.20
       '@types/sinon-chai': 3.2.12
+      axios-mock-adapter: 1.22.0_axios@1.6.4
       cpx2: 4.2.0
       cspell: 5.21.2
       eslint: 8.55.0
@@ -2257,6 +2259,16 @@ packages:
   /axe-core/4.7.0:
     resolution: {integrity: sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==}
     engines: {node: '>=4'}
+    dev: true
+
+  /axios-mock-adapter/1.22.0_axios@1.6.4:
+    resolution: {integrity: sha512-dmI0KbkyAhntUR05YY96qg2H6gg0XMl2+qTW0xmYg6Up+BFBAJYRLROMXRdDEL06/Wqwa0TJThAYvFtSFdRCZw==}
+    peerDependencies:
+      axios: '>= 0.17.0'
+    dependencies:
+      axios: 1.6.4
+      fast-deep-equal: 3.1.3
+      is-buffer: 2.0.5
     dev: true
 
   /axios/1.6.4:
@@ -4195,6 +4207,11 @@ packages:
     dependencies:
       call-bind: 1.0.5
       has-tostringtag: 1.0.0
+    dev: true
+
+  /is-buffer/2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
     dev: true
 
   /is-callable/1.2.7:

--- a/itwin-platform-access/imodels-access-common/src/ErrorAdapter.ts
+++ b/itwin-platform-access/imodels-access-common/src/ErrorAdapter.ts
@@ -141,6 +141,7 @@ export class ErrorAdapter {
       case IModelsErrorCode.NewerChangesExist:
         return IModelHubStatus.PullIsRequired;
       case IModelsErrorCode.BaselineFileInitializationTimedOut:
+      case IModelsErrorCode.IModelFromTemplateInitializationTimedOut:
       case IModelsErrorCode.ClonedIModelInitializationTimedOut:
         return IModelHubStatus.InitializationTimeout;
 

--- a/itwin-platform-access/imodels-access-common/src/ErrorAdapter.ts
+++ b/itwin-platform-access/imodels-access-common/src/ErrorAdapter.ts
@@ -73,6 +73,7 @@ export class ErrorAdapter {
       case IModelsErrorCode.BaselineFileNotFound:
       case IModelsErrorCode.BaselineFileInitializationFailed:
       case IModelsErrorCode.IModelFromTemplateInitializationFailed:
+      case IModelsErrorCode.ClonedIModelInitializationFailed:
       case IModelsErrorCode.ChangesetDownloadFailed:
         return true;
       default: return false;
@@ -140,6 +141,7 @@ export class ErrorAdapter {
       case IModelsErrorCode.NewerChangesExist:
         return IModelHubStatus.PullIsRequired;
       case IModelsErrorCode.BaselineFileInitializationTimedOut:
+      case IModelsErrorCode.ClonedIModelInitializationTimedOut:
         return IModelHubStatus.InitializationTimeout;
 
       default:

--- a/tests/imodels-access-common-tests/src/ErrorAdapter.test.ts
+++ b/tests/imodels-access-common-tests/src/ErrorAdapter.test.ts
@@ -48,6 +48,7 @@ describe("ErrorAdapter", () => {
     IModelsErrorCode.BaselineFileNotFound,
     IModelsErrorCode.BaselineFileInitializationFailed,
     IModelsErrorCode.IModelFromTemplateInitializationFailed,
+    IModelsErrorCode.ClonedIModelInitializationFailed,
     IModelsErrorCode.ChangesetDownloadFailed
   ].forEach((originalErrorCode) => {
 
@@ -75,7 +76,8 @@ describe("ErrorAdapter", () => {
     { originalErrorCode: IModelsErrorCode.NamedVersionOnChangesetExists, expectedErrorNumber: IModelHubStatus.ChangeSetAlreadyHasVersion },
     { originalErrorCode: IModelsErrorCode.ConflictWithAnotherUser, expectedErrorNumber: IModelHubStatus.AnotherUserPushing },
     { originalErrorCode: IModelsErrorCode.NewerChangesExist, expectedErrorNumber: IModelHubStatus.PullIsRequired },
-    { originalErrorCode: IModelsErrorCode.BaselineFileInitializationTimedOut, expectedErrorNumber: IModelHubStatus.InitializationTimeout }
+    { originalErrorCode: IModelsErrorCode.BaselineFileInitializationTimedOut, expectedErrorNumber: IModelHubStatus.InitializationTimeout },
+    { originalErrorCode: IModelsErrorCode.ClonedIModelInitializationTimedOut, expectedErrorNumber: IModelHubStatus.InitializationTimeout }
   ].forEach((testCase: { originalErrorCode: IModelsErrorCode, expectedErrorNumber: number }) => {
 
     it(`should return correct error number (${testCase.originalErrorCode})`, () => {

--- a/tests/imodels-access-common-tests/src/ErrorAdapter.test.ts
+++ b/tests/imodels-access-common-tests/src/ErrorAdapter.test.ts
@@ -77,6 +77,7 @@ describe("ErrorAdapter", () => {
     { originalErrorCode: IModelsErrorCode.ConflictWithAnotherUser, expectedErrorNumber: IModelHubStatus.AnotherUserPushing },
     { originalErrorCode: IModelsErrorCode.NewerChangesExist, expectedErrorNumber: IModelHubStatus.PullIsRequired },
     { originalErrorCode: IModelsErrorCode.BaselineFileInitializationTimedOut, expectedErrorNumber: IModelHubStatus.InitializationTimeout },
+    { originalErrorCode: IModelsErrorCode.IModelFromTemplateInitializationTimedOut, expectedErrorNumber: IModelHubStatus.InitializationTimeout },
     { originalErrorCode: IModelsErrorCode.ClonedIModelInitializationTimedOut, expectedErrorNumber: IModelHubStatus.InitializationTimeout }
   ].forEach((testCase: { originalErrorCode: IModelsErrorCode, expectedErrorNumber: number }) => {
 

--- a/tests/imodels-clients-tests/package.json
+++ b/tests/imodels-clients-tests/package.json
@@ -58,6 +58,7 @@
     "@types/node": "^18.11.18",
     "@types/sinon": "^10.0.15",
     "@types/sinon-chai": "^3.2.9",
+    "axios-mock-adapter": "~1.22.0",
     "cpx2": "4.2.0",
     "cspell": "~5.21.0",
     "eslint": "~8.55.0",

--- a/tests/imodels-clients-tests/src/integration/management/IModelOperations.test.ts
+++ b/tests/imodels-clients-tests/src/integration/management/IModelOperations.test.ts
@@ -6,7 +6,7 @@ import { randomUUID } from "crypto";
 
 import { expect } from "chai";
 
-import { AuthorizationCallback, ChangesetIdOrIndex, CloneIModelParams, CreateEmptyIModelParams, CreateIModelFromTemplateParams, EntityListIterator, Extent, GetIModelListParams, GetSingleIModelParams, IModel, IModelOrderByProperty, IModelsClient, IModelsClientOptions, IModelsErrorCode, MinimalIModel, OrderByOperator, UpdateIModelParams, take, toArray } from "@itwin/imodels-client-management";
+import { AuthorizationCallback, CloneIModelParams, CreateEmptyIModelParams, CreateIModelFromTemplateParams, EntityListIterator, Extent, GetIModelListParams, GetSingleIModelParams, IModel, IModelOrderByProperty, IModelsClient, IModelsClientOptions, IModelsErrorCode, MinimalIModel, OrderByOperator, UpdateIModelParams, take, toArray } from "@itwin/imodels-client-management";
 import { IModelMetadata, ReusableIModelMetadata, ReusableTestIModelProvider, TestAuthorizationProvider, TestIModelCreator, TestIModelFileProvider, TestIModelGroup, TestIModelGroupFactory, TestITwinProvider, TestUtilTypes, assertCollection, assertError, assertIModel, assertMinimalIModel } from "@itwin/imodels-client-test-utils";
 
 import { Constants, getTestDIContainer, getTestRunId } from "../common";
@@ -336,70 +336,41 @@ describe("[Management] IModelOperations", () => {
     });
   });
 
-  [
-    // {
-    //   label: "without changeset id/index specified",
-    //   getChangesetIdOrIndex: (): ChangesetIdOrIndex | undefined => undefined,
-    //   getExpectedChangesetCount: () => testIModelFileProvider.changesets.length
-    // },
-    // {
-    //   label: "with empty changeset id specified",
-    //   getChangesetIdOrIndex: (): ChangesetIdOrIndex | undefined => ({ changesetId: "" }),
-    //   getExpectedChangesetCount: () => 0
-    // },
-    {
-      label: "with non-empty changeset id specified",
-      getChangesetIdOrIndex: (): ChangesetIdOrIndex | undefined => ({ changesetId: testIModelFileProvider.changesets[2].id }),
-      getExpectedChangesetCount: () => 3
-    }
-    // {
-    //   label: "with zero changeset index specified",
-    //   getChangesetIdOrIndex: (): ChangesetIdOrIndex | undefined => ({ changesetIndex: 0 }),
-    //   getExpectedChangesetCount: () => 0
-    // },
-    // {
-    //   label: "with non-zero changeset index specified",
-    //   getChangesetIdOrIndex: (): ChangesetIdOrIndex | undefined => ({ changesetIndex: testIModelFileProvider.changesets[5].index }),
-    //   getExpectedChangesetCount: () => 6
-    // }
-  ].forEach((testCase) => {
-    it(`should clone iModel (${testCase.label})`, async () => {
-      // Arrange
-      const sourceIModel = await iModelsClient.iModels.getSingle({
-        authorization,
-        iModelId: testIModelForRead.id
-      });
-      const changesetIdOrIndex = testCase.getChangesetIdOrIndex();
-      const expectedChangesetCount = testCase.getExpectedChangesetCount();
-      const cloneIModelParams: CloneIModelParams = {
-        authorization,
-        iModelId: testIModelForRead.id,
-        iModelProperties: {
-          iTwinId,
-          name: testIModelGroup.getPrefixedUniqueIModelName(`cloned iModel (${testCase.label})`),
-          ...changesetIdOrIndex
-        }
-      };
-
-      // Act
-      const newIModel = await iModelsClient.iModels.clone(cloneIModelParams);
-
-      // Assert
-      await assertIModel({
-        actualIModel: newIModel,
-        expectedIModelProperties: {
-          iTwinId,
-          name: cloneIModelParams.iModelProperties.name!,
-          description: sourceIModel.description ?? undefined,
-          extent: sourceIModel.extent ?? undefined
-        }
-      });
-      const changesets = await toArray(iModelsClient.changesets.getMinimalList({
-        authorization,
-        iModelId: newIModel.id
-      }));
-      expect(changesets.length).to.equal(expectedChangesetCount);
+  it("should clone iModel (with non-empty changeset index specified)", async () => {
+    // Arrange
+    const sourceIModel = await iModelsClient.iModels.getSingle({
+      authorization,
+      iModelId: testIModelForRead.id
     });
+    const changesetIndex = 3;
+    const cloneIModelParams: CloneIModelParams = {
+      authorization,
+      iModelId: testIModelForRead.id,
+      iModelProperties: {
+        iTwinId,
+        name: testIModelGroup.getPrefixedUniqueIModelName("cloned iModel"),
+        changesetIndex
+      }
+    };
+
+    // Act
+    const newIModel = await iModelsClient.iModels.clone(cloneIModelParams);
+
+    // Assert
+    await assertIModel({
+      actualIModel: newIModel,
+      expectedIModelProperties: {
+        iTwinId,
+        name: cloneIModelParams.iModelProperties.name!,
+        description: sourceIModel.description ?? undefined,
+        extent: sourceIModel.extent ?? undefined
+      }
+    });
+    const changesets = await toArray(iModelsClient.changesets.getMinimalList({
+      authorization,
+      iModelId: newIModel.id
+    }));
+    expect(changesets.length).to.equal(changesetIndex);
   });
 
   it("should update iModel name", async () => {

--- a/tests/imodels-clients-tests/src/integration/management/OperationOperations.test.ts
+++ b/tests/imodels-clients-tests/src/integration/management/OperationOperations.test.ts
@@ -5,15 +5,19 @@
 
 import { expect } from "chai";
 
-import { AuthorizationCallback, GetCreateIModelOperationDetailsParams, IModelCreationState, IModelsClient, IModelsClientOptions } from "@itwin/imodels-client-management";
-import { ReusableIModelMetadata, ReusableTestIModelProvider, TestAuthorizationProvider, TestUtilTypes } from "@itwin/imodels-client-test-utils";
+import { AuthorizationCallback, ClonedFrom, GetCreateIModelOperationDetailsParams, IModelCreationState, IModelsClient, IModelsClientOptions } from "@itwin/imodels-client-management";
+import { ReusableIModelMetadata, ReusableTestIModelProvider, TestAuthorizationProvider, TestIModelFileProvider, TestIModelGroup, TestIModelGroupFactory, TestITwinProvider, TestUtilTypes } from "@itwin/imodels-client-test-utils";
 
-import { getTestDIContainer } from "../common";
+import { Constants, getTestDIContainer, getTestRunId } from "../common";
 
 describe("[Management] OperationOperations", () => {
   let iModelsClient: IModelsClient;
   let authorization: AuthorizationCallback;
+  let iTwinId: string;
+
+  let testIModelFileProvider: TestIModelFileProvider;
   let testIModel: ReusableIModelMetadata;
+  let testIModelGroup: TestIModelGroup;
 
   before(async () => {
     const container = getTestDIContainer();
@@ -23,6 +27,14 @@ describe("[Management] OperationOperations", () => {
 
     const authorizationProvider = container.get(TestAuthorizationProvider);
     authorization = authorizationProvider.getAdmin1Authorization();
+
+    const testITwinProvider = container.get(TestITwinProvider);
+    iTwinId = await testITwinProvider.getOrCreate();
+
+    testIModelFileProvider = container.get(TestIModelFileProvider);
+
+    const testIModelGroupFactory = container.get(TestIModelGroupFactory);
+    testIModelGroup = testIModelGroupFactory.create({ testRunId: getTestRunId(), packageName: Constants.PackagePrefix, testSuiteName: "ManagementOperationOperations" });
 
     const reusableTestIModelProvider = container.get(ReusableTestIModelProvider);
     testIModel = await reusableTestIModelProvider.getOrCreate();
@@ -40,6 +52,34 @@ describe("[Management] OperationOperations", () => {
 
     // Assert
     expect(operationDetails.clonedFrom).to.be.null;
+    expect(operationDetails.state).to.equal(IModelCreationState.Successful);
+  });
+
+  it("should get create iModel operation details of cloned iModel", async () => {
+    // Arrange
+    const expectedClonedFrom: ClonedFrom = {
+      iModelId: testIModel.id,
+      changesetId: testIModelFileProvider.changesets[0].id
+    };
+    const newIModel = await iModelsClient.iModels.clone({
+      authorization,
+      iModelId: expectedClonedFrom.iModelId,
+      iModelProperties: {
+        iTwinId,
+        name: testIModelGroup.getPrefixedUniqueIModelName("cloned iModel for get create iModel operation details"),
+        changesetId: expectedClonedFrom.changesetId
+      }
+    });
+    const operationParams: GetCreateIModelOperationDetailsParams = {
+      authorization,
+      iModelId: newIModel.id
+    };
+
+    // Act
+    const operationDetails = await iModelsClient.operations.getCreateIModelDetails(operationParams);
+
+    // Assert
+    expect(operationDetails.clonedFrom).to.deep.equal(expectedClonedFrom);
     expect(operationDetails.state).to.equal(IModelCreationState.Successful);
   });
 });

--- a/tests/imodels-clients-tests/src/integration/management/ThumbnailOperations.test.ts
+++ b/tests/imodels-clients-tests/src/integration/management/ThumbnailOperations.test.ts
@@ -5,13 +5,13 @@
 import * as fs from "fs";
 import * as path from "path";
 
-import { expect, use } from "chai";
-import * as chaiAsPromised from "chai-as-promised";
+import chai, { expect } from "chai";
+import chaiAsPromised from "chai-as-promised";
 
 import { AuthorizationCallback, ContentType, DownloadThumbnailParams, IModelScopedOperationParams, IModelsClient, IModelsClientOptions, Thumbnail, ThumbnailSize, UploadThumbnailParams } from "@itwin/imodels-client-management";
 import { IModelMetadata, ReusableIModelMetadata, ReusableTestIModelProvider, TestAuthorizationProvider, TestIModelCreator, TestIModelGroup, TestIModelGroupFactory, TestUtilTypes, assertThumbnail, cleanupDirectory, createGuidValue } from "@itwin/imodels-client-test-utils";
 
-use(chaiAsPromised);
+chai.use(chaiAsPromised);
 
 import { Constants, getTestDIContainer, getTestRunId } from "../common";
 

--- a/tests/imodels-clients-tests/src/unit/management/AxiosRestClient.test.ts
+++ b/tests/imodels-clients-tests/src/unit/management/AxiosRestClient.test.ts
@@ -96,7 +96,7 @@ describe("[Management] AxiosRestClient", () => {
     // Act
     const response = await restClient.sendPostRequest(requestParams);
     const actualHeaders = response.headers.getAll();
-    
+
     // Assert
     expect(Object.assign({}, actualHeaders)).to.deep.equal(expectedHeaders);
   });

--- a/tests/imodels-clients-tests/src/unit/management/AxiosRestClient.test.ts
+++ b/tests/imodels-clients-tests/src/unit/management/AxiosRestClient.test.ts
@@ -1,0 +1,46 @@
+import { AxiosRestClient, IModelsErrorParser } from "@itwin/imodels-client-management/lib/base/internal";
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
+import { expect } from "chai";
+
+import { ContentType, HttpRequestWithJsonBodyParams } from "@itwin/imodels-client-management";
+
+describe("[Management] AxiosRestClient", () => {
+  let axiosMock: MockAdapter;
+
+  before(() => {
+    axiosMock = new MockAdapter(axios);
+  });
+
+  it("should get response header value by case-insensitive name", async () => {
+    // Arrange
+    const requestParams: HttpRequestWithJsonBodyParams = {
+      url: "https://imodelhub.bentley.com",
+      headers: {},
+      body: {
+        content: {},
+        contentType: ContentType.Json
+      }
+    };
+    const responseData = {
+      iModelId: "IMODEL_ID"
+    };
+    const responseHeaders = {
+      "location": "https://some-url.com",
+      "retry-after": 60
+    };
+    axiosMock.onPost(requestParams.url).reply(200, responseData, responseHeaders);
+    const restClient = new AxiosRestClient(IModelsErrorParser.parse);
+
+    // Act
+    const response = await restClient.sendPostRequest(requestParams);
+
+    // Assert
+    expect(response.data).to.deep.equal(responseData);
+    expect(response.headers.get("location")).to.equal("https://some-url.com");
+    expect(response.headers.get("Location")).to.equal("https://some-url.com");
+    expect(response.headers.get("LOCATION")).to.equal("https://some-url.com");
+    expect(response.headers.get("Retry-After")).to.equal("60");
+    expect(response.headers.get("non-existent-header")).to.not.exist;
+  });
+});

--- a/tests/imodels-clients-tests/src/unit/management/AxiosRestClient.test.ts
+++ b/tests/imodels-clients-tests/src/unit/management/AxiosRestClient.test.ts
@@ -1,4 +1,4 @@
-import { AxiosRestClient, IModelsErrorParser } from "@itwin/imodels-client-management/lib/base/internal";
+import { AxiosHeadersAdapterFactory, AxiosRestClient, IModelsErrorParser } from "@itwin/imodels-client-management/lib/base/internal";
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
 import { expect } from "chai";
@@ -22,21 +22,21 @@ describe("[Management] AxiosRestClient", () => {
         contentType: ContentType.Json
       }
     };
-    const responseData = {
+    const responseBody = {
       iModelId: "IMODEL_ID"
     };
     const responseHeaders = {
       "location": "https://some-url.com",
       "retry-after": 60
     };
-    axiosMock.onPost(requestParams.url).reply(200, responseData, responseHeaders);
-    const restClient = new AxiosRestClient(IModelsErrorParser.parse);
+    axiosMock.onPost(requestParams.url).reply(200, responseBody, responseHeaders);
+    const restClient = new AxiosRestClient(IModelsErrorParser.parse, new AxiosHeadersAdapterFactory());
 
     // Act
     const response = await restClient.sendPostRequest(requestParams);
 
     // Assert
-    expect(response.data).to.deep.equal(responseData);
+    expect(response.body).to.deep.equal(responseBody);
     expect(response.headers.get("location")).to.equal("https://some-url.com");
     expect(response.headers.get("Location")).to.equal("https://some-url.com");
     expect(response.headers.get("LOCATION")).to.equal("https://some-url.com");

--- a/tests/imodels-clients-tests/src/unit/management/AxiosRestClient.test.ts
+++ b/tests/imodels-clients-tests/src/unit/management/AxiosRestClient.test.ts
@@ -1,4 +1,8 @@
-import { AxiosHeadersAdapterFactory, AxiosRestClient, IModelsErrorParser } from "@itwin/imodels-client-management/lib/base/internal";
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { AxiosRestClient, IModelsErrorParser } from "@itwin/imodels-client-management/lib/base/internal";
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
 import { expect } from "chai";
@@ -12,7 +16,7 @@ describe("[Management] AxiosRestClient", () => {
     axiosMock = new MockAdapter(axios);
   });
 
-  it("should get response header value by case-insensitive name", async () => {
+  it("should get response body", async () => {
     // Arrange
     const requestParams: HttpRequestWithJsonBodyParams = {
       url: "https://imodelhub.bentley.com",
@@ -23,24 +27,77 @@ describe("[Management] AxiosRestClient", () => {
       }
     };
     const responseBody = {
-      iModelId: "IMODEL_ID"
+      iModelId: "IMODEL_ID",
+      changesetId: 4,
+      _links: {
+        self: "https://imodelhub.bentley.com/something"
+      }
     };
-    const responseHeaders = {
-      "location": "https://some-url.com",
-      "retry-after": 60
-    };
-    axiosMock.onPost(requestParams.url).reply(200, responseBody, responseHeaders);
-    const restClient = new AxiosRestClient(IModelsErrorParser.parse, new AxiosHeadersAdapterFactory());
+    axiosMock.onPost(requestParams.url).reply(200, responseBody, {});
+    const restClient = new AxiosRestClient(IModelsErrorParser.parse);
 
     // Act
     const response = await restClient.sendPostRequest(requestParams);
 
     // Assert
     expect(response.body).to.deep.equal(responseBody);
+  });
+
+  it("should get response header value by case-insensitive name", async () => {
+    // Arrange
+    const requestParams: HttpRequestWithJsonBodyParams = {
+      url: "https://imodelhub.bentley.com",
+      headers: {},
+      body: {
+        content: {},
+        contentType: ContentType.Json
+      }
+    };
+    const responseHeaders = {
+      "location": "https://some-url.com",
+      "retry-after": 60
+    };
+    axiosMock.onPost(requestParams.url).reply(200, {}, responseHeaders);
+    const restClient = new AxiosRestClient(IModelsErrorParser.parse);
+
+    // Act & Assert
+    const response = await restClient.sendPostRequest(requestParams);
+
     expect(response.headers.get("location")).to.equal("https://some-url.com");
     expect(response.headers.get("Location")).to.equal("https://some-url.com");
     expect(response.headers.get("LOCATION")).to.equal("https://some-url.com");
     expect(response.headers.get("Retry-After")).to.equal("60");
     expect(response.headers.get("non-existent-header")).to.not.exist;
+  });
+
+  it("should get all response headers", async () => {
+    // Arrange
+    const requestParams: HttpRequestWithJsonBodyParams = {
+      url: "https://imodelhub.bentley.com",
+      headers: {},
+      body: {
+        content: {},
+        contentType: ContentType.Json
+      }
+    };
+    const responseHeaders = {
+      "location": "https://some-url.com",
+      "retry-after": 60,
+      "Content-Type": "application/json"
+    };
+    const expectedHeaders = {
+      "location": "https://some-url.com",
+      "retry-after": "60",
+      "Content-Type": "application/json"
+    };
+    axiosMock.onPost(requestParams.url).reply(200, {}, responseHeaders);
+    const restClient = new AxiosRestClient(IModelsErrorParser.parse);
+
+    // Act
+    const response = await restClient.sendPostRequest(requestParams);
+    const actualHeaders = response.headers.getAll();
+
+    // Assert
+    expect(JSON.stringify(actualHeaders)).to.deep.equal(JSON.stringify(expectedHeaders));
   });
 });

--- a/tests/imodels-clients-tests/src/unit/management/AxiosRestClient.test.ts
+++ b/tests/imodels-clients-tests/src/unit/management/AxiosRestClient.test.ts
@@ -96,8 +96,8 @@ describe("[Management] AxiosRestClient", () => {
     // Act
     const response = await restClient.sendPostRequest(requestParams);
     const actualHeaders = response.headers.getAll();
-
+    
     // Assert
-    expect(JSON.stringify(actualHeaders)).to.deep.equal(JSON.stringify(expectedHeaders));
+    expect(Object.assign({}, actualHeaders)).to.deep.equal(expectedHeaders);
   });
 });

--- a/tests/imodels-clients-tests/src/unit/management/IModelsApiUrlFormatter.test.ts
+++ b/tests/imodels-clients-tests/src/unit/management/IModelsApiUrlFormatter.test.ts
@@ -25,6 +25,17 @@ describe("[Management] IModelsApiUrlFormatter", () => {
       expect(createIModelUrl).to.be.equal("https://api.bentley.com/imodels");
     });
 
+    it("should format clone iModel url", () => {
+      // Arrange
+      const getCloneIModelUrlParams = { iModelId: "IMODEL_ID" };
+
+      // Act
+      const cloneIModelUrl = iModelsApiUrlFormatter.getCloneIModelUrl(getCloneIModelUrlParams);
+
+      // Assert
+      expect(cloneIModelUrl).to.be.equal("https://api.bentley.com/imodels/IMODEL_ID/clone");
+    });
+
     it("should format single iModel url", () => {
       // Arrange
       const getSingleIModelUrlParams = { iModelId: "IMODEL_ID" };
@@ -45,6 +56,17 @@ describe("[Management] IModelsApiUrlFormatter", () => {
 
       // Assert
       expect(iModelListUrl).to.equal("https://api.bentley.com/imodels?iTwinId=ITWIN_ID");
+    });
+
+    it("should parse iModel url", () => {
+      // Arrange
+      const iModelUrl = "https://api.bentley.com/imodels/IMODEL_ID";
+
+      // Act
+      const { iModelId } = iModelsApiUrlFormatter.parseIModelUrl(iModelUrl);
+
+      // Assert
+      expect(iModelId).to.be.equal("IMODEL_ID");
     });
   });
 

--- a/tests/imodels-clients-tests/src/unit/management/TestOperationsWrapper.ts
+++ b/tests/imodels-clients-tests/src/unit/management/TestOperationsWrapper.ts
@@ -6,27 +6,27 @@ export class TestOperationsWrapper extends OperationsBase<OperationsBaseOptions>
     super(options);
   }
 
-  public override async sendGetRequest<TData>(params: SendGetRequestParams & { responseType?: ContentType.Json }): Promise<HttpResponse<TData>>;
+  public override async sendGetRequest<TBody>(params: SendGetRequestParams & { responseType?: ContentType.Json }): Promise<HttpResponse<TBody>>;
   public override async sendGetRequest(params: SendGetRequestParams & { responseType: ContentType.Png }): Promise<HttpResponse<Uint8Array>>;
-  public override async sendGetRequest<TData>(params: SendGetRequestParams): Promise<HttpResponse<TData | Uint8Array>> {
+  public override async sendGetRequest<TBody>(params: SendGetRequestParams): Promise<HttpResponse<TBody | Uint8Array>> {
     if(params.responseType === ContentType.Png)
       return super.sendGetRequest({...params, responseType: params.responseType});
-    return super.sendGetRequest<TData>({...params, responseType: params.responseType });
+    return super.sendGetRequest<TBody>({...params, responseType: params.responseType });
   }
 
-  public override async sendPostRequest<TData>(params: SendPostRequestParams): Promise<HttpResponse<TData>> {
+  public override async sendPostRequest<TBody>(params: SendPostRequestParams): Promise<HttpResponse<TBody>> {
     return super.sendPostRequest(params);
   }
 
-  public override async sendDeleteRequest<TData>(params: SendDeleteRequestParams): Promise<HttpResponse<TData>> {
+  public override async sendDeleteRequest<TBody>(params: SendDeleteRequestParams): Promise<HttpResponse<TBody>> {
     return super.sendDeleteRequest(params);
   }
 
-  public override async sendPutRequest<TData>(params: SendPutRequestParams): Promise<HttpResponse<TData>> {
+  public override async sendPutRequest<TBody>(params: SendPutRequestParams): Promise<HttpResponse<TBody>> {
     return super.sendPutRequest(params);
   }
 
-  public override async sendPatchRequest<TData>(params: SendPatchRequestParams): Promise<HttpResponse<TData>> {
+  public override async sendPatchRequest<TBody>(params: SendPatchRequestParams): Promise<HttpResponse<TBody>> {
     return super.sendPatchRequest(params);
   }
 }

--- a/tests/imodels-clients-tests/src/unit/management/TestOperationsWrapper.ts
+++ b/tests/imodels-clients-tests/src/unit/management/TestOperationsWrapper.ts
@@ -1,34 +1,32 @@
 import { OperationsBase, OperationsBaseOptions, SendDeleteRequestParams, SendGetRequestParams, SendPatchRequestParams, SendPostRequestParams, SendPutRequestParams } from "@itwin/imodels-client-management/lib/base/internal";
-import { ContentType } from "@itwin/imodels-client-management/lib/base/types";
+import { ContentType, HttpResponse } from "@itwin/imodels-client-management/lib/base/types";
 
 export class TestOperationsWrapper extends OperationsBase<OperationsBaseOptions> {
-
   public constructor(options: OperationsBaseOptions) {
     super(options);
   }
 
-  public override async sendGetRequest<TResponse>(params: SendGetRequestParams & { responseType?: ContentType.Json }): Promise<TResponse>;
-  public override async sendGetRequest(params: SendGetRequestParams & { responseType: ContentType.Png }): Promise<Uint8Array>;
-  public override async sendGetRequest<TResponse>(params: SendGetRequestParams): Promise<TResponse | Uint8Array> {
+  public override async sendGetRequest<TData>(params: SendGetRequestParams & { responseType?: ContentType.Json }): Promise<HttpResponse<TData>>;
+  public override async sendGetRequest(params: SendGetRequestParams & { responseType: ContentType.Png }): Promise<HttpResponse<Uint8Array>>;
+  public override async sendGetRequest<TData>(params: SendGetRequestParams): Promise<HttpResponse<TData | Uint8Array>> {
     if(params.responseType === ContentType.Png)
       return super.sendGetRequest({...params, responseType: params.responseType});
-    return super.sendGetRequest<TResponse>({...params, responseType: params.responseType });
+    return super.sendGetRequest<TData>({...params, responseType: params.responseType });
   }
 
-  public override async sendPostRequest<TResponse>(params: SendPostRequestParams): Promise<TResponse> {
+  public override async sendPostRequest<TData>(params: SendPostRequestParams): Promise<HttpResponse<TData>> {
     return super.sendPostRequest(params);
   }
 
-  public override async sendDeleteRequest<TResponse>(params: SendDeleteRequestParams): Promise<TResponse> {
+  public override async sendDeleteRequest<TData>(params: SendDeleteRequestParams): Promise<HttpResponse<TData>> {
     return super.sendDeleteRequest(params);
   }
 
-  public override async sendPutRequest<TResponse>(params: SendPutRequestParams): Promise<TResponse> {
+  public override async sendPutRequest<TData>(params: SendPutRequestParams): Promise<HttpResponse<TData>> {
     return super.sendPutRequest(params);
   }
 
-  public override async sendPatchRequest<TResponse>(params: SendPatchRequestParams): Promise<TResponse> {
+  public override async sendPatchRequest<TData>(params: SendPatchRequestParams): Promise<HttpResponse<TData>> {
     return super.sendPatchRequest(params);
   }
-
 }

--- a/tests/imodels-clients-tests/tsconfig.json
+++ b/tests/imodels-clients-tests/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "./node_modules/@itwin/imodels-client-common-config/tsconfig.json",
   "compilerOptions": {
     "outDir": "./lib",
+    "esModuleInterop": true,
     "experimentalDecorators": true
   },
   "include": [


### PR DESCRIPTION
- Added iModel Clone operation. **This introduces breaking changes** in `RestClient` interface because it is necessary to access response headers.
- Added `IModelFromTemplateInitializationTimedOut` error code.
- Fixed `LocksResponse` interface since it did not extend from `CollectionResponse`. 