### PR TITLE
Add ability to specify a GCS on iModel creation

### DIFF
--- a/clients/imodels-client-management/src/base/types/IModelsErrorInterfaces.ts
+++ b/clients/imodels-client-management/src/base/types/IModelsErrorInterfaces.ts
@@ -20,6 +20,7 @@ export enum IModelsErrorCode {
   ConflictWithAnotherUser = "ConflictWithAnotherUser",
   DataConflict = "DataConflict",
   DownloadAborted = "DownloadAborted",
+  EmptyIModelInitializationFailed = "EmptyIModelInitializationFailed",
   FileNotFound = "FileNotFound",
   IModelExists = "iModelExists",
   IModelForkInitializationFailed = "IModelForkInitializationFailed",

--- a/clients/imodels-client-management/src/base/types/apiEntities/IModelInterfaces.ts
+++ b/clients/imodels-client-management/src/base/types/apiEntities/IModelInterfaces.ts
@@ -45,6 +45,12 @@ export interface Extent {
   northEast: Point;
 }
 
+/** The GeographicCoordinateSystem is used to determine how to spatially locate the iModel on the Earth's surface. */
+export interface GeographicCoordinateSystem {
+  /** A string identifier corresponding to a horizontal Coordinate Reference System in iTwin.js. */
+  horizontalCRSId: string;
+}
+
 /** Minimal representation of an iModel. */
 export interface MinimalIModel {
   /** iModel id. */

--- a/clients/imodels-client-management/src/operations/imodel/IModelOperationParams.ts
+++ b/clients/imodels-client-management/src/operations/imodel/IModelOperationParams.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { AtLeastOneProperty, AuthorizationParam, ContainerTypes, Extent, HeadersParam, IModel, IModelScopedOperationParams, OrderableCollectionRequestParams } from "../../base/types";
+import { AtLeastOneProperty, AuthorizationParam, ContainerTypes, Extent, GeographicCoordinateSystem, HeadersParam, IModel, IModelScopedOperationParams, OrderableCollectionRequestParams } from "../../base/types";
 import { ChangesetIdOrIndex } from "../OperationParamExports";
 
 /**
@@ -13,6 +13,11 @@ export enum IModelOrderByProperty {
   Name = "name",
   CreatedDateTime = "createdDateTime",
 }
+
+/**
+ * The mode of iModel creation.
+ */
+export type IModelCreationMode = "empty" | "fromIModelVersion" | "fromBaseline";
 
 /** Url parameters supported in iModel list query. */
 export interface GetIModelListUrlParams extends OrderableCollectionRequestParams<IModel, IModelOrderByProperty> {
@@ -48,12 +53,25 @@ export interface IModelProperties {
   extent?: Extent;
   /** iModel container types. See {@link ContainerTypes}. */
   containersEnabled?: ContainerTypes;
+  /** 
+   * iModel GCS. If provided, {@link creationMode} must be set or value will be ignored. 
+   * See {@link GeographicCoordinateSystem}. 
+   */  
+  geographicCoordinateSystem?: GeographicCoordinateSystem;
+  /** 
+   * The mode of iModel creation. Possible values: 'empty', 'fromiModelVersion', 'fromBaseline'. 
+   * If not provided empty instantly initialized iModel is created.
+   * However, instant iModel creation has been deprecated and might be removed in a future version. 
+   */  
+  creationMode?: IModelCreationMode;
 }
 
 /** Parameters for create iModel operation. */
-export interface CreateEmptyIModelParams extends AuthorizationParam, HeadersParam {
+export interface CreateEmptyIModelParams extends AuthorizationParam, HeadersParam  {
   /** Properties of the new iModel. See {@link IModelProperties}. */
   iModelProperties: IModelProperties;
+  /** Time period to wait until the iModel is initialized. Default value is 300,000 ms (5 minutes). */
+  timeOutInMs?: number
 }
 
 /** A set of properties that define the source iModel for creating a new iModel from template. */

--- a/itwin-platform-access/imodels-access-common/src/ErrorAdapter.ts
+++ b/itwin-platform-access/imodels-access-common/src/ErrorAdapter.ts
@@ -79,6 +79,7 @@ export class ErrorAdapter {
       case IModelsErrorCode.BaselineFileNotFound:
       case IModelsErrorCode.BaselineFileInitializationFailed:
       case IModelsErrorCode.IModelFromTemplateInitializationFailed:
+      case IModelsErrorCode.EmptyIModelInitializationFailed:
       case IModelsErrorCode.ClonedIModelInitializationFailed:
       case IModelsErrorCode.ChangesetDownloadFailed:
         return true;

--- a/tests/imodels-access-common-tests/src/ErrorAdapter.test.ts
+++ b/tests/imodels-access-common-tests/src/ErrorAdapter.test.ts
@@ -49,6 +49,7 @@ describe("ErrorAdapter", () => {
     IModelsErrorCode.ChangesetGroupNotFound,
     IModelsErrorCode.BaselineFileNotFound,
     IModelsErrorCode.BaselineFileInitializationFailed,
+    IModelsErrorCode.EmptyIModelInitializationFailed,
     IModelsErrorCode.IModelFromTemplateInitializationFailed,
     IModelsErrorCode.ClonedIModelInitializationFailed,
     IModelsErrorCode.ChangesetDownloadFailed

--- a/tests/imodels-clients-tests/src/integration/management/IModelOperations.test.ts
+++ b/tests/imodels-clients-tests/src/integration/management/IModelOperations.test.ts
@@ -377,6 +377,36 @@ describe("[Management] IModelOperations", () => {
     });
   });
 
+  it("should create an empty iModel with defined GCS", async () => {
+    const createIModelParams: CreateEmptyIModelParams = {
+      authorization,
+      iModelProperties: {
+        iTwinId,
+        name: testIModelGroup.getPrefixedUniqueIModelName("Empty Test IModel with GCS"),
+        description: "Sample iModel description",
+        extent: {
+          southWest: { latitude: 1, longitude: 2 },
+          northEast: { latitude: 3, longitude: 4 },
+        },
+        containersEnabled: ContainerTypes.None,
+        geographicCoordinateSystem: {
+          horizontalCRSId: "EPSG:3857",
+        },
+        creationMode: "empty"
+      },
+      headers: {
+        "X-Correlation-Id": randomUUID()
+      }
+    };
+
+    const iModel: IModel = await iModelsClient.iModels.createEmpty(createIModelParams);
+
+    await assertIModel({
+      actualIModel: iModel,
+      expectedIModelProperties: createIModelParams.iModelProperties
+    });
+  })
+
   it("should create iModel from template (without changeset id specified)", async () => {
     // Arrange
     const createIModelFromTemplateParams: CreateIModelFromTemplateParams = {

--- a/utils/imodels-client-common-config/cspell.json
+++ b/utils/imodels-client-common-config/cspell.json
@@ -21,7 +21,8 @@
     "bootstrapper",
     "ITWINS",
     "Guids",
-    "backoff"
+    "backoff",
+    "epsg"
   ],
   "ignoreRegExpList": [
     "/imodel.*/i"


### PR DESCRIPTION
Adds `geographicCoordinateSystem.horizontalCRSId` to `iModelProperties`. Because GCS cannot be processed on instantly-created iModels, `creationMode` has also been added to `iModelProperties`. When both properties are present, the client will wait for empty iModel initialization, reusing behavior intended for creation from template or baseline files. 

closes #284 