### PR TITLE
Fix ConflictWithAnotherUser error code handling in ErrorAdapter

### DIFF
--- a/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
@@ -129,7 +129,8 @@ export class BackendIModelsAccess implements BackendHubAccess {
       changesetProperties: PlatformToClientAdapter.toChangesetPropertiesForCreate(arg.changesetProps, changesetDescription)
     };
     const createdChangeset: Changeset = await handleAPIErrors(
-      async () => this._iModelsClient.changesets.create(createChangesetParams)
+      async () => this._iModelsClient.changesets.create(createChangesetParams),
+      "createChangeset"
     );
 
     return createdChangeset.index;
@@ -307,7 +308,8 @@ export class BackendIModelsAccess implements BackendHubAccess {
     };
 
     await handleAPIErrors(
-      async () => this._iModelsClient.locks.update(updateLockParams)
+      async () => this._iModelsClient.locks.update(updateLockParams),
+      "updateLocks"
     );
   }
 
@@ -503,7 +505,8 @@ export class BackendIModelsAccess implements BackendHubAccess {
       };
 
       await handleAPIErrors(
-        async () => this._iModelsClient.locks.update(updateLockParams)
+        async () => this._iModelsClient.locks.update(updateLockParams),
+        "updateLocks"
       );
     }
   }

--- a/itwin-platform-access/imodels-access-common/src/ErrorAdapter.ts
+++ b/itwin-platform-access/imodels-access-common/src/ErrorAdapter.ts
@@ -8,9 +8,9 @@ import { IModelError } from "@itwin/core-common";
 
 import { IModelsError, IModelsErrorCode, isIModelsApiError } from "@itwin/imodels-client-management";
 
-export type OperationNameForErrorMapping 
-  = "acquireBriefcase" 
-  | "downloadChangesets" 
+export type OperationNameForErrorMapping
+  = "acquireBriefcase"
+  | "downloadChangesets"
   | "updateLocks"
   | "createChangeset";
 
@@ -108,7 +108,7 @@ export class ErrorAdapter {
 
     if (apiErrorCode === IModelsErrorCode.DownloadAborted && operationName === "downloadChangesets")
       return ChangeSetStatus.DownloadCancelled;
-  
+
     if (apiErrorCode === IModelsErrorCode.ConflictWithAnotherUser) {
       if (operationName === "createChangeset")
         return IModelHubStatus.AnotherUserPushing;

--- a/tests/imodels-access-common-tests/src/ErrorAdapter.test.ts
+++ b/tests/imodels-access-common-tests/src/ErrorAdapter.test.ts
@@ -75,7 +75,6 @@ describe("ErrorAdapter", () => {
     { originalErrorCode: IModelsErrorCode.VersionExists, expectedErrorNumber: IModelHubStatus.VersionAlreadyExists },
     { originalErrorCode: IModelsErrorCode.ChangesetExists, expectedErrorNumber: IModelHubStatus.ChangeSetAlreadyExists },
     { originalErrorCode: IModelsErrorCode.NamedVersionOnChangesetExists, expectedErrorNumber: IModelHubStatus.ChangeSetAlreadyHasVersion },
-    { originalErrorCode: IModelsErrorCode.ConflictWithAnotherUser, expectedErrorNumber: IModelHubStatus.AnotherUserPushing },
     { originalErrorCode: IModelsErrorCode.NewerChangesExist, expectedErrorNumber: IModelHubStatus.PullIsRequired },
     { originalErrorCode: IModelsErrorCode.BaselineFileInitializationTimedOut, expectedErrorNumber: IModelHubStatus.InitializationTimeout },
     { originalErrorCode: IModelsErrorCode.IModelFromTemplateInitializationTimedOut, expectedErrorNumber: IModelHubStatus.InitializationTimeout },
@@ -106,10 +105,20 @@ describe("ErrorAdapter", () => {
       originalErrorCode: IModelsErrorCode.DownloadAborted,
       operationName: "downloadChangesets" as const,
       expectedErrorNumber: ChangeSetStatus.DownloadCancelled
+    },
+    {
+      originalErrorCode: IModelsErrorCode.ConflictWithAnotherUser,
+      operationName: "createChangeset" as const,
+      expectedErrorNumber: IModelHubStatus.AnotherUserPushing
+    },
+    {
+      originalErrorCode: IModelsErrorCode.ConflictWithAnotherUser,
+      operationName: "updateLocks" as const,
+      expectedErrorNumber: IModelHubStatus.LockOwnedByAnotherBriefcase
     }
   ].forEach((testCase: { originalErrorCode: IModelsErrorCode, operationName: OperationNameForErrorMapping, expectedErrorNumber: number }) => {
 
-    it(`should handle generic error codes for specific operation (${testCase.originalErrorCode})`, () => {
+    it(`should handle generic error codes for specific operation (${testCase.originalErrorCode}, ${testCase.operationName})`, () => {
       const originalErrorMessage = "test error message";
       const originalError = new IModelsErrorImpl({ code: testCase.originalErrorCode, message: originalErrorMessage });
 
@@ -138,6 +147,10 @@ describe("ErrorAdapter", () => {
     },
     {
       originalErrorCode: IModelsErrorCode.DownloadAborted,
+      operationName: "acquireBriefcase" as const
+    },
+    {
+      originalErrorCode: IModelsErrorCode.ConflictWithAnotherUser,
       operationName: "acquireBriefcase" as const
     }
   ].forEach((testCase: { originalErrorCode: IModelsErrorCode, operationName: OperationNameForErrorMapping | undefined }) => {

--- a/tests/imodels-clients-tests/src/integration/management/IModelOperations.test.ts
+++ b/tests/imodels-clients-tests/src/integration/management/IModelOperations.test.ts
@@ -264,7 +264,7 @@ describe("[Management] IModelOperations", () => {
       authorization,
       urlParams: {
         iTwinId,
-        $search: "For search"
+        $search: testIModelGroup.getPrefixedUniqueIModelName("test iModel for update and for Sear")
       },
       headers: {
         "X-Correlation-Id": randomUUID()
@@ -520,7 +520,7 @@ describe("[Management] IModelOperations", () => {
       }
     });
 
-    const newIModelName = testIModelGroup.getPrefixedUniqueIModelName("new iModel name for search");
+    const newIModelName = testIModelGroup.getPrefixedUniqueIModelName("TEST iModel for update and for search Updated");
     const updateIModelParams: UpdateIModelParams = {
       authorization,
       iModelId: testIModelForUpdate.id,

--- a/tests/imodels-clients-tests/src/integration/management/IModelOperations.test.ts
+++ b/tests/imodels-clients-tests/src/integration/management/IModelOperations.test.ts
@@ -520,7 +520,7 @@ describe("[Management] IModelOperations", () => {
       }
     });
 
-    const newIModelName = testIModelGroup.getPrefixedUniqueIModelName("TEST iModel for update and for search Updated");
+    const newIModelName = testIModelGroup.getPrefixedUniqueIModelName("Test iModel for update and for search updated");
     const updateIModelParams: UpdateIModelParams = {
       authorization,
       iModelId: testIModelForUpdate.id,


### PR DESCRIPTION
- Fix `ConflictWithAnotherUser` error code handling in `ErrorAdapter`
- Make iModel filtering by `$search` integration tests less flaky while running in parallel on multiple machines