### PR TITLE
remove exports map and clean up deps

### DIFF
--- a/clients/imodels-client-authoring/package.json
+++ b/clients/imodels-client-authoring/package.json
@@ -19,12 +19,6 @@
     "name": "Bentley Systems, Inc.",
     "url": "http://www.bentley.com"
   },
-  "exports": {
-    ".": {
-      "import": "./lib/esm/index.js",
-      "require": "./lib/cjs/index.js"
-    }
-  },
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
   "typings": "lib/cjs/index",

--- a/clients/imodels-client-management/package.json
+++ b/clients/imodels-client-management/package.json
@@ -19,12 +19,6 @@
     "name": "Bentley Systems, Inc.",
     "url": "http://www.bentley.com"
   },
-  "exports": {
-    ".": {
-      "import": "./lib/esm/index.js",
-      "require": "./lib/cjs/index.js"
-    }
-  },
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
   "typings": "lib/cjs/index",

--- a/common/changes/@itwin/imodels-access-backend/maint-fix-deps_2025-05-20-19-08.json
+++ b/common/changes/@itwin/imodels-access-backend/maint-fix-deps_2025-05-20-19-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodels-access-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodels-access-backend"
+}

--- a/common/changes/@itwin/imodels-access-common/maint-fix-deps_2025-05-20-19-08.json
+++ b/common/changes/@itwin/imodels-access-common/maint-fix-deps_2025-05-20-19-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodels-access-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodels-access-common"
+}

--- a/common/changes/@itwin/imodels-access-frontend/maint-fix-deps_2025-05-20-19-08.json
+++ b/common/changes/@itwin/imodels-access-frontend/maint-fix-deps_2025-05-20-19-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodels-access-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodels-access-frontend"
+}

--- a/common/changes/@itwin/imodels-client-authoring/maint-fix-deps_2025-05-20-19-08.json
+++ b/common/changes/@itwin/imodels-client-authoring/maint-fix-deps_2025-05-20-19-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodels-client-authoring",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodels-client-authoring"
+}

--- a/common/changes/@itwin/imodels-client-management/maint-fix-deps_2025-05-20-19-08.json
+++ b/common/changes/@itwin/imodels-client-management/maint-fix-deps_2025-05-20-19-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodels-client-management",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodels-client-management"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -116,18 +116,6 @@ importers:
 
   ../../itwin-platform-access/imodels-access-backend:
     dependencies:
-      '@azure/abort-controller':
-        specifier: ^1.1.0
-        version: 1.1.0
-      '@itwin/imodels-access-common':
-        specifier: workspace:*
-        version: link:../imodels-access-common
-      '@itwin/imodels-client-authoring':
-        specifier: workspace:*
-        version: link:../../clients/imodels-client-authoring
-      '@itwin/imodels-client-management':
-        specifier: workspace:*
-        version: link:../../clients/imodels-client-management
       axios:
         specifier: ^1.8.2
         version: 1.8.4
@@ -150,9 +138,18 @@ importers:
       '@itwin/eslint-plugin':
         specifier: ~3.7.8
         version: 3.7.17(eslint@8.55.0)(typescript@5.8.3)
+      '@itwin/imodels-access-common':
+        specifier: workspace:*
+        version: link:../imodels-access-common
+      '@itwin/imodels-client-authoring':
+        specifier: workspace:*
+        version: link:../../clients/imodels-client-authoring
       '@itwin/imodels-client-common-config':
         specifier: workspace:*
         version: link:../../utils/imodels-client-common-config
+      '@itwin/imodels-client-management':
+        specifier: workspace:*
+        version: link:../../clients/imodels-client-management
       '@types/node':
         specifier: 14.14.31
         version: 14.14.31
@@ -1554,6 +1551,9 @@ packages:
 
   '@types/node@14.14.31':
     resolution: {integrity: sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==}
+
+  '@types/node@20.17.49':
+    resolution: {integrity: sha512-lu4U+g0EbSW2aPGksNyqcesB2D3eDD0mv8ig9youJsEs/DuMOdeqcEbFOBDCCurXNpa10NkKSSRfOQLBFCiD8w==}
 
   '@types/node@22.15.18':
     resolution: {integrity: sha512-v1DKRfUdyW+jJhZNEI1PYy29S2YRxMV5AOO/x/SjKmW0acCIOqmbj6Haf9eHAhsPmrhlHSxEhv/1WszcLWV4cg==}
