### PR TITLE
Adding ESM support for @itwin/imodels-access-common

### DIFF
--- a/common/changes/@itwin/imodels-access-common/lb-esm-output_2024-12-16-10-42.json
+++ b/common/changes/@itwin/imodels-access-common/lb-esm-output_2024-12-16-10-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodels-access-common",
+      "comment": "Adding ES Module output",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodels-access-common"
+}

--- a/common/changes/@itwin/imodels-access-frontend/lb-esm-output_2024-12-16-10-42.json
+++ b/common/changes/@itwin/imodels-access-frontend/lb-esm-output_2024-12-16-10-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodels-access-frontend",
+      "comment": "Using ES Modules from @itwin/imodels-access-common",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodels-access-frontend"
+}

--- a/itwin-platform-access/imodels-access-common/package.json
+++ b/itwin-platform-access/imodels-access-common/package.json
@@ -18,6 +18,9 @@
     "name": "Bentley Systems, Inc.",
     "url": "http://www.bentley.com"
   },
+  "main": "lib/index.js",
+  "module": "lib/esm/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json && tsc -p tsconfig.esm.json 1>&2",
     "clean": "rimraf lib",

--- a/itwin-platform-access/imodels-access-common/package.json
+++ b/itwin-platform-access/imodels-access-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-access-common",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "description": "Common code package for @itwin/imodels-access-frontend and @itwin/imodels-access-backend.",
   "keywords": [
     "Bentley",
@@ -19,7 +19,7 @@
     "url": "http://www.bentley.com"
   },
   "scripts": {
-    "build": "tsc 1>&2",
+    "build": "tsc -p tsconfig.json && tsc -p tsconfig.esm.json 1>&2",
     "clean": "rimraf lib",
     "lint": "eslint ./src/**/*.ts 1>&2",
     "lint-fix": "eslint --fix ./src/**/*.ts 1>&2 && sort-package-json",

--- a/itwin-platform-access/imodels-access-common/src/index.ts
+++ b/itwin-platform-access/imodels-access-common/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./AccessTokenAdapter";
+export * from "./ChangesetFunctions";
+export * from "./Constants";
+export * from "./ErrorAdapter";
+export * from "./ErrorHandlingFunctions";

--- a/itwin-platform-access/imodels-access-common/tsconfig.esm.json
+++ b/itwin-platform-access/imodels-access-common/tsconfig.esm.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./node_modules/@itwin/imodels-client-common-config/tsconfig.esm.json",
+  "compilerOptions": {
+    "outDir": "./lib/esm",
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "./src/**/*.ts"
+  ],
+  "exclude": [
+    "lib",
+    "node_modules"
+  ]
+}

--- a/itwin-platform-access/imodels-access-frontend/package.json
+++ b/itwin-platform-access/imodels-access-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodels-access-frontend",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "description": "Interoperability package between iModels API and iTwin.js library for frontend.",
   "keywords": [
     "Bentley",

--- a/itwin-platform-access/imodels-access-frontend/src/index.ts
+++ b/itwin-platform-access/imodels-access-frontend/src/index.ts
@@ -2,5 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-export * from "@itwin/imodels-access-common/lib/esm/AccessTokenAdapter";
+import { AccessTokenAdapter } from "@itwin/imodels-access-common";
+
 export * from "./FrontendIModelsAccess";
+export { AccessTokenAdapter };

--- a/itwin-platform-access/imodels-access-frontend/src/index.ts
+++ b/itwin-platform-access/imodels-access-frontend/src/index.ts
@@ -2,5 +2,5 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-export * from "@itwin/imodels-access-common/lib/AccessTokenAdapter";
+export * from "@itwin/imodels-access-common/lib/esm/AccessTokenAdapter";
 export * from "./FrontendIModelsAccess";


### PR DESCRIPTION
iTwin.js Sandbox needs @itwin/imodels-access-frontend to be ESM, however it directly reexports a class from @itwin/imodels-access-common, which is currently cjs.

Here is a proposition to support ESM:

* Added barrel export (index.ts) to @itwin/imodels-access-common (is that ok? I'm not really sure why it's direct path imports everywhere in this monorepo)
* Changed reexport to use barrel import from @itwin/imodels-access-common, to avoid depending on specific path.
