### PR TITLE
Add HTTP status code to iModels error

### DIFF
--- a/clients/imodels-client-authoring/src/operations/FileDownload.ts
+++ b/clients/imodels-client-authoring/src/operations/FileDownload.ts
@@ -67,6 +67,8 @@ function adaptAbortError(error: unknown): unknown {
 
   return new IModelsErrorImpl({
     code: IModelsErrorCode.DownloadAborted,
-    message: `Download was aborted. Message: ${error.message}}.`
+    message: `Download was aborted. Message: ${error.message}}.`,
+    statusCode: undefined, 
+    details: undefined
   });
 }

--- a/clients/imodels-client-authoring/src/operations/FileDownload.ts
+++ b/clients/imodels-client-authoring/src/operations/FileDownload.ts
@@ -68,7 +68,7 @@ function adaptAbortError(error: unknown): unknown {
   return new IModelsErrorImpl({
     code: IModelsErrorCode.DownloadAborted,
     message: `Download was aborted. Message: ${error.message}}.`,
-    statusCode: undefined, 
+    statusCode: undefined,
     details: undefined
   });
 }

--- a/clients/imodels-client-authoring/src/operations/changeset/ChangesetOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/changeset/ChangesetOperations.ts
@@ -225,7 +225,9 @@ export class ChangesetOperations<TOptions extends OperationOptions> extends Mana
 
         throw new IModelsErrorImpl({
           code: IModelsErrorCode.ChangesetDownloadFailed,
-          message: `Failed to download changeset. Changeset id: ${params.changeset.id}, changeset index: ${params.changeset.index}, error: ${JSON.stringify(errorAfterRetry)}.`
+          message: `Failed to download changeset. Changeset id: ${params.changeset.id}, changeset index: ${params.changeset.index}, error: ${JSON.stringify(errorAfterRetry)}.`,
+          statusCode: undefined,
+          details: undefined
         });
       }
     }

--- a/clients/imodels-client-authoring/src/operations/imodel/IModelOperations.ts
+++ b/clients/imodels-client-authoring/src/operations/imodel/IModelOperations.ts
@@ -92,7 +92,9 @@ export class IModelOperations<TOptions extends OperationOptions> extends Managem
       )
         throw new IModelsErrorImpl({
           code: IModelsErrorCode.BaselineFileInitializationFailed,
-          message: `Baseline File initialization failed with state '${state}.'`
+          message: `Baseline File initialization failed with state '${state}.'`,
+          statusCode: undefined,
+          details: undefined
         });
 
       return state === BaselineFileState.Initialized;
@@ -102,7 +104,9 @@ export class IModelOperations<TOptions extends OperationOptions> extends Managem
       conditionToSatisfy: isBaselineInitialized,
       timeoutErrorFactory: () => new IModelsErrorImpl({
         code: IModelsErrorCode.BaselineFileInitializationTimedOut,
-        message: "Timed out waiting for Baseline File initialization."
+        message: "Timed out waiting for Baseline File initialization.",
+        statusCode: undefined,
+        details: undefined
       }),
       timeOutInMs: params.timeOutInMs
     });

--- a/clients/imodels-client-management/src/base/internal/AxiosRestClient.ts
+++ b/clients/imodels-client-management/src/base/internal/AxiosRestClient.ts
@@ -7,12 +7,13 @@ import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
 import { ContentType, HttpGetRequestParams, HttpRequestParams, HttpRequestWithBinaryBodyParams, HttpRequestWithJsonBodyParams, HttpResponse, RestClient } from "../types/RestClient";
 
 import { AxiosResponseHeadersAdapter } from "./AxiosResponseHeadersAdapter";
+import { ResponseInfo } from "./IModelsErrorParser";
 
 /**
  * Function that is called if the HTTP request fails and which returns an error that will be thrown by one of the
  * methods in {@link RestClient}.
  */
