### PR TITLE
Fix file download cancellation handling

### DIFF
--- a/clients/imodels-client-authoring/src/base/types/CommonInterfaces.ts
+++ b/clients/imodels-client-authoring/src/base/types/CommonInterfaces.ts
@@ -26,7 +26,7 @@ export type ProgressCallback = (downloaded: number, total: number) => void;
 
 /** Common parameters for progress reporting download operations. */
 export interface DownloadProgressParam {
-  /** 
+  /**
    * Function called to report download progress.
    * IMPORTANT: This function should never throw an error or cancel the download, otherwise it may result in unexpected behavior.
    */

--- a/clients/imodels-client-authoring/src/base/types/CommonInterfaces.ts
+++ b/clients/imodels-client-authoring/src/base/types/CommonInterfaces.ts
@@ -26,7 +26,10 @@ export type ProgressCallback = (downloaded: number, total: number) => void;
 
 /** Common parameters for progress reporting download operations. */
 export interface DownloadProgressParam {
-  /** Function called to report download progress. */
+  /** 
+   * Function called to report download progress.
+   * IMPORTANT: This function should never throw an error or cancel the download, otherwise it may result in unexpected behavior.
+   */
   progressCallback?: ProgressCallback;
   /** Abort signal for cancelling download. */
   abortSignal?: GenericAbortSignal;

--- a/common/changes/@itwin/imodels-access-backend/enable-download-cancellation-test_2024-08-16-09-11.json
+++ b/common/changes/@itwin/imodels-access-backend/enable-download-cancellation-test_2024-08-16-09-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodels-access-backend",
+      "comment": "Fix file download cancellation handling.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodels-access-backend"
+}

--- a/common/changes/@itwin/imodels-client-authoring/enable-download-cancellation-test_2024-08-16-09-11.json
+++ b/common/changes/@itwin/imodels-client-authoring/enable-download-cancellation-test_2024-08-16-09-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodels-client-authoring",
+      "comment": "Add a documentation comment to inform users to not throw errors inside progress callback functions passed to operations that download files.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodels-client-authoring"
+}

--- a/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
@@ -33,7 +33,7 @@ import {
 
 import { getV1CheckpointSize, queryCurrentOrPrecedingV1Checkpoint, queryCurrentOrPrecedingV2Checkpoint } from "./CheckpointHelperFunctions";
 import { ClientToPlatformAdapter } from "./interface-adapters/ClientToPlatformAdapter";
-import { DownloadAbortWatchdogFunc, PlatformToClientAdapter } from "./interface-adapters/PlatformToClientAdapter";
+import { DownloadCancellationMonitorFunc, PlatformToClientAdapter } from "./interface-adapters/PlatformToClientAdapter";
 
 export class BackendIModelsAccess implements BackendHubAccess {
   protected readonly _iModelsClient: IModelsClient;
@@ -49,10 +49,10 @@ export class BackendIModelsAccess implements BackendHubAccess {
     };
     downloadParams.urlParams = PlatformToClientAdapter.toChangesetRangeUrlParams(arg.range);
 
-    let downloadAbortWatchdogFunc: DownloadAbortWatchdogFunc | undefined;
+    let downloadCancellationMonitorFunc: DownloadCancellationMonitorFunc | undefined;
     try {
       const downloadProgressParams = PlatformToClientAdapter.toDownloadProgressParam(arg.progressCallback);
-      downloadAbortWatchdogFunc = downloadProgressParams?.downloadAbortWatchdogFunc;
+      downloadCancellationMonitorFunc = downloadProgressParams?.downloadCancellationMonitorFunc;
       downloadParams.progressCallback = downloadProgressParams?.progressCallback;
       downloadParams.abortSignal = downloadProgressParams?.abortSignal;
 
@@ -64,7 +64,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
       const result: ChangesetFileProps[] = downloadedChangesets.map(ClientToPlatformAdapter.toChangesetFileProps);
       return result;
     } finally {
-      downloadAbortWatchdogFunc?.({ shouldAbort: false });
+      downloadCancellationMonitorFunc?.({ shouldCancel: false });
     }
   }
 
@@ -75,10 +75,10 @@ export class BackendIModelsAccess implements BackendHubAccess {
       targetDirectoryPath: arg.targetDir
     };
 
-    let downloadAbortWatchdogFunc: DownloadAbortWatchdogFunc | undefined;
+    let downloadCancellationMonitorFunc: DownloadCancellationMonitorFunc | undefined;
     try {
       const downloadProgressParams = PlatformToClientAdapter.toDownloadProgressParam(arg.progressCallback);
-      downloadAbortWatchdogFunc = downloadProgressParams?.downloadAbortWatchdogFunc;
+      downloadCancellationMonitorFunc = downloadProgressParams?.downloadCancellationMonitorFunc;
       downloadSingleChangesetParams.progressCallback = downloadProgressParams?.progressCallback;
       downloadSingleChangesetParams.abortSignal = downloadProgressParams?.abortSignal;
 
@@ -98,7 +98,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
       const result: ChangesetFileProps = ClientToPlatformAdapter.toChangesetFileProps(downloadedChangeset);
       return result;
     } finally {
-      downloadAbortWatchdogFunc?.({ shouldAbort: false });
+      downloadCancellationMonitorFunc?.({ shouldCancel: false });
     }
   }
 
@@ -255,10 +255,10 @@ export class BackendIModelsAccess implements BackendHubAccess {
 
     const v1CheckpointSize = await getV1CheckpointSize(checkpoint._links.download.href);
 
-    let downloadAbortWatchdogFunc: DownloadAbortWatchdogFunc | undefined;
+    let downloadCancellationMonitorFunc: DownloadCancellationMonitorFunc | undefined;
     try {
       const downloadProgressParams = PlatformToClientAdapter.toDownloadProgressParam(arg.onProgress);
-      downloadAbortWatchdogFunc = downloadProgressParams?.downloadAbortWatchdogFunc;
+      downloadCancellationMonitorFunc = downloadProgressParams?.downloadCancellationMonitorFunc;
       const totalDownloadCallback = downloadProgressParams?.progressCallback
         ? (downloaded: number) => downloadProgressParams.progressCallback?.(downloaded, v1CheckpointSize)
         : undefined;
@@ -276,7 +276,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
 
       return { index: checkpoint.changesetIndex, id: checkpoint.changesetId };
     } finally {
-      downloadAbortWatchdogFunc?.({ shouldAbort: false });
+      downloadCancellationMonitorFunc?.({ shouldCancel: false });
     }
   }
 

--- a/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
@@ -33,7 +33,7 @@ import {
 
 import { getV1CheckpointSize, queryCurrentOrPrecedingV1Checkpoint, queryCurrentOrPrecedingV2Checkpoint } from "./CheckpointHelperFunctions";
 import { ClientToPlatformAdapter } from "./interface-adapters/ClientToPlatformAdapter";
-import { PlatformToClientAdapter } from "./interface-adapters/PlatformToClientAdapter";
+import { DownloadAbortWatchdogFunc, PlatformToClientAdapter } from "./interface-adapters/PlatformToClientAdapter";
 
 export class BackendIModelsAccess implements BackendHubAccess {
   protected readonly _iModelsClient: IModelsClient;
@@ -49,20 +49,23 @@ export class BackendIModelsAccess implements BackendHubAccess {
     };
     downloadParams.urlParams = PlatformToClientAdapter.toChangesetRangeUrlParams(arg.range);
 
-    let triggerDownloadCancellationFunc: ((shouldCancel: boolean) => void) | undefined;
+    let downloadAbortWatchdogFunc: DownloadAbortWatchdogFunc | undefined;
+    try {
+      const downloadProgressParams = PlatformToClientAdapter.toDownloadProgressParam(arg.progressCallback);
+      downloadAbortWatchdogFunc = downloadProgressParams?.downloadAbortWatchdogFunc;
+      downloadParams.progressCallback = downloadProgressParams?.progressCallback;
+      downloadParams.abortSignal = downloadProgressParams?.abortSignal;
 
+      const downloadedChangesets: DownloadedChangeset[] = await handleAPIErrors(
+        async () => this._iModelsClient.changesets.downloadList(downloadParams),
+        "downloadChangesets"
+      );
 
-    [const progressCallback, const abortSignal, triggerDownloadCancellationFunc] = PlatformToClientAdapter.toProgressCallback(arg.progressCallback) ?? [];
-    downloadParams.progressCallback = progressCallback;
-    downloadParams.abortSignal = abortSignal;
-
-    const downloadedChangesets: DownloadedChangeset[] = await handleAPIErrors(
-      async () => this._iModelsClient.changesets.downloadList(downloadParams),
-      "downloadChangesets"
-    );
-
-    const result: ChangesetFileProps[] = downloadedChangesets.map(ClientToPlatformAdapter.toChangesetFileProps);
-    return result;
+      const result: ChangesetFileProps[] = downloadedChangesets.map(ClientToPlatformAdapter.toChangesetFileProps);
+      return result;
+    } finally {
+      downloadAbortWatchdogFunc?.({ shouldAbort: false });
+    }
   }
 
   public async downloadChangeset(arg: DownloadChangesetArg): Promise<ChangesetFileProps> {
@@ -72,25 +75,31 @@ export class BackendIModelsAccess implements BackendHubAccess {
       targetDirectoryPath: arg.targetDir
     };
 
-    const [progressCallback, abortSignal] = PlatformToClientAdapter.toProgressCallback(arg.progressCallback) ?? [];
-    downloadSingleChangesetParams.progressCallback = progressCallback;
-    downloadSingleChangesetParams.abortSignal = abortSignal;
+    let downloadAbortWatchdogFunc: DownloadAbortWatchdogFunc | undefined;
+    try {
+      const downloadProgressParams = PlatformToClientAdapter.toDownloadProgressParam(arg.progressCallback);
+      downloadAbortWatchdogFunc = downloadProgressParams?.downloadAbortWatchdogFunc;
+      downloadSingleChangesetParams.progressCallback = downloadProgressParams?.progressCallback;
+      downloadSingleChangesetParams.abortSignal = downloadProgressParams?.abortSignal;
 
-    const downloadedChangeset: DownloadedChangeset = await handleAPIErrors(
-      async () => {
-        const stopwatch = new StopWatch(`[${arg.changeset.id}]`, true);
-        Logger.logInfo("BackendIModelsAccess", `Starting download of changeset with id ${stopwatch.description}`);
+      const downloadedChangeset: DownloadedChangeset = await handleAPIErrors(
+        async () => {
+          const stopwatch = new StopWatch(`[${arg.changeset.id}]`, true);
+          Logger.logInfo("BackendIModelsAccess", `Starting download of changeset with id ${stopwatch.description}`);
 
-        const innerResult = await this._iModelsClient.changesets.downloadSingle(downloadSingleChangesetParams);
+          const innerResult = await this._iModelsClient.changesets.downloadSingle(downloadSingleChangesetParams);
 
-        Logger.logInfo("BackendIModelsAccess", `Downloaded changeset with id ${stopwatch.description} (${stopwatch.elapsedSeconds} seconds)`);
-        return innerResult;
-      },
-      "downloadChangesets"
-    );
+          Logger.logInfo("BackendIModelsAccess", `Downloaded changeset with id ${stopwatch.description} (${stopwatch.elapsedSeconds} seconds)`);
+          return innerResult;
+        },
+        "downloadChangesets"
+      );
 
-    const result: ChangesetFileProps = ClientToPlatformAdapter.toChangesetFileProps(downloadedChangeset);
-    return result;
+      const result: ChangesetFileProps = ClientToPlatformAdapter.toChangesetFileProps(downloadedChangeset);
+      return result;
+    } finally {
+      downloadAbortWatchdogFunc?.({ shouldAbort: false });
+    }
   }
 
   public async queryChangeset(arg: ChangesetArg): Promise<ChangesetProps> {
@@ -245,21 +254,30 @@ export class BackendIModelsAccess implements BackendHubAccess {
       throw new IModelError(BriefcaseStatus.VersionNotFound, "V1 checkpoint not found");
 
     const v1CheckpointSize = await getV1CheckpointSize(checkpoint._links.download.href);
-    const [progressCallback, abortSignal] = PlatformToClientAdapter.toProgressCallback(arg.onProgress) ?? [];
-    const totalDownloadCallback = progressCallback ? (downloaded: number) => progressCallback?.(downloaded, v1CheckpointSize) : undefined;
 
-    const stopwatch = new StopWatch(`[${checkpoint.changesetId}]`, true);
-    Logger.logInfo("BackendIModelsAccess", `Starting download of checkpoint with id ${stopwatch.description}`);
-    await downloadFile({
-      storage: this._iModelsClient.cloudStorage,
-      url: checkpoint._links.download.href,
-      localPath: arg.localFile,
-      totalDownloadCallback,
-      abortSignal
-    });
-    Logger.logInfo("BackendIModelsAccess", `Downloaded checkpoint with id ${stopwatch.description} (${stopwatch.elapsedSeconds} seconds)`);
-
-    return { index: checkpoint.changesetIndex, id: checkpoint.changesetId };
+    let downloadAbortWatchdogFunc: DownloadAbortWatchdogFunc | undefined;
+    try {
+      const downloadProgressParams = PlatformToClientAdapter.toDownloadProgressParam(arg.onProgress);
+      downloadAbortWatchdogFunc = downloadProgressParams?.downloadAbortWatchdogFunc;
+      const totalDownloadCallback = downloadProgressParams?.progressCallback
+        ? (downloaded: number) => downloadProgressParams.progressCallback?.(downloaded, v1CheckpointSize)
+        : undefined;
+  
+      const stopwatch = new StopWatch(`[${checkpoint.changesetId}]`, true);
+      Logger.logInfo("BackendIModelsAccess", `Starting download of checkpoint with id ${stopwatch.description}`);
+      await downloadFile({
+        storage: this._iModelsClient.cloudStorage,
+        url: checkpoint._links.download.href,
+        localPath: arg.localFile,
+        totalDownloadCallback,
+        abortSignal: downloadProgressParams?.abortSignal
+      });
+      Logger.logInfo("BackendIModelsAccess", `Downloaded checkpoint with id ${stopwatch.description} (${stopwatch.elapsedSeconds} seconds)`);
+  
+      return { index: checkpoint.changesetIndex, id: checkpoint.changesetId };
+    } finally {
+      downloadAbortWatchdogFunc?.({ shouldAbort: false });
+    }
   }
 
   public async queryV2Checkpoint(arg: CheckpointProps): Promise<V2CheckpointAccessProps | undefined> {
@@ -435,7 +453,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
       const foundWalFile = IModelJsFs.existsSync(`${baselineFilePath}-wal`);
       const db = IModelDb.openDgnDb({ path: baselineFilePath }, OpenMode.ReadWrite);
       if (foundWalFile) {
-        Logger.logWarning("BackendIModelsAccess", "Wal file found while uploading file, performing checkpoint.", {baselineFilePath});
+        Logger.logWarning("BackendIModelsAccess", "Wal file found while uploading file, performing checkpoint.", { baselineFilePath });
         db.performCheckpoint();
       }
       this.closeFile(db);

--- a/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
@@ -262,7 +262,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
       const totalDownloadCallback = downloadProgressParams?.progressCallback
         ? (downloaded: number) => downloadProgressParams.progressCallback?.(downloaded, v1CheckpointSize)
         : undefined;
-  
+
       const stopwatch = new StopWatch(`[${checkpoint.changesetId}]`, true);
       Logger.logInfo("BackendIModelsAccess", `Starting download of checkpoint with id ${stopwatch.description}`);
       await downloadFile({
@@ -273,7 +273,7 @@ export class BackendIModelsAccess implements BackendHubAccess {
         abortSignal: downloadProgressParams?.abortSignal
       });
       Logger.logInfo("BackendIModelsAccess", `Downloaded checkpoint with id ${stopwatch.description} (${stopwatch.elapsedSeconds} seconds)`);
-  
+
       return { index: checkpoint.changesetIndex, id: checkpoint.changesetId };
     } finally {
       downloadAbortWatchdogFunc?.({ shouldAbort: false });

--- a/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
@@ -49,7 +49,10 @@ export class BackendIModelsAccess implements BackendHubAccess {
     };
     downloadParams.urlParams = PlatformToClientAdapter.toChangesetRangeUrlParams(arg.range);
 
-    const [progressCallback, abortSignal] = PlatformToClientAdapter.toProgressCallback(arg.progressCallback) ?? [];
+    let triggerDownloadCancellationFunc: ((shouldCancel: boolean) => void) | undefined;
+
+
+    [const progressCallback, const abortSignal, triggerDownloadCancellationFunc] = PlatformToClientAdapter.toProgressCallback(arg.progressCallback) ?? [];
     downloadParams.progressCallback = progressCallback;
     downloadParams.abortSignal = abortSignal;
 

--- a/itwin-platform-access/imodels-access-backend/src/interface-adapters/PlatformToClientAdapter.ts
+++ b/itwin-platform-access/imodels-access-backend/src/interface-adapters/PlatformToClientAdapter.ts
@@ -12,7 +12,7 @@ import {
   LockLevel, LockedObjects
 } from "@itwin/imodels-client-authoring";
 
-type DownloadAbortWatchdogFuncParams = { shouldAbort: boolean };
+interface DownloadAbortWatchdogFuncParams { shouldAbort: boolean }
 export type DownloadAbortWatchdogFunc = (params: DownloadAbortWatchdogFuncParams) => void;
 
 export class PlatformToClientAdapter {
@@ -85,21 +85,20 @@ export class PlatformToClientAdapter {
 
     const abortController = new AbortController();
 
-    // We construct a promise that will resolve when the `cancel !== ProgressStatus.Continue` condition inside progress callback is met.
-    // Once it resolves, it will call `abortController.abort` to cancel the download.
+    // We construct a promise which, if resolved with `{ shouldAbort: true }`, will abort the download.
     // We have to do this instead of calling `abortController.abort` inside `progressCallback` function because `progressCallback` is called inside "on `data`"
-    // event handler of the download stream, which is out of the execution context of the `iModelsClient.changesets.downloadList` function.
-    // That results in an unhandled exception.
+    // event handler of the download stream, which is out of the execution context of the `iModelsClient.changesets.downloadList` function. That results in an
+    // unhandled exception.
     let downloadAbortWatchdogFunc: DownloadAbortWatchdogFunc = undefined!;
-    new Promise<DownloadAbortWatchdogFuncParams>((resolve) => {
+    void new Promise<DownloadAbortWatchdogFuncParams>((resolve) => {
       downloadAbortWatchdogFunc = resolve;
     }).then((params: DownloadAbortWatchdogFuncParams) => {
       console.log("inside then");
       if (params.shouldAbort) {
-        console.log("aborting")
+        console.log("aborting");
         abortController.abort();
       } else {
-        console.log("not aborting")
+        console.log("not aborting");
       }
     });
 

--- a/itwin-platform-access/imodels-access-backend/src/interface-adapters/PlatformToClientAdapter.ts
+++ b/itwin-platform-access/imodels-access-backend/src/interface-adapters/PlatformToClientAdapter.ts
@@ -97,16 +97,8 @@ export class PlatformToClientAdapter {
     void new Promise<DownloadCancellationMonitorFuncParams>((resolve) => {
       downloadCancellationMonitorFunc = resolve;
     }).then((params: DownloadCancellationMonitorFuncParams) => {
-      // eslint-disable-next-line no-console
-      console.log("inside then");
-      if (params.shouldCancel) {
-        // eslint-disable-next-line no-console
-        console.log("aborting");
+      if (params.shouldCancel)
         abortController.abort();
-      } else {
-        // eslint-disable-next-line no-console
-        console.log("not aborting");
-      }
     });
 
     const convertedProgressCallback = (downloaded: number, total: number) => {

--- a/itwin-platform-access/imodels-access-backend/src/interface-adapters/PlatformToClientAdapter.ts
+++ b/itwin-platform-access/imodels-access-backend/src/interface-adapters/PlatformToClientAdapter.ts
@@ -79,6 +79,10 @@ export class PlatformToClientAdapter {
     };
   }
 
+  /**
+   * @returns `progressCallback` and `abortSignal` instances to pass to iModels client functions, and `downloadAbortWatchdogFunc`.
+   * IMPORTANT: `downloadAbortWatchdogFunc` must be called at least once to not leave pending promises.
+   */
   public static toDownloadProgressParam(progressCallback?: ProgressFunction): (DownloadProgressParam & { downloadAbortWatchdogFunc: DownloadAbortWatchdogFunc }) | undefined {
     if (!progressCallback)
       return;

--- a/itwin-platform-access/imodels-access-backend/src/interface-adapters/PlatformToClientAdapter.ts
+++ b/itwin-platform-access/imodels-access-backend/src/interface-adapters/PlatformToClientAdapter.ts
@@ -93,11 +93,14 @@ export class PlatformToClientAdapter {
     void new Promise<DownloadAbortWatchdogFuncParams>((resolve) => {
       downloadAbortWatchdogFunc = resolve;
     }).then((params: DownloadAbortWatchdogFuncParams) => {
+      // eslint-disable-next-line no-console
       console.log("inside then");
       if (params.shouldAbort) {
+        // eslint-disable-next-line no-console
         console.log("aborting");
         abortController.abort();
       } else {
+        // eslint-disable-next-line no-console
         console.log("not aborting");
       }
     });

--- a/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
+++ b/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
@@ -137,7 +137,7 @@ describe("BackendIModelsAccess", () => {
       }
     });
 
-    it.skip("should cancel changesets download and finish downloading missing changesets during next download", async () => {
+    it.only("should cancel changesets download and finish downloading missing changesets during next download", async () => {
       // Arrange
       const downloadChangesetsParams: DownloadChangesetRangeArg = {
         accessToken,

--- a/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
+++ b/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
@@ -137,41 +137,6 @@ describe("BackendIModelsAccess", () => {
       }
     });
 
-    it.only("should cancel single changeset download", async () => {
-      // Arrange
-      const firstChangesetInfo = testIModelFileProvider.changesets[0];
-      const downloadChangesetsParams: DownloadChangesetArg = {
-        accessToken,
-        iModelId: testIModelForRead.id,
-        targetDir: testDownloadPath,
-        changeset: firstChangesetInfo
-      };
-
-      let progressReports: ProgressReport[] = [];
-      const progressCallbackForDownload = (downloaded: number, total: number) => {
-        progressReports.push({ downloaded, total });
-        return downloaded < total / 4 ? ProgressStatus.Continue : ProgressStatus.Abort;
-      };
-
-      // Act
-      let thrownError: unknown;
-      try {
-        await backendIModelsAccess.downloadChangeset({
-          ...downloadChangesetsParams,
-          progressCallback: progressCallbackForDownload
-        });
-      } catch (error: unknown) {
-        thrownError = error;
-      }
-
-      // Assert #1
-      const expectedErrorNumber = ChangeSetStatus.CHANGESET_ERROR_BASE + 26; // ChangeSetStatus.DownloadCancelled (only available from iTwinJs 3.5)
-      expect(thrownError).to.ownProperty("errorNumber", expectedErrorNumber);
-
-      expect(fs.readdirSync(testDownloadPath).length).to.be.greaterThan(0);
-      assertProgressReports(progressReports, false);
-    });
-
     it.only("should cancel changesets download and finish downloading missing changesets during next download", async () => {
       // Arrange
       const downloadChangesetsParams: DownloadChangesetRangeArg = {

--- a/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
+++ b/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
@@ -6,7 +6,7 @@ import { assert } from "console";
 import * as fs from "fs";
 import * as path from "path";
 
-import { AcquireNewBriefcaseIdArg, BriefcaseDbArg, ChangesetRangeArg, CheckpointProps, CreateNewIModelProps, DownloadChangesetRangeArg, DownloadRequest, IModelHost, IModelIdArg, IModelJsFs, LockMap, LockProps, LockState, PhysicalModel, ProgressFunction, ProgressStatus, StandaloneDb, V2CheckpointAccessProps } from "@itwin/core-backend";
+import { AcquireNewBriefcaseIdArg, BriefcaseDbArg, ChangesetRangeArg, CheckpointProps, CreateNewIModelProps, DownloadChangesetArg, DownloadChangesetRangeArg, DownloadRequest, IModelHost, IModelIdArg, IModelJsFs, LockMap, LockProps, LockState, PhysicalModel, ProgressFunction, ProgressStatus, StandaloneDb, V2CheckpointAccessProps } from "@itwin/core-backend";
 import { Guid, Logger } from "@itwin/core-bentley";
 import { BriefcaseId, ChangeSetStatus, ChangesetFileProps, ChangesetIndexAndId, ChangesetType, IModel as CoreIModel, LocalDirName } from "@itwin/core-common";
 import { BackendIModelsAccess } from "@itwin/imodels-access-backend";
@@ -135,6 +135,41 @@ describe("BackendIModelsAccess", () => {
         else
           expect(downloadedChangeset.changesType).to.be.equal(ChangesetType.Regular);
       }
+    });
+
+    it.only("should cancel single changeset download", async () => {
+      // Arrange
+      const firstChangesetInfo = testIModelFileProvider.changesets[0];
+      const downloadChangesetsParams: DownloadChangesetArg = {
+        accessToken,
+        iModelId: testIModelForRead.id,
+        targetDir: testDownloadPath,
+        changeset: firstChangesetInfo
+      };
+
+      let progressReports: ProgressReport[] = [];
+      const progressCallbackForDownload = (downloaded: number, total: number) => {
+        progressReports.push({ downloaded, total });
+        return downloaded < total / 4 ? ProgressStatus.Continue : ProgressStatus.Abort;
+      };
+
+      // Act
+      let thrownError: unknown;
+      try {
+        await backendIModelsAccess.downloadChangeset({
+          ...downloadChangesetsParams,
+          progressCallback: progressCallbackForDownload
+        });
+      } catch (error: unknown) {
+        thrownError = error;
+      }
+
+      // Assert #1
+      const expectedErrorNumber = ChangeSetStatus.CHANGESET_ERROR_BASE + 26; // ChangeSetStatus.DownloadCancelled (only available from iTwinJs 3.5)
+      expect(thrownError).to.ownProperty("errorNumber", expectedErrorNumber);
+
+      expect(fs.readdirSync(testDownloadPath).length).to.be.greaterThan(0);
+      assertProgressReports(progressReports, false);
     });
 
     it.only("should cancel changesets download and finish downloading missing changesets during next download", async () => {

--- a/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
+++ b/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
@@ -6,7 +6,7 @@ import { assert } from "console";
 import * as fs from "fs";
 import * as path from "path";
 
-import { AcquireNewBriefcaseIdArg, BriefcaseDbArg, ChangesetRangeArg, CheckpointProps, CreateNewIModelProps, DownloadChangesetArg, DownloadChangesetRangeArg, DownloadRequest, IModelHost, IModelIdArg, IModelJsFs, LockMap, LockProps, LockState, PhysicalModel, ProgressFunction, ProgressStatus, StandaloneDb, V2CheckpointAccessProps } from "@itwin/core-backend";
+import { AcquireNewBriefcaseIdArg, BriefcaseDbArg, ChangesetRangeArg, CheckpointProps, CreateNewIModelProps, DownloadChangesetRangeArg, DownloadRequest, IModelHost, IModelIdArg, IModelJsFs, LockMap, LockProps, LockState, PhysicalModel, ProgressFunction, ProgressStatus, StandaloneDb, V2CheckpointAccessProps } from "@itwin/core-backend";
 import { Guid, Logger } from "@itwin/core-bentley";
 import { BriefcaseId, ChangeSetStatus, ChangesetFileProps, ChangesetIndexAndId, ChangesetType, IModel as CoreIModel, LocalDirName } from "@itwin/core-common";
 import { BackendIModelsAccess } from "@itwin/imodels-access-backend";

--- a/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
+++ b/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
@@ -137,7 +137,7 @@ describe("BackendIModelsAccess", () => {
       }
     });
 
-    it.only("should cancel changesets download and finish downloading missing changesets during next download", async () => {
+    it("should cancel changesets download and finish downloading missing changesets during next download", async () => {
       // Arrange
       const downloadChangesetsParams: DownloadChangesetRangeArg = {
         accessToken,

--- a/tests/imodels-clients-tests/src/integration/authoring/ChangesetOperations.test.ts
+++ b/tests/imodels-clients-tests/src/integration/authoring/ChangesetOperations.test.ts
@@ -488,28 +488,27 @@ describe("[Authoring] ChangesetOperations", () => {
       assertProgressReports(progressReports);
     });
 
-    it.only("should cancel changesets download", async () => {
+    it("should cancel changesets download", async () => {
       // Arrange
       const abortController = new AbortController();
       const abortSignal = abortController.signal;
 
-      // `waitForSomeProgressReportedPromise` is used to wait before aborting the download to ensure that some files have been downloaded.
-      // Its `resolve` function is saved into `waitForSomeProgressReportedPromiseResolveFunc` variable and called once we download some changesets,
-      // `waitForSomeProgressReportedPromise` resolves and we can then immediately call `abortController.abort`.
+      // `triggerDownloadCancellationPromise` is used to wait before aborting the download to ensure that some files have been downloaded.
+      // Its `resolve` function is saved into `triggerDownloadCancellation` variable and called once we download some changesets,
+      // `triggerDownloadCancellationPromise` resolves and we can then immediately call `abortController.abort`.
       // We have to do this instead of calling `abortController.abort` inside `progressCallback` function because `progressCallback` is called inside "on `data`"
       // event handler of the download stream, which is out of the execution context of the `downloadList` function. That results in an unhandled exception.
-      let waitForSomeProgressReportedPromiseResolveFunc: () => void = undefined!;
-      const waitForSomeProgressReportedPromise = new Promise<void>(resolve => {
-        waitForSomeProgressReportedPromiseResolveFunc = resolve;
+      let triggerDownloadCancellation: () => void = undefined!;
+      const triggerDownloadCancellationPromise = new Promise<void>(resolve => {
+        triggerDownloadCancellation = resolve;
       });
 
       const progressReports: ProgressReport[] = [];
       const progressCallback: ProgressCallback = (downloaded, total) => {
         progressReports.push({downloaded, total});
         if (downloaded > total / 2)
-          waitForSomeProgressReportedPromiseResolveFunc();
+          triggerDownloadCancellation();
       };
-
 
       const downloadPath = path.join(Constants.TestDownloadDirectoryPath, "[Authoring] ChangesetOperations", "cancel changesets download");
       const downloadChangesetListParams: DownloadChangesetListParams = {
@@ -525,7 +524,7 @@ describe("[Authoring] ChangesetOperations", () => {
       try {
         const testedFunctionPromise = iModelsClient.changesets.downloadList(downloadChangesetListParams);
 
-        await waitForSomeProgressReportedPromise;
+        await triggerDownloadCancellationPromise;
         abortController.abort();
 
         await testedFunctionPromise;

--- a/tests/imodels-clients-tests/src/integration/authoring/ChangesetOperations.test.ts
+++ b/tests/imodels-clients-tests/src/integration/authoring/ChangesetOperations.test.ts
@@ -493,13 +493,11 @@ describe("[Authoring] ChangesetOperations", () => {
       const abortController = new AbortController();
       const abortSignal = abortController.signal;
 
-      // `triggerDownloadCancellationPromise` is used to wait before aborting the download to ensure that some files have been downloaded.
-      // Its `resolve` function is saved into `triggerDownloadCancellation` variable and called once we download some changesets,
-      // `triggerDownloadCancellationPromise` resolves and we can then immediately call `abortController.abort`.
-      // We have to do this instead of calling `abortController.abort` inside `progressCallback` function because `progressCallback` is called inside "on `data`"
-      // event handler of the download stream, which is out of the execution context of the `downloadList` function. That results in an unhandled exception.
+      // Promise construction below mimics the cancellation workflow implemented in
+      // `PlatformToClientAdapter.toDownloadProgressParam` function `@itwin/imodels-access-backend` package.
+      // Refer to that for an explanation on why this is needed.
       let triggerDownloadCancellation: () => void = undefined!;
-      const triggerDownloadCancellationPromise = new Promise<void>(resolve => {
+      const triggerDownloadCancellationPromise = new Promise<void>((resolve) => {
         triggerDownloadCancellation = resolve;
       });
 


### PR DESCRIPTION
In this PR:
- Fixed file download cancellation handling - changed the code to not call `abortController.abort()` in progress callback function. Progress callback function [is called on `data` stream event](https://github.com/iTwin/imodels-clients/blob/0df469038bd8725313a3cb14cb7b89d5c000c5f2/clients/imodels-client-authoring/src/operations/FileDownload.ts#L49) in clients, which results in an unhandled error, since the error is thrown not in the scope of  `iModelsClient.changesets.downloadList` or `iModelsClient.changesets.downloadSingle`, but in the global context.

  Same unhandled exception can be reproduced if we just throw a random error (`throw new Error("foo")`) in progress callback instead of calling `abortController.abort()`, so it is not specific to this particular abort controller. However, the behavior of abort controller makes it more difficult to debug the situation, since `abortController.abort()` does not just throw an error internally, but it emits an `abort` event, which is listened to by Azure SDK, and the listener function calls `stream.destroy(errorToThrow)`. 

  The question remains why this worked previously. With this PR https://github.com/iTwin/imodels-clients/pull/272 we can see in `pnpm-lock.yaml` that Azure SDK internals were updated, so it is likely that they changed something on their end how `abort` signals are processed. 

- Enabled tests which were disabled with this PR https://github.com/iTwin/imodels-clients/pull/272