@@ -4308,6 +4308,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -5331,6 +5334,11 @@ snapshots:
 
   '@types/node@14.14.31': {}
 
+  '@types/node@20.17.49':
+    dependencies:
+      undici-types: 6.19.8
+    optional: true
+
   '@types/node@22.15.18':
     dependencies:
       undici-types: 6.21.0
@@ -5373,7 +5381,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 22.15.18
+      '@types/node': 20.17.49
     optional: true
 
   '@typescript-eslint/eslint-plugin@4.31.2(@typescript-eslint/parser@4.31.2(eslint@8.55.0)(typescript@5.8.3))(eslint@8.55.0)(typescript@5.8.3)':
@@ -8613,6 +8621,9 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  undici-types@6.19.8:
+    optional: true
 
   undici-types@6.21.0: {}
 

--- a/itwin-platform-access/imodels-access-backend/package.json
+++ b/itwin-platform-access/imodels-access-backend/package.json
@@ -18,12 +18,6 @@
     "name": "Bentley Systems, Inc.",
     "url": "http://www.bentley.com"
   },
-  "exports": {
-    ".": {
-      "import": "./lib/esm/index.js",
-      "require": "./lib/cjs/index.js"
-    }
-  },
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
   "typings": "lib/cjs/index",
@@ -41,10 +35,6 @@
     "extends": "./node_modules/@itwin/imodels-client-common-config/.eslintrc.js"
   },
   "dependencies": {
-    "@azure/abort-controller": "^1.1.0",
-    "@itwin/imodels-access-common": "workspace:*",
-    "@itwin/imodels-client-authoring": "workspace:*",
-    "@itwin/imodels-client-management": "workspace:*",
     "axios": "^1.8.2"
   },
   "devDependencies": {
@@ -54,7 +44,10 @@
     "@itwin/core-geometry": "^5.0.0-dev.112",
     "@itwin/ecschema-metadata": "^5.0.0-dev.112",
     "@itwin/eslint-plugin": "~3.7.8",
+    "@itwin/imodels-access-common": "workspace:*",
     "@itwin/imodels-client-common-config": "workspace:*",
+    "@itwin/imodels-client-authoring": "workspace:*",
+    "@itwin/imodels-client-management": "workspace:*",
     "@types/node": "14.14.31",
     "@types/ws": "^7.0.0",
     "@typescript-eslint/eslint-plugin": "~6.14.0",
@@ -71,6 +64,9 @@
   "peerDependencies": {
     "@itwin/core-backend": "^5.0.0-dev.112",
     "@itwin/core-bentley": "^5.0.0-dev.112",
-    "@itwin/core-common": "^5.0.0-dev.112"
+    "@itwin/core-common": "^5.0.0-dev.112",
+    "@itwin/imodels-access-common": "workspace:*",
+    "@itwin/imodels-client-authoring": "workspace:*",
+    "@itwin/imodels-client-management": "workspace:*"
   }
 }

--- a/itwin-platform-access/imodels-access-backend/src/interface-adapters/PlatformToClientAdapter.ts
+++ b/itwin-platform-access/imodels-access-backend/src/interface-adapters/PlatformToClientAdapter.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { AbortController } from "@azure/abort-controller";
-
 import {
   CreateNewIModelProps,
   LockMap,

--- a/itwin-platform-access/imodels-access-common/package.json
+++ b/itwin-platform-access/imodels-access-common/package.json
@@ -18,12 +18,6 @@
     "name": "Bentley Systems, Inc.",
     "url": "http://www.bentley.com"
   },
-  "exports": {
-    ".": {
-      "import": "./lib/esm/index.js",
-      "require": "./lib/cjs/index.js"
-    }
-  },
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
   "typings": "lib/cjs/index",
@@ -40,14 +34,12 @@
   "eslintConfig": {
     "extends": "./node_modules/@itwin/imodels-client-common-config/.eslintrc.js"
   },
