### PR TITLE
Fix not respected long running operation timeout (iModel cloning, forking, creation from baseline)

### DIFF
--- a/clients/imodels-client-authoring/src/operations/imodel/IModelOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/imodel/IModelOperations.ts
@@ -60,7 +60,8 @@ export class IModelOperations<TOptions extends OperationOptions> extends Managem
     await this.waitForBaselineFileInitialization({
       authorization: params.authorization,
       iModelId: createdIModel.id,
-      headers: params.headers
+      headers: params.headers,
+      timeOutInMs: params.timeOutInMs
     });
     return this.getSingle({
       authorization: params.authorization,

--- a/clients/imodels-client-management/src/operations/imodel/IModelOperations.ts
+++ b/clients/imodels-client-management/src/operations/imodel/IModelOperations.ts
@@ -105,8 +105,8 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
     await this.waitForTemplatedIModelInitialization({
       authorization: params.authorization,
       iModelId: createdIModel.id,
-      timeOutInMs: params.timeOutInMs,
-      headers: params.headers
+      headers: params.headers,
+      timeOutInMs: params.timeOutInMs
     });
 
     return this.getSingle({
@@ -142,7 +142,9 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
 
     await this.waitForClonedIModelInitialization({
       authorization: params.authorization,
-      iModelId: clonedIModelId
+      iModelId: clonedIModelId,
+      headers: params.headers,
+      timeOutInMs: params.timeOutInMs
     });
 
     return this.getSingle({
@@ -179,7 +181,9 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
 
     await this.waitForForkIModelInitialization({
       authorization: params.authorization,
-      iModelId: forkIModelId
+      iModelId: forkIModelId,
+      headers: params.headers,
+      timeOutInMs: params.timeOutInMs
     });
 
     return this.getSingle({


### PR DESCRIPTION
In this PR:
- Fixed not respected timeout. The issue was that user specified timeout `params.timeOutInMs` was not passed through to waiting functions `waitForBaselineFileInitialization`, `waitForTemplatedIModelInitialization`, ...
  - `params.headers` was not passed too, to fixed that as well. 