-export type ParseErrorFunc = (response: { statusCode?: number, body?: unknown }, originalError: Error & { code?: string }) => Error;
+export type ParseErrorFunc = (response: ResponseInfo, originalError: Error & { code?: string }) => Error;
 
 /** Default implementation for {@link RestClient} interface that uses `axios` library for sending the requests. */
 export class AxiosRestClient implements RestClient {

--- a/clients/imodels-client-management/src/base/internal/IModelsErrorParser.ts
+++ b/clients/imodels-client-management/src/base/internal/IModelsErrorParser.ts
@@ -14,6 +14,7 @@ interface IModelsApiErrorWrapper {
 
 export interface IModelsApiError {
   code: string;
+  statusCode?: number;
   message?: string;
   details?: IModelsApiErrorDetail[];
 }
@@ -36,10 +37,12 @@ export class IModelsErrorBaseImpl extends Error {
 
 export class IModelsErrorImpl extends IModelsErrorBaseImpl implements IModelsError {
   public details?: IModelsErrorDetail[];
+  public statusCode?: number;
 
-  constructor(params: { code: IModelsErrorCode, message: string, details?: IModelsErrorDetail[] }) {
+  constructor(params: { code: IModelsErrorCode, message: string, details?: IModelsErrorDetail[], statusCode?: number }) {
     super(params);
     this.details = params.details;
+    this.statusCode = params.statusCode;
   }
 }
 
@@ -74,6 +77,7 @@ export class IModelsErrorParser {
 
     return new IModelsErrorImpl({
       code: errorCode,
+      statusCode: response.statusCode,
       message: errorMessage,
       details: errorDetails
     });
@@ -123,6 +127,7 @@ export class IModelsErrorParser {
   private static createUnrecognizedError(response: ResponseInfo, originalError: OriginalError): Error {
     return new IModelsErrorImpl({
       code: IModelsErrorCode.Unrecognized,
+      statusCode: response.statusCode,
       message: `${IModelsErrorParser._defaultErrorMessage}.\n` +
         `Original error message: ${originalError.message},\n` +
         `original error code: ${originalError.code},\n` +
@@ -137,6 +142,7 @@ export class IModelsErrorParser {
       ?? IModelsErrorParser._defaultUnauthorizedMessage;
     return new IModelsErrorImpl({
       code: IModelsErrorCode.Unauthorized,
+      statusCode: response.statusCode,
       message: errorMessage
     });
   }

--- a/clients/imodels-client-management/src/base/internal/IModelsErrorParser.ts
+++ b/clients/imodels-client-management/src/base/internal/IModelsErrorParser.ts
@@ -39,11 +39,11 @@ export class IModelsErrorImpl extends IModelsErrorBaseImpl implements IModelsErr
   public details?: IModelsErrorDetail[];
   public statusCode?: number;
 
-  constructor(params: { 
-    code: IModelsErrorCode, 
-    message: string, 
-    details: IModelsErrorDetail[] | undefined, 
-    statusCode: number | undefined
+  constructor(params: {
+    code: IModelsErrorCode;
+    message: string;
+    details: IModelsErrorDetail[] | undefined;
+    statusCode: number | undefined;
   }) {
     super(params);
     this.details = params.details;

--- a/clients/imodels-client-management/src/base/internal/IModelsErrorParser.ts
+++ b/clients/imodels-client-management/src/base/internal/IModelsErrorParser.ts
@@ -39,7 +39,12 @@ export class IModelsErrorImpl extends IModelsErrorBaseImpl implements IModelsErr
   public details?: IModelsErrorDetail[];
   public statusCode?: number;
 
-  constructor(params: { code: IModelsErrorCode, message: string, details?: IModelsErrorDetail[], statusCode?: number }) {
+  constructor(params: { 
+    code: IModelsErrorCode, 
+    message: string, 
+    details: IModelsErrorDetail[] | undefined, 
+    statusCode: number | undefined
+  }) {
     super(params);
     this.details = params.details;
     this.statusCode = params.statusCode;
@@ -132,7 +137,8 @@ export class IModelsErrorParser {
         `Original error message: ${originalError.message},\n` +
         `original error code: ${originalError.code},\n` +
         `response status code: ${response.statusCode},\n` +
-        `response body: ${JSON.stringify(response.body)}`
+        `response body: ${JSON.stringify(response.body)}`,
+      details: undefined
     });
   }
 
@@ -143,7 +149,8 @@ export class IModelsErrorParser {
     return new IModelsErrorImpl({
       code: IModelsErrorCode.Unauthorized,
       statusCode: response.statusCode,
-      message: errorMessage
+      message: errorMessage,
+      details: undefined
     });
   }
 }

--- a/clients/imodels-client-management/src/base/types/IModelsErrorInterfaces.ts
+++ b/clients/imodels-client-management/src/base/types/IModelsErrorInterfaces.ts
@@ -17,6 +17,7 @@ export enum IModelsErrorCode {
   ResourceQuotaExceeded = "ResourceQuotaExceeded",
   DataConflict = "DataConflict",
   MutuallyExclusivePropertiesProvided = "MutuallyExclusivePropertiesProvided",
+  MutuallyExclusiveParametersProvided = "MutuallyExclusiveParametersProvided",
   MissingRequiredProperty = "MissingRequiredProperty",
   MissingRequiredParameter = "MissingRequiredParameter",
   MissingRequiredHeader = "MissingRequiredHeader",
@@ -90,6 +91,8 @@ export interface IModelsErrorBase extends Error {
 export interface IModelsError extends IModelsErrorBase {
   /** Data that describes the error in more detail. See {@link iModelsErrorDetail}. */
   details?: IModelsErrorDetail[];
+  /** HTTP response status code. */
+  statusCode?: number;
 }
 
 export function isIModelsApiError(error: unknown): error is IModelsError {

--- a/clients/imodels-client-management/src/operations/imodel/IModelOperations.ts
+++ b/clients/imodels-client-management/src/operations/imodel/IModelOperations.ts
@@ -327,7 +327,9 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
     )
       throw new IModelsErrorImpl({
         code: params.errorCodeOnFailure,
-        message: `iModel initialization failed with state '${state}'`
+        message: `iModel initialization failed with state '${state}'`,
+        statusCode: undefined,
+        details: undefined
       });
 
     return state === IModelCreationState.Successful;
@@ -347,7 +349,9 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
     if (state === IModelCreationState.MainIModelIsMissingFederationGuids)
       throw new IModelsErrorImpl({
         code: IModelsErrorCode.MainIModelIsMissingFederationGuids,
-        message: "iModel fork initialization failed because some elements in the main iModel do not have FederationGuid property set."
+        message: "iModel fork initialization failed because some elements in the main iModel do not have FederationGuid property set.",
+        statusCode: undefined,
+        details: undefined
       });
 
     if (state !== IModelCreationState.Scheduled &&
@@ -356,7 +360,9 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
     )
       throw new IModelsErrorImpl({
         code: IModelsErrorCode.IModelForkInitializationFailed,
-        message: `iModel fork initialization failed with state '${state}'`
+        message: `iModel fork initialization failed with state '${state}'`,
+        statusCode: undefined,
+        details: undefined
       });
 
     return state === IModelCreationState.Successful;
@@ -377,7 +383,9 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
       }),
       timeoutErrorFactory: () => new IModelsErrorImpl({
         code: IModelsErrorCode.IModelFromTemplateInitializationTimedOut,
-        message: "Timed out waiting for Baseline File initialization."
+        message: "Timed out waiting for Baseline File initialization.",
+        statusCode: undefined,
+        details: undefined
       }),
       timeOutInMs: params.timeOutInMs
     });
@@ -398,7 +406,9 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
       }),
       timeoutErrorFactory: () => new IModelsErrorImpl({
         code: IModelsErrorCode.ClonedIModelInitializationTimedOut,
-        message: "Timed out waiting for Cloned iModel initialization."
+        message: "Timed out waiting for Cloned iModel initialization.",
+        statusCode: undefined,
+        details: undefined
       }),
       timeOutInMs: params.timeOutInMs
     });
@@ -418,7 +428,9 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
       }),
       timeoutErrorFactory: () => new IModelsErrorImpl({
         code: IModelsErrorCode.IModelForkInitializationTimedOut,
-        message: "Timed out waiting for iModel fork initialization."
+        message: "Timed out waiting for iModel fork initialization.",
+        statusCode: undefined,
+        details: undefined
       }),
       timeOutInMs: params.timeOutInMs
     });

--- a/itwin-platform-access/imodels-access-common/src/ErrorAdapter.ts
+++ b/itwin-platform-access/imodels-access-common/src/ErrorAdapter.ts
@@ -54,6 +54,7 @@ export class ErrorAdapter {
       case IModelsErrorCode.InvalidRequestBody:
       case IModelsErrorCode.InvalidThumbnailFormat:
       case IModelsErrorCode.MutuallyExclusivePropertiesProvided:
+      case IModelsErrorCode.MutuallyExclusiveParametersProvided:
       case IModelsErrorCode.MissingRequestBody:
       case IModelsErrorCode.MissingRequiredProperty:
       case IModelsErrorCode.MissingRequiredParameter:

--- a/tests/imodels-access-common-tests/src/ErrorAdapter.test.ts
+++ b/tests/imodels-access-common-tests/src/ErrorAdapter.test.ts
@@ -37,6 +37,7 @@ describe("ErrorAdapter", () => {
     IModelsErrorCode.InvalidRequestBody,
     IModelsErrorCode.InvalidThumbnailFormat,
     IModelsErrorCode.MutuallyExclusivePropertiesProvided,
+    IModelsErrorCode.MutuallyExclusiveParametersProvided,
     IModelsErrorCode.MissingRequestBody,
     IModelsErrorCode.MissingRequiredProperty,
     IModelsErrorCode.MissingRequiredParameter,
@@ -84,7 +85,7 @@ describe("ErrorAdapter", () => {
 
     it(`should return correct error number (${testCase.originalErrorCode})`, () => {
       const originalErrorMessage = "test error message";
-      const originalError = new IModelsErrorImpl({ code: testCase.originalErrorCode, message: originalErrorMessage });
+      const originalError = new IModelsErrorImpl({ code: testCase.originalErrorCode, statusCode: 400, message: originalErrorMessage });
 
       const result = ErrorAdapter.toIModelError(originalError, undefined);
 

--- a/tests/imodels-access-common-tests/src/ErrorAdapter.test.ts
+++ b/tests/imodels-access-common-tests/src/ErrorAdapter.test.ts
@@ -13,7 +13,7 @@ import { IModelsErrorCode } from "@itwin/imodels-client-management";
 describe("ErrorAdapter", () => {
   [
     { foo: "bar" },
-    new IModelsErrorImpl({ code: 5 as any, message: "" })
+    new IModelsErrorImpl({ code: 5 as any, message: "", statusCode: undefined, details: undefined })
   ].forEach((originalError: unknown) => {
 
     it("should return original error if it does not have a string error code", () => {
@@ -55,7 +55,7 @@ describe("ErrorAdapter", () => {
   ].forEach((originalErrorCode) => {
 
     it(`should return original error if error code is unrecognized, indicates auth issue or does not have a corresponding status in IModelHubStatus (${originalErrorCode})`, () => {
-      const error = new IModelsErrorImpl({ code: originalErrorCode, message: "" });
+      const error = new IModelsErrorImpl({ code: originalErrorCode, message: "", statusCode: undefined, details: undefined });
 
       const result = ErrorAdapter.toIModelError(error, undefined);
 
@@ -85,7 +85,7 @@ describe("ErrorAdapter", () => {
 
     it(`should return correct error number (${testCase.originalErrorCode})`, () => {
       const originalErrorMessage = "test error message";
-      const originalError = new IModelsErrorImpl({ code: testCase.originalErrorCode, statusCode: 400, message: originalErrorMessage });
+      const originalError = new IModelsErrorImpl({ code: testCase.originalErrorCode, statusCode: 400, message: originalErrorMessage, details: undefined });
 
       const result = ErrorAdapter.toIModelError(originalError, undefined);
 
@@ -112,7 +112,7 @@ describe("ErrorAdapter", () => {
 
     it(`should handle generic error codes for specific operation (${testCase.originalErrorCode})`, () => {
       const originalErrorMessage = "test error message";
-      const originalError = new IModelsErrorImpl({ code: testCase.originalErrorCode, message: originalErrorMessage });
+      const originalError = new IModelsErrorImpl({ code: testCase.originalErrorCode, message: originalErrorMessage, statusCode: undefined, details: undefined });
 
       const result = ErrorAdapter.toIModelError(originalError, testCase.operationName);
 
@@ -145,7 +145,7 @@ describe("ErrorAdapter", () => {
 
     it(`should return IModelHubStatus.Unknown specific status could not be determined (${testCase.originalErrorCode})`, () => {
       const originalErrorMessage = "test error message";
-      const originalError = new IModelsErrorImpl({ code: testCase.originalErrorCode, message: originalErrorMessage });
+      const originalError = new IModelsErrorImpl({ code: testCase.originalErrorCode, message: originalErrorMessage, statusCode: undefined, details: undefined });
 
       const result = ErrorAdapter.toIModelError(originalError, testCase.operationName);
 

--- a/tests/imodels-clients-tests/src/unit/CommonErrorParsingTests.ts
+++ b/tests/imodels-clients-tests/src/unit/CommonErrorParsingTests.ts
@@ -34,7 +34,7 @@ export function testIModelsErrorParser(testedFunction: (response: ResponseInfo, 
     };
 
     // Act
-    const parsedError: IModelsError = testedFunction({ body: errorResponse }, new Error()) as IModelsError;
+    const parsedError: IModelsError = testedFunction({ statusCode: 422, body: errorResponse }, new Error()) as IModelsError;
 
     // Assert
     const expectedErrorMessage = "Cannot create iModel. Details:\n" +
@@ -45,6 +45,7 @@ export function testIModelsErrorParser(testedFunction: (response: ResponseInfo, 
       objectThrown: parsedError,
       expectedError: {
         code: IModelsErrorCode.InvalidIModelsRequest,
+        statusCode: 422,
         message: expectedErrorMessage,
         details: [
           {
@@ -83,6 +84,7 @@ export function testIModelsErrorParser(testedFunction: (response: ResponseInfo, 
       objectThrown: parsedError,
       expectedError: {
         code: IModelsErrorCode.Unauthorized,
+        statusCode: 422,
         message: "iModels API message"
       }
     });
@@ -103,6 +105,7 @@ export function testIModelsErrorParser(testedFunction: (response: ResponseInfo, 
       objectThrown: parsedError,
       expectedError: {
         code: IModelsErrorCode.Unauthorized,
+        statusCode: 401,
         message: "unwrapped error message"
       }
     });
@@ -120,6 +123,7 @@ export function testIModelsErrorParser(testedFunction: (response: ResponseInfo, 
       objectThrown: parsedError,
       expectedError: {
         code: IModelsErrorCode.Unauthorized,
+        statusCode: 401,
         message: "Authorization failed"
       }
     });
@@ -172,6 +176,7 @@ export function testIModelsErrorParser(testedFunction: (response: ResponseInfo, 
       objectThrown: parsedError,
       expectedError: {
         code: IModelsErrorCode.Unrecognized,
+        statusCode: 444,
         message: "Unknown error occurred.\n"+
           "Original error message: originalErrorMessage,\n"+
           "original error code: undefined,\n"+
@@ -190,6 +195,7 @@ export function testIModelsErrorParser(testedFunction: (response: ResponseInfo, 
       objectThrown: parsedError,
       expectedError: {
         code: IModelsErrorCode.Unrecognized,
+        statusCode: 445,
         message: "Unknown error occurred.\n"+
           "Original error message: originalErrorMessage,\n"+
           "original error code: undefined,\n"+
@@ -211,6 +217,7 @@ export function testIModelsErrorParser(testedFunction: (response: ResponseInfo, 
       objectThrown: parsedError,
       expectedError: {
         code: IModelsErrorCode.Unrecognized,
+        statusCode: 446,
         message: "Unknown error occurred.\n"+
           "Original error message: originalErrorMessage,\n"+
           "original error code: undefined,\n"+


### PR DESCRIPTION
- Add HTTP status code to iModels error
- Add `MutuallyExclusiveParametersProvided` as known error for `$search` parameter