-  "dependencies": {
-    "@itwin/imodels-client-authoring": "workspace:*",
-    "@itwin/imodels-client-management": "workspace:*"
-  },
   "devDependencies": {
     "@itwin/core-bentley": "^5.0.0-dev.112",
     "@itwin/eslint-plugin": "~3.7.8",
+    "@itwin/imodels-client-authoring": "workspace:*",
     "@itwin/imodels-client-common-config": "workspace:*",
+    "@itwin/imodels-client-management": "workspace:*",
     "@typescript-eslint/eslint-plugin": "~6.14.0",
     "cspell": "~5.21.0",
     "eslint": "~8.55.0",
@@ -60,6 +52,7 @@
     "typescript": "^5.8.3"
   },
   "peerDependencies": {
-    "@itwin/core-bentley": "^5.0.0-dev.112"
+    "@itwin/core-bentley": "^5.0.0-dev.112",
+    "@itwin/imodels-client-management": "workspace:*"
   }
 }

--- a/itwin-platform-access/imodels-access-common/src/ErrorAdapter.ts
+++ b/itwin-platform-access/imodels-access-common/src/ErrorAdapter.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ITwinError } from "@itwin/core-bentley";
-import { ConflictingLock } from "@itwin/imodels-client-authoring";
+import { type ConflictingLock } from "@itwin/imodels-client-authoring";
 import {
   IModelsError,
   IModelsErrorCode,

--- a/itwin-platform-access/imodels-access-common/src/IModelsClientsErrorInterfaces.ts
+++ b/itwin-platform-access/imodels-access-common/src/IModelsClientsErrorInterfaces.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { ITwinError } from "@itwin/core-bentley";
-import { ConflictingLock } from "@itwin/imodels-client-authoring";
+import { type ConflictingLock } from "@itwin/imodels-client-authoring";
 import { IModelsErrorScope } from "@itwin/imodels-client-management";
 
 /** Most common error returned in the majority of error cases by imodels-clients. */

--- a/itwin-platform-access/imodels-access-frontend/package.json
+++ b/itwin-platform-access/imodels-access-frontend/package.json
@@ -34,10 +34,6 @@
   "eslintConfig": {
     "extends": "./node_modules/@itwin/imodels-client-common-config/.eslintrc.js"
   },
-  "dependencies": {
-    "@itwin/imodels-access-common": "workspace:*",
-    "@itwin/imodels-client-management": "workspace:*"
-  },
   "devDependencies": {
     "@itwin/appui-abstract": "^5.0.0-dev.112",
     "@itwin/core-bentley": "^5.0.0-dev.112",
@@ -49,7 +45,9 @@
     "@itwin/ecschema-metadata": "^5.0.0-dev.112",
     "@itwin/ecschema-rpcinterface-common": "^5.0.0-dev.112",
     "@itwin/eslint-plugin": "~3.7.8",
+    "@itwin/imodels-access-common": "workspace:*",
     "@itwin/imodels-client-common-config": "workspace:*",
+    "@itwin/imodels-client-management": "workspace:*",
     "@itwin/webgl-compatibility": "^5.0.0-dev.112",
     "@types/node": "^22.15.14",
     "@typescript-eslint/eslint-plugin": "~6.14.0",
@@ -65,6 +63,8 @@
   },
   "peerDependencies": {
     "@itwin/core-bentley": "^5.0.0-dev.112",
-    "@itwin/core-frontend": "^5.0.0-dev.112"
+    "@itwin/core-frontend": "^5.0.0-dev.112",
+    "@itwin/imodels-access-common": "workspace:^*",
+    "@itwin/imodels-client-management": "workspace:^*"
   }
 }


### PR DESCRIPTION
- remove exports map for pkgs consumed on the backend as there are issues with using cjs where esm is expected and vice versa, eg
```
Argument of type 'import("/Users/arun.george/repos/itwin/imodel-access-backend/node_modules/.pnpm/@itwin+imodels-client-management@6.0.0-dev.2/node_modules/@itwin/imodels-client-management/lib/esm/IModelsClient").IModelsClient' is not assignable to parameter of type 'import("/Users/arun.george/repos/itwin/imodel-access-backend/node_modules/.pnpm/@itwin+imodels-client-management@6.0.0-dev.2/node_modules/@itwin/imodels-client-management/lib/cjs/IModelsClient").IModelsClient'.
  Property '_operationsOptions' is protected but type 'IModelsClient' is not a class derived from 'IModelsClient'.
```
- also update deps to peers accordingly 