### PR TITLE
Added user statistics

### DIFF
--- a/clients/imodels-client-management/src/base/types/apiEntities/ThumbnailInterfaces.ts
+++ b/clients/imodels-client-management/src/base/types/apiEntities/ThumbnailInterfaces.ts
@@ -8,7 +8,7 @@ import { ContentType } from "../RestClient";
 export enum ThumbnailSize {
   /** A small Thumbnail is a 400x250 PNG image. */
   Small = "small",
-  /** A large thumbnail is a 800x500 PNG image. */
+  /** A large Thumbnail is a 800x500 PNG image. */
   Large = "large"
 }
 

--- a/clients/imodels-client-management/src/base/types/apiEntities/UserInterfaces.ts
+++ b/clients/imodels-client-management/src/base/types/apiEntities/UserInterfaces.ts
@@ -20,15 +20,15 @@ export interface MinimalUser {
   _links: MinimalUserLinks;
 }
 
-/** User statistics */
+/** User Statistics */
 export interface UserStatistics {
-  /** Number of changesets pushed by the user. */
+  /** Number of Changesets pushed by the user. */
   pushedChangesetsCount: number;
-  /** Universal datetime value of the last time a changeset was pushed to the iModel by the user. */
+  /** Universal datetime value of the last time a Changeset was pushed to the iModel by the user. */
   lastChangesetPushDate: string | null;
-  /** Number of named versions created by the user. */
+  /** Number of Named Versions created by the user. */
   createdVersionsCount: number;
-  /** Number of briefcases owned by the user. */
+  /** Number of Briefcases owned by the user. */
   briefcasesCount: number;
 }
 
@@ -40,6 +40,6 @@ export interface User extends MinimalUser {
   surname: string;
   /** User email address. */
   email: string;
-  /** User statistics */
+  /** User Statistics */
   statistics: UserStatistics;
 }

--- a/clients/imodels-client-management/src/base/types/apiEntities/UserInterfaces.ts
+++ b/clients/imodels-client-management/src/base/types/apiEntities/UserInterfaces.ts
@@ -20,6 +20,18 @@ export interface MinimalUser {
   _links: MinimalUserLinks;
 }
 
+/** User statistics */
+export interface UserStatistics {
+  /** Number of changesets pushed by the user. */
+  pushedChangesetsCount: number;
+  /** Universal datetime value of the last time a changeset was pushed to the iModel by the user. */
+  lastChangesetPushDate: string;
+  /** Number of named versions created by the user. */
+  createdVersionsCount: number;
+  /** Number of briefcases owned by the user. */
+  briefcasesCount: number;
+}
+
 /** Full representation of a User. */
 export interface User extends MinimalUser {
   /** User given name. */
@@ -28,4 +40,6 @@ export interface User extends MinimalUser {
   surname: string;
   /** User email address. */
   email: string;
+  /** User statistics */
+  statistics: UserStatistics;
 }

--- a/clients/imodels-client-management/src/base/types/apiEntities/UserInterfaces.ts
+++ b/clients/imodels-client-management/src/base/types/apiEntities/UserInterfaces.ts
@@ -25,7 +25,7 @@ export interface UserStatistics {
   /** Number of changesets pushed by the user. */
   pushedChangesetsCount: number;
   /** Universal datetime value of the last time a changeset was pushed to the iModel by the user. */
-  lastChangesetPushDate: string;
+  lastChangesetPushDate: string | null;
   /** Number of named versions created by the user. */
   createdVersionsCount: number;
   /** Number of briefcases owned by the user. */

--- a/common/changes/@itwin/imodels-client-management/add-user-statistics_2024-09-24-11-49.json
+++ b/common/changes/@itwin/imodels-client-management/add-user-statistics_2024-09-24-11-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodels-client-management",
+      "comment": "Add user statistics",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodels-client-management"
+}

--- a/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
+++ b/tests/imodels-access-backend-tests/src/BackendiModelsAccess.test.ts
@@ -333,7 +333,7 @@ describe("BackendIModelsAccess", () => {
       //  changeset index 10   - only v1 (v2 failed)
       // This iModel is a clone of the testIModelFileProvider aka "[do not delete][iModelsClientsTests] Reusable Test iModel"
       // so it will have the same 10 changesets in total.
-      const iModelId = "4cdf1c96-2901-46c5-b251-3da2e19b919b";
+      const iModelId = "e71f4085-75a6-479c-bab8-dce19b9352f6";
       await assertHardcodedIModelExists(
         iModelId,
         "iModel for queryV2Checkpoint test was not found. Please recreate the test iModel as described within the test, or disable the test.");
@@ -396,7 +396,7 @@ describe("BackendIModelsAccess", () => {
       //  changeset index 10   - v1 and v2
       // This iModel is a clone of the testIModelFileProvider aka "[do not delete][iModelsClientsTests] Reusable Test iModel"
       // so it will have the same 10 changesets in total.
-      const iModelId = "deeefc49-251b-4399-af51-8c8db2d22c83";
+      const iModelId = "c53e6b49-020f-4bf6-804b-d320463c5e00";
       await assertHardcodedIModelExists(
         iModelId,
         "iModel for downloadV1Checkpoint test was not found. Please recreate the test iModel as described within the test, or disable the test.");

--- a/tests/imodels-clients-tests/src/integration/management/UserOperations.test.ts
+++ b/tests/imodels-clients-tests/src/integration/management/UserOperations.test.ts
@@ -5,7 +5,7 @@
 import { expect } from "chai";
 
 import { AuthorizationCallback, EntityListIterator, GetSingleUserParams, GetUserListParams, IModelsClient, IModelsClientOptions, MinimalUser, OrderByOperator, User, UserOrderByProperty, take, toArray } from "@itwin/imodels-client-management";
-import { ReusableIModelMetadata, ReusableTestIModelProvider, TestAuthorizationProvider, TestUtilTypes, assertCollection, assertMinimalUser, assertUser } from "@itwin/imodels-client-test-utils";
+import { ReusableIModelMetadata, ReusableTestIModelProvider, TestAuthorizationProvider, TestUtilTypes, assertCollection, assertMinimalUser, assertUser, assertUserStatistics } from "@itwin/imodels-client-test-utils";
 
 import { getTestDIContainer } from "../common";
 
@@ -94,6 +94,17 @@ describe("[Management] UserOperations", () => {
     // Assert
     assertUser({
       actualUser: user
+    });
+
+    // Assert user statistics
+    assertUserStatistics({
+      actualUser: user,
+      expectedUserStatistics: {
+        briefcasesCount: 0,
+        createdVersionsCount: 2,
+        lastChangesetPushDate: null,
+        pushedChangesetsCount: 0
+      }
     });
   });
 

--- a/utils/imodels-client-test-utils/src/assertions/BrowserFriendlyAssertions.ts
+++ b/utils/imodels-client-test-utils/src/assertions/BrowserFriendlyAssertions.ts
@@ -214,6 +214,12 @@ export function assertUser(params: {
   expect(params.actualUser.givenName).to.not.be.empty;
   expect(params.actualUser.surname).to.not.be.empty;
   expect(params.actualUser.email).to.not.be.empty;
+
+  expect(params.actualUser.statistics).to.exist;
+  expect(params.actualUser.statistics.pushedChangesetsCount).to.be.equal(0);
+  expect(params.actualUser.statistics.lastChangesetPushDate).to.be.null;
+  expect(params.actualUser.statistics.createdVersionsCount).to.be.equal(2);
+  expect(params.actualUser.statistics.briefcasesCount).to.equal(0);
 }
 
 export function assertUserPermissions(params: {

--- a/utils/imodels-client-test-utils/src/assertions/BrowserFriendlyAssertions.ts
+++ b/utils/imodels-client-test-utils/src/assertions/BrowserFriendlyAssertions.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
 
-import { Application, Briefcase, ChangesetExtendedData, Checkpoint, CheckpointState, ContentType, EntityListIterator, IModel, IModelPermission, IModelProperties, IModelState, IModelsError, IModelsErrorDetail, Link, MinimalBriefcase, MinimalIModel, MinimalNamedVersion, MinimalUser, NamedVersion, NamedVersionPropertiesForCreate, NamedVersionState, Thumbnail, ThumbnailSize, User, UserPermissions } from "@itwin/imodels-client-management";
+import { Application, Briefcase, ChangesetExtendedData, Checkpoint, CheckpointState, ContentType, EntityListIterator, IModel, IModelPermission, IModelProperties, IModelState, IModelsError, IModelsErrorDetail, Link, MinimalBriefcase, MinimalIModel, MinimalNamedVersion, MinimalUser, NamedVersion, NamedVersionPropertiesForCreate, NamedVersionState, Thumbnail, ThumbnailSize, User, UserPermissions, UserStatistics } from "@itwin/imodels-client-management";
 
 import { assertBriefcaseCallbacks, assertIModelCallbacks, assertNamedVersionCallbacks } from "./RelatedEntityCallbackAssertions";
 
@@ -216,10 +216,20 @@ export function assertUser(params: {
   expect(params.actualUser.email).to.not.be.empty;
 
   expect(params.actualUser.statistics).to.exist;
-  expect(params.actualUser.statistics.pushedChangesetsCount).to.be.equal(0);
-  expect(params.actualUser.statistics.lastChangesetPushDate).to.be.null;
-  expect(params.actualUser.statistics.createdVersionsCount).to.be.equal(2);
-  expect(params.actualUser.statistics.briefcasesCount).to.equal(0);
+  expect(params.actualUser.statistics.pushedChangesetsCount).to.be.greaterThanOrEqual(0);
+  expect(params.actualUser.statistics.createdVersionsCount).to.be.greaterThanOrEqual(0);
+  expect(params.actualUser.statistics.briefcasesCount).to.greaterThanOrEqual(0);
+}
+
+export function assertUserStatistics(params: {
+  actualUser: User;
+  expectedUserStatistics: UserStatistics;
+}): void {
+  expect(params.actualUser.statistics).to.exist;
+  expect(params.actualUser.statistics.pushedChangesetsCount).to.equal(params.expectedUserStatistics.pushedChangesetsCount);
+  expect(params.actualUser.statistics.createdVersionsCount).to.equal(params.expectedUserStatistics.createdVersionsCount);
+  assertOptionalProperty(params.expectedUserStatistics.lastChangesetPushDate, params.actualUser.statistics.lastChangesetPushDate);
+  expect(params.actualUser.statistics.briefcasesCount).to.equal(params.expectedUserStatistics.briefcasesCount);
 }
 
 export function assertUserPermissions(params: {


### PR DESCRIPTION
Added user statistics to the endpoints "Get iModel User" and "Get iModel Users" representation prefer version.

{
      "statistics": {
        "pushedChangesetsCount": 0,
        "lastChangesetPushDate": null,
        "createdVersionsCount": 0,
        "briefcasesCount": 0
      }
}