### PR TITLE
Get ITwin iModels endpoint `state` param support

### DIFF
--- a/clients/imodels-client-management/src/operations/imodel/IModelOperationParams.ts
+++ b/clients/imodels-client-management/src/operations/imodel/IModelOperationParams.ts
@@ -35,7 +35,7 @@ export interface GetIModelListUrlParams
   iTwinId: string;
   /** Filters iModels with a specific name. */
   name?: string;
-  /** Filters iModels with a specific state. Valid values for this parameter are 'initialized' or 'notInitialized'. */
+  /** Filters iModels with a specific state. */
   state?: IModelState;
 }
 

--- a/clients/imodels-client-management/src/operations/imodel/IModelOperationParams.ts
+++ b/clients/imodels-client-management/src/operations/imodel/IModelOperationParams.ts
@@ -12,6 +12,7 @@ import {
   IModel,
   IModelCreationMode,
   IModelScopedOperationParams,
+  IModelState,
   OrderableCollectionRequestParams,
 } from "../../base/types";
 import { ChangesetIdOrIndex } from "../OperationParamExports";
@@ -34,6 +35,8 @@ export interface GetIModelListUrlParams
   iTwinId: string;
   /** Filters iModels with a specific name. */
   name?: string;
+  /** Filters iModels with a specific state. Valid values for this parameter are 'initialized' or 'notInitialized'. */
+  state?: IModelState;
 }
 
 /** Parameters for get iModel list operation. */

--- a/common/changes/@itwin/imodels-client-management/nadegamra-GetIModelListUrlParams-state_2025-05-15-06-48.json
+++ b/common/changes/@itwin/imodels-client-management/nadegamra-GetIModelListUrlParams-state_2025-05-15-06-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodels-client-management",
+      "comment": "Added state parameter support for methods, that wrap https://developer.bentley.com/apis/imodels-v2/operations/get-itwin-imodels/ operation from iModels API",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodels-client-management"
+}

--- a/tests/imodels-clients-tests/src/integration/management/IModelOperations.test.ts
+++ b/tests/imodels-clients-tests/src/integration/management/IModelOperations.test.ts
@@ -19,6 +19,7 @@ import {
   GetSingleIModelParams,
   IModel,
   IModelOrderByProperty,
+  IModelState,
   IModelsClient,
   IModelsClientOptions,
   IModelsErrorCode,
@@ -360,6 +361,54 @@ describe("[Management] IModelOperations", () => {
     expect(iModelArray.length).to.equal(1);
     const iModel = iModelArray[0];
     expect(iModel.id).to.equal(testIModelForUpdate.id);
+  });
+
+  it("should return iModels that match the provided state (notInitialized)", async () => {
+    // Arrange
+    const getIModelListParams: GetIModelListParams = {
+      authorization,
+      urlParams: {
+        iTwinId,
+        state: IModelState.NotInitialized,
+      },
+      headers: {
+        "X-Correlation-Id": randomUUID(),
+      },
+    };
+
+    // Act
+    const iModels =
+      iModelsClient.iModels.getRepresentationList(getIModelListParams);
+
+    // Assert
+    const iModelArray = await toArray(iModels);
+    iModelArray.forEach((iModel) => {
+      expect(iModel.state).to.be.equal(IModelState.NotInitialized);
+    });
+  });
+
+  it("should return iModels that match the provided state (initialized)", async () => {
+    // Arrange
+    const getIModelListParams: GetIModelListParams = {
+      authorization,
+      urlParams: {
+        iTwinId,
+        state: IModelState.Initialized,
+      },
+      headers: {
+        "X-Correlation-Id": randomUUID(),
+      },
+    };
+
+    // Act
+    const iModels =
+      iModelsClient.iModels.getRepresentationList(getIModelListParams);
+
+    // Assert
+    const iModelArray = await toArray(iModels);
+    iModelArray.forEach((iModel) => {
+      expect(iModel.state).to.be.equal(IModelState.Initialized);
+    });
   });
 
   it("should get minimal iModel", async () => {


### PR DESCRIPTION
`state` parameter is supported by [Get iTwin iModels](https://developer.bentley.com/apis/imodels-v2/operations/get-itwin-imodels/#request-parameters) endpoint. However, this parameter is not supported by the `IModelsClient`, which looks like an oversight.