### PR TITLE
Fix reusable iModel creation in integration tests

### DIFF
--- a/utils/imodels-client-test-utils/src/test-context-providers/imodel/ReusableTestIModelProvider.ts
+++ b/utils/imodels-client-test-utils/src/test-context-providers/imodel/ReusableTestIModelProvider.ts
@@ -2,9 +2,10 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import { sleep } from "@itwin/imodels-client-management/lib/base/internal";
 import { injectable } from "inversify";
 
-import { DeleteIModelParams } from "@itwin/imodels-client-authoring";
+import { DeleteIModelParams, IModel } from "@itwin/imodels-client-authoring";
 
 import { TestAuthorizationProvider } from "../auth/TestAuthorizationProvider";
 
@@ -43,7 +44,27 @@ export class ReusableTestIModelProvider {
       return this._testIModelCreator.createReusable(this._config.testIModelName);
     }
 
-    return this._testIModelRetriever.queryRelatedData(existingReusableIModel);
+    return await this.waitForInitializedIModel(existingReusableIModel);
+  }
+
+  private async waitForInitializedIModel(iModel: IModel): Promise<ReusableIModelMetadata> {
+    const timeoutInMs = 3 * 60 * 1000; // 3 minutes
+    const pollingIntervalInMs = 5 * 1000; // 5 seconds
+
+    for (let attempt = 0; attempt < Math.ceil(timeoutInMs / pollingIntervalInMs); attempt++) {
+      if (this._testIModelCreator.isReusableIModelInitialized(iModel)) {
+        return this._testIModelRetriever.queryRelatedData(iModel);
+      }
+
+      await sleep(pollingIntervalInMs);
+
+      iModel = await this._iModelsClient.iModels.getSingle({
+        authorization: this._testAuthorizationProvider.getAdmin1Authorization(),
+        iModelId: iModel.id
+      });
+    }
+
+    throw Error("Timed out while waiting for reusable iModel to be initialized.");
   }
 
   private async deleteIModel(iModelId: string): Promise<void> {
@@ -53,5 +74,4 @@ export class ReusableTestIModelProvider {
     };
     return this._iModelsClient.iModels.delete(deleteIModelParams);
   }
-
 }

--- a/utils/imodels-client-test-utils/src/test-context-providers/imodel/ReusableTestIModelProvider.ts
+++ b/utils/imodels-client-test-utils/src/test-context-providers/imodel/ReusableTestIModelProvider.ts
@@ -44,7 +44,7 @@ export class ReusableTestIModelProvider {
       return this._testIModelCreator.createReusable(this._config.testIModelName);
     }
 
-    return await this.waitForInitializedIModel(existingReusableIModel);
+    return this.waitForInitializedIModel(existingReusableIModel);
   }
 
   private async waitForInitializedIModel(iModel: IModel): Promise<ReusableIModelMetadata> {

--- a/utils/imodels-client-test-utils/src/test-context-providers/imodel/TestIModelCreator.ts
+++ b/utils/imodels-client-test-utils/src/test-context-providers/imodel/TestIModelCreator.ts
@@ -29,8 +29,8 @@ export class TestIModelCreator {
     { description: "Another one", changesetIndexes: [4, 5, 6] }
   ];
 
-  private readonly _nonInitializedIModelDescription = "Initializing iModel";
-  private readonly _initializedIModelDescription = "Some description";
+  private readonly _reusableIModelCreationInProgressDescription = "Reusable iModel creation in progress";
+  private readonly _reusableIModelCreationCompletedDescription = "Reusable iModel creation completed";
   private readonly _briefcaseDeviceName = "Some device name";
 
   constructor(
@@ -40,7 +40,7 @@ export class TestIModelCreator {
     private readonly _testIModelFileProvider: TestIModelFileProvider
   ) { }
 
-  public async createEmpty(iModelName: string, iModelDescription: string = this._initializedIModelDescription): Promise<IModelMetadata> {
+  public async createEmpty(iModelName: string, iModelDescription: string = "Some description"): Promise<IModelMetadata> {
     const iTwinId = await this._testITwinProvider.getOrCreate();
     const iModel = await this._iModelsClient.iModels.createEmpty({
       authorization: this._testAuthorizationProvider.getAdmin1Authorization(),
@@ -67,7 +67,7 @@ export class TestIModelCreator {
   }
 
   public async createReusable(iModelName: string): Promise<ReusableIModelMetadata> {
-    const iModel = await this.createEmpty(iModelName, this._nonInitializedIModelDescription);
+    const iModel = await this.createEmpty(iModelName, this._reusableIModelCreationInProgressDescription);
     const briefcases = await this.acquireBriefcases(iModel.id, TestIModelCreator.briefcaseCount);
     const changesetGroups = await this.createChangesetGroups(iModel.id);
     await this.uploadChangesets(iModel.id, briefcases[0].id, changesetGroups);
@@ -78,7 +78,7 @@ export class TestIModelCreator {
       authorization: this._testAuthorizationProvider.getAdmin1Authorization(),
       iModelId: iModel.id,
       iModelProperties: {
-        description: this._initializedIModelDescription
+        description: this._reusableIModelCreationCompletedDescription
       }
     });
 
@@ -93,7 +93,7 @@ export class TestIModelCreator {
   }
 
   public isReusableIModelInitialized(iModel: IModel): boolean {
-    return iModel.description === this._initializedIModelDescription;
+    return iModel.description === this._reusableIModelCreationCompletedDescription;
   }
 
   private async createNamedVersionsOnReusableIModel(iModelId: string): Promise<NamedVersionMetadata[]> {


### PR DESCRIPTION
Fix reusable iModel creation in integration tests