### PR TITLE
Make object-storage implementations optional

### DIFF
--- a/clients/imodels-client-authoring/README.md
+++ b/clients/imodels-client-authoring/README.md
@@ -34,6 +34,7 @@ To include custom headers in your requests, you have the option to provide addit
 
 ```typescript
 iModelsClient = new IModelsClient({
+  cloudStorage: createDefaultClientStorage(),
   headers: {
     "X-Correlation-Id": () => "xCorrelationIdValue",
     "some-custom-header": "someCustomValue",
@@ -59,7 +60,7 @@ import {
 
 /** Function that creates a new iModel from Baseline file and prints its id to the console. */
 async function createIModelFromBaselineFile(): Promise<void> {
-  const iModelsClient: IModelsClient = new IModelsClient();
+  const iModelsClient: IModelsClient = new IModelsClient({ cloudStorage: createDefaultClientStorage() });
   const iModel: IModel = await iModelsClient.iModels.createFromBaseline({
     authorization: () => getAuthorization(),
     iModelProperties: {

--- a/clients/imodels-client-authoring/package.json
+++ b/clients/imodels-client-authoring/package.json
@@ -38,13 +38,17 @@
   "dependencies": {
     "@azure/storage-blob": "^12.7.0",
     "@itwin/imodels-client-management": "workspace:*",
+    "@itwin/object-storage-core": "^3.0.0-dev.0"
+  },
+  "optionalPeerDependencies": {
     "@itwin/object-storage-azure": "^3.0.0-dev.0",
-    "@itwin/object-storage-core": "^3.0.0-dev.0",
     "@itwin/object-storage-google": "^3.0.0-dev.0"
   },
   "devDependencies": {
     "@itwin/eslint-plugin": "~3.7.8",
     "@itwin/imodels-client-common-config": "workspace:*",
+    "@itwin/object-storage-azure": "^3.0.0-dev.0",
+    "@itwin/object-storage-google": "^3.0.0-dev.0",
     "@types/node": "^22.15.14",
     "@typescript-eslint/eslint-plugin": "~6.14.0",
     "cspell": "~5.21.0",

--- a/clients/imodels-client-authoring/src/IModelsClient.ts
+++ b/clients/imodels-client-authoring/src/IModelsClient.ts
@@ -16,11 +16,7 @@ import {
 
 import { ClientStorage } from "@itwin/object-storage-core";
 
-import {
-  createDefaultClientStorage,
-  IModelsErrorParser,
-  NodeLocalFileSystem,
-} from "./base/internal";
+import { IModelsErrorParser, NodeLocalFileSystem } from "./base/internal";
 import { LocalFileSystem } from "./base/types";
 import {
   BaselineFileOperations,
@@ -44,10 +40,10 @@ export interface IModelsClientOptions extends ManagementIModelsClientOptions {
   localFileSystem?: LocalFileSystem;
   /**
    * Storage handler to use in operations which transfer files. Examples of such operations are Changeset download in
-   * {@link ChangesetOperations}, iModel creation from Baseline in {@link iModelOperations}. If `undefined` the default
-   * is used which supports both Azure and Google storage.
+   * {@link ChangesetOperations}, iModel creation from Baseline in {@link iModelOperations}. You can use
+   * {@link createDefaultClientStorage} which supports both Azure and Google storage.
    */
-  cloudStorage?: ClientStorage;
+  cloudStorage: ClientStorage;
 }
 
 /**
@@ -62,7 +58,7 @@ export class IModelsClient extends ManagementIModelsClient {
    * @param {iModelsClientOptions} options client options. If `options` are `undefined` or if some of the properties
    * are `undefined` the client uses defaults. See {@link iModelsClientOptions}.
    */
-  constructor(options?: IModelsClientOptions) {
+  constructor(options: IModelsClientOptions) {
     const filledIModelsClientOptions =
       IModelsClient.fillAuthoringClientConfiguration(options);
     super(filledIModelsClientOptions);
@@ -123,7 +119,7 @@ export class IModelsClient extends ManagementIModelsClient {
   }
 
   private static fillAuthoringClientConfiguration(
-    options: IModelsClientOptions | undefined
+    options: IModelsClientOptions
   ): RecursiveRequired<IModelsClientOptions> {
     const retryPolicy =
       options?.retryPolicy ??
@@ -137,10 +133,10 @@ export class IModelsClient extends ManagementIModelsClient {
 
     return {
       api: this.fillApiConfiguration(options?.api),
-      restClient: options?.restClient ?? new AxiosRestClient(retryPolicy),
-      localFileSystem: options?.localFileSystem ?? new NodeLocalFileSystem(),
-      cloudStorage: options?.cloudStorage ?? createDefaultClientStorage(),
-      headers: options?.headers ?? {},
+      restClient: options.restClient ?? new AxiosRestClient(retryPolicy),
+      localFileSystem: options.localFileSystem ?? new NodeLocalFileSystem(),
+      headers: options.headers ?? {},
+      cloudStorage: options.cloudStorage,
       retryPolicy,
     };
   }

--- a/common/changes/@itwin/imodels-access-backend/optional-object-storage_2025-05-21-04-05.json
+++ b/common/changes/@itwin/imodels-access-backend/optional-object-storage_2025-05-21-04-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodels-access-backend",
+      "comment": "Remove default for iModelsClient option",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodels-access-backend"
+}

--- a/common/changes/@itwin/imodels-client-authoring/optional-object-storage_2025-05-21-04-05.json
+++ b/common/changes/@itwin/imodels-client-authoring/optional-object-storage_2025-05-21-04-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodels-client-authoring",
+      "comment": "Remove default for cloudStorage option",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodels-client-authoring"
+}

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -28,6 +28,15 @@
       "allowWarningsInSuccessfulBuild": true
     },
     {
+      "name": "test",
+      "commandKind": "bulk",
+      "summary": "Run tests on each package",
+      "description": "Iterates through each package in the monorepo and runs the 'test' script",
+      "enableParallelism": false,
+      "ignoreMissingScript": true,
+      "allowWarningsInSuccessfulBuild": false
+    },
+    {
       "name": "spell-check",
       "commandKind": "bulk",
       "summary": "Run spell check on each package",

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -18,15 +18,9 @@ importers:
       '@itwin/imodels-client-management':
         specifier: workspace:*
         version: link:../imodels-client-management
-      '@itwin/object-storage-azure':
-        specifier: ^3.0.0-dev.0
-        version: 3.0.0-dev.0(inversify@6.0.3)(reflect-metadata@0.1.14)
       '@itwin/object-storage-core':
         specifier: ^3.0.0-dev.0
         version: 3.0.0-dev.0(inversify@6.0.3)(reflect-metadata@0.1.14)
-      '@itwin/object-storage-google':
-        specifier: ^3.0.0-dev.0
-        version: 3.0.0-dev.0
     devDependencies:
       '@itwin/eslint-plugin':
         specifier: ~3.7.8
@@ -34,6 +28,12 @@ importers:
       '@itwin/imodels-client-common-config':
         specifier: workspace:*
         version: link:../../utils/imodels-client-common-config
+      '@itwin/object-storage-azure':
+        specifier: ^3.0.0-dev.0
+        version: 3.0.0-dev.0(inversify@6.0.3)(reflect-metadata@0.1.14)
+      '@itwin/object-storage-google':
+        specifier: ^3.0.0-dev.0
+        version: 3.0.0-dev.0(inversify@6.0.3)(reflect-metadata@0.1.14)
       '@types/node':
         specifier: ^22.15.14
         version: 22.15.18
@@ -188,13 +188,6 @@ importers:
         version: 5.8.3
 
   ../../itwin-platform-access/imodels-access-common:
-    dependencies:
-      '@itwin/imodels-client-authoring':
-        specifier: workspace:*
-        version: link:../../clients/imodels-client-authoring
-      '@itwin/imodels-client-management':
-        specifier: workspace:*
-        version: link:../../clients/imodels-client-management
     devDependencies:
       '@itwin/core-bentley':
         specifier: ^5.0.0-dev.112
@@ -202,9 +195,15 @@ importers:
       '@itwin/eslint-plugin':
         specifier: ~3.7.8
         version: 3.7.17(eslint@8.55.0)(typescript@5.8.3)
+      '@itwin/imodels-client-authoring':
+        specifier: workspace:*
+        version: link:../../clients/imodels-client-authoring
       '@itwin/imodels-client-common-config':
         specifier: workspace:*
         version: link:../../utils/imodels-client-common-config
+      '@itwin/imodels-client-management':
+        specifier: workspace:*
+        version: link:../../clients/imodels-client-management
       '@typescript-eslint/eslint-plugin':
         specifier: ~6.14.0
         version: 6.14.0(@typescript-eslint/parser@6.14.0(eslint@8.55.0)(typescript@5.8.3))(eslint@8.55.0)(typescript@5.8.3)
@@ -237,13 +236,6 @@ importers:
         version: 5.8.3
 
   ../../itwin-platform-access/imodels-access-frontend:
-    dependencies:
-      '@itwin/imodels-access-common':
-        specifier: workspace:*
-        version: link:../imodels-access-common
-      '@itwin/imodels-client-management':
-        specifier: workspace:*
-        version: link:../../clients/imodels-client-management
     devDependencies:
       '@itwin/appui-abstract':
         specifier: ^5.0.0-dev.112
@@ -275,9 +267,15 @@ importers:
       '@itwin/eslint-plugin':
         specifier: ~3.7.8
         version: 3.7.17(eslint@8.55.0)(typescript@5.8.3)
+      '@itwin/imodels-access-common':
+        specifier: workspace:*
+        version: link:../imodels-access-common
       '@itwin/imodels-client-common-config':
         specifier: workspace:*
         version: link:../../utils/imodels-client-common-config
+      '@itwin/imodels-client-management':
+        specifier: workspace:*
+        version: link:../../clients/imodels-client-management
       '@itwin/webgl-compatibility':
         specifier: ^5.0.0-dev.112
         version: 5.0.0-dev.112
@@ -617,6 +615,9 @@ importers:
       '@itwin/object-storage-core':
         specifier: ^3.0.0-dev.0
         version: 3.0.0-dev.0(inversify@6.0.3)(reflect-metadata@0.1.14)
+      '@itwin/object-storage-google':
+        specifier: ^3.0.0-dev.0
+        version: 3.0.0-dev.0(inversify@6.0.3)(reflect-metadata@0.1.14)
       axios:
         specifier: ^1.8.2
         version: 1.8.4
@@ -841,7 +842,13 @@ importers:
       '@itwin/imodels-client-management':
         specifier: workspace:*
         version: link:../../clients/imodels-client-management
+      '@itwin/object-storage-azure':
+        specifier: ^3.0.0-dev.0
+        version: 3.0.0-dev.0(inversify@6.0.3)(reflect-metadata@0.1.14)
       '@itwin/object-storage-core':
+        specifier: ^3.0.0-dev.0
+        version: 3.0.0-dev.0(inversify@6.0.3)(reflect-metadata@0.1.14)
+      '@itwin/object-storage-google':
         specifier: ^3.0.0-dev.0
         version: 3.0.0-dev.0(inversify@6.0.3)(reflect-metadata@0.1.14)
       '@puppeteer/browsers':
@@ -1551,9 +1558,6 @@ packages:
 
   '@types/node@14.14.31':
     resolution: {integrity: sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==}
-
-  '@types/node@20.17.49':
-    resolution: {integrity: sha512-lu4U+g0EbSW2aPGksNyqcesB2D3eDD0mv8ig9youJsEs/DuMOdeqcEbFOBDCCurXNpa10NkKSSRfOQLBFCiD8w==}
 
   '@types/node@22.15.18':
     resolution: {integrity: sha512-v1DKRfUdyW+jJhZNEI1PYy29S2YRxMV5AOO/x/SjKmW0acCIOqmbj6Haf9eHAhsPmrhlHSxEhv/1WszcLWV4cg==}
@@ -4308,9 +4312,6 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  undici-types@6.19.8:
-    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
-
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -5141,7 +5142,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@itwin/object-storage-google@3.0.0-dev.0':
+  '@itwin/object-storage-google@3.0.0-dev.0(inversify@6.0.3)(reflect-metadata@0.1.14)':
     dependencies:
       '@google-cloud/storage': 7.16.0
       '@google-cloud/storage-control': 0.2.1
@@ -5149,6 +5150,9 @@ snapshots:
       '@itwin/object-storage-core': 3.0.0-dev.0(inversify@6.0.3)(reflect-metadata@0.1.14)
       axios: 1.8.4
       google-auth-library: 9.15.1
+    optionalDependencies:
+      inversify: 6.0.3
+      reflect-metadata: 0.1.14
     transitivePeerDependencies:
       - debug
       - encoding
@@ -5334,11 +5338,6 @@ snapshots:
 
   '@types/node@14.14.31': {}
 
-  '@types/node@20.17.49':
-    dependencies:
-      undici-types: 6.19.8
-    optional: true
-
   '@types/node@22.15.18':
     dependencies:
       undici-types: 6.21.0
@@ -5381,7 +5380,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 20.17.49
+      '@types/node': 22.15.18
     optional: true
 
   '@typescript-eslint/eslint-plugin@4.31.2(@typescript-eslint/parser@4.31.2(eslint@8.55.0)(typescript@5.8.3))(eslint@8.55.0)(typescript@5.8.3)':
@@ -8621,9 +8620,6 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
-
-  undici-types@6.19.8:
-    optional: true
 
   undici-types@6.21.0: {}
 

--- a/docs/IModelsClientAuthoring.md
+++ b/docs/IModelsClientAuthoring.md
@@ -3,26 +3,33 @@
 `@itwin/imodels-client-authoring` package extends `IModelsClient` exposed by `@itwin/imodels-client-management` package thus this documentation references sections from [`@itwin/imodels-client-management` documentation](./IModelsClientManagement.md).
 
 ## Key types
+
 - [`IModelsClient`](../clients/imodels-client-authoring/src/IModelsClient.ts#L38)
 - [`IModelsClientOptions`](../clients/imodels-client-authoring/src/IModelsClient.ts#L19)
 
 ### Parameter and response types
+
 Please see [documentation](./IModelsClientManagement.md#parameter-and-response-types) of parameter and response types for `@itwin/imodels-client-management`.
 
 Additional types:
+
 - [`TargetDirectoryParam`](../clients/imodels-client-authoring/src/base/public/CommonInterfaces.ts#L13)
 
 ### Entities
+
 Please see [documentation](./IModelsClientManagement.md#entities) of entities for `@itwin/imodels-client-management`.
 
 Additional types:
+
 - [`BaselineFile`](../clients/imodels-client-authoring/src/base/public/apiEntities/BaselineFileInterfaces.ts#L31)
 - [`Lock`](../clients/imodels-client-authoring/src/base/public/apiEntities/LockInterfaces.ts#L25)
 
 ## Key methods
+
 Please see [documentation](./IModelsClientManagement.md#key-methods) of key methods for `@itwin/imodels-client-management`.
 
 Additional methods:
+
 - [`IModelsClient.iModels`](../clients/imodels-client-authoring/src/IModelsClient.ts#L38)
   - [`createFromBaseline(params: CreateIModelFromBaselineParams): Promise<IModel>`](../clients/imodels-client-authoring/src/operations/imodel/IModelOperations.ts#L37) ([sample](#create-imodel-from-baseline-file))
 - [`IModelsClient.baselineFiles`](../clients/imodels-client-authoring/src/IModelsClient.ts#L70)
@@ -45,6 +52,7 @@ Since the `@itwin/imodels-client-authoring` package extends the `@itwin/imodels-
 ### Authorization
 
 `IModelsClient` expects the authorization info to be passed in a form of an asynchronous callback that returns authorization info. It is a common use case to consume `IModelsClient` in iTwin.js platform based applications which use `IModelApp.getAccessToken` or `IModelHost.getAccessToken` to get the authorization header value returned as a string. The authorization header value specifies the schema and access token e.g. `Bearer ey...`. To convert this value into the format that `IModelsClients` expect users can use `AccessTokenAdapter` class which is exported by both [`@itwin/imodels-access-frontend`](../itwin-platform-access/imodels-access-frontend/src/interface-adapters/AccessTokenAdapter.ts) and [`@itwin/imodels-access-backend`](../itwin-platform-access/imodels-access-backend/src/interface-adapters/AccessTokenAdapter.ts) packages.
+
 ```typescript
 const iModelIterator: EntityListIterator<MinimalIModel> = iModelsClient.iModels.getMinimalList({
   authorization: AccessTokenAdapter.toAuthorizationCallback(IModelHost.getAccessToken),
@@ -55,12 +63,13 @@ const iModelIterator: EntityListIterator<MinimalIModel> = iModelsClient.iModels.
 ```
 
 ### Create iModel from Baseline File
+
 ```typescript
 import { Authorization, IModel, IModelsClient } from "@itwin/imodels-client-authoring";
 
 /** Function that creates a new iModel from Baseline file and prints its id to the console. */
 async function createIModelFromBaselineFile(): Promise<void> {
-  const iModelsClient: IModelsClient = new IModelsClient();
+  const iModelsClient: IModelsClient = new IModelsClient({ cloudStorage: createDefaultClientStorage() });
   const iModel: IModel = await iModelsClient.iModels.createFromBaseline({
     authorization: () => getAuthorization(),
     iModelProperties: {

--- a/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
@@ -110,11 +110,7 @@ import {
 } from "./interface-adapters/PlatformToClientAdapter";
 
 export class BackendIModelsAccess implements BackendHubAccess {
-  protected readonly _iModelsClient: IModelsClient;
-
-  constructor(iModelsClient?: IModelsClient) {
-    this._iModelsClient = iModelsClient ?? new IModelsClient();
-  }
+  constructor(private readonly _iModelsClient: IModelsClient) {}
 
   public async downloadChangesets(
     arg: DownloadChangesetRangeArg

--- a/tests/imodels-access-backend-tests/package.json
+++ b/tests/imodels-access-backend-tests/package.json
@@ -26,6 +26,7 @@
     "lint": "eslint --resolve-plugins-relative-to node_modules/@itwin/imodels-client-common-config ./src/**/*.ts 1>&2",
     "lint-fix": "eslint --resolve-plugins-relative-to node_modules/@itwin/imodels-client-common-config --fix ./src/**/*.ts 1>&2 && sort-package-json",
     "spell-check": "cspell \"**\" --config ./node_modules/@itwin/imodels-client-common-config/cspell.json",
+    "test": "npm run test:integration",
     "test:integration": "mocha lib/**/*.test.js --color --timeout 180000 --exit"
   },
   "prettier": "./node_modules/@itwin/imodels-client-common-config/prettier.json",

--- a/tests/imodels-access-common-tests/package.json
+++ b/tests/imodels-access-common-tests/package.json
@@ -26,6 +26,7 @@
     "lint": "eslint --resolve-plugins-relative-to node_modules/@itwin/imodels-client-common-config ./src/**/*.ts 1>&2",
     "lint-fix": "eslint --resolve-plugins-relative-to node_modules/@itwin/imodels-client-common-config --fix ./src/**/*.ts 1>&2 && sort-package-json",
     "spell-check": "cspell \"**\" --config ./node_modules/@itwin/imodels-client-common-config/cspell.json",
+    "test": "npm run test:unit",
     "test:unit": "mocha lib/**/*.test.js --color --timeout 180000 --exit"
   },
   "prettier": "./node_modules/@itwin/imodels-client-common-config/prettier.json",

--- a/tests/imodels-access-frontend-tests/package.json
+++ b/tests/imodels-access-frontend-tests/package.json
@@ -26,6 +26,7 @@
     "lint": "eslint --resolve-plugins-relative-to node_modules/@itwin/imodels-client-common-config ./src/**/*.ts 1>&2",
     "lint-fix": "eslint --resolve-plugins-relative-to node_modules/@itwin/imodels-client-common-config --fix ./src/**/*.ts 1>&2 && sort-package-json",
     "spell-check": "cspell \"**\" --config ./node_modules/@itwin/imodels-client-common-config/cspell.json",
+    "test": "npm run test:integration",
     "test:integration": "mocha lib/**/*.test.js --color --timeout 180000 --exit"
   },
   "prettier": "./node_modules/@itwin/imodels-client-common-config/prettier.json",

--- a/tests/imodels-clients-tests-browser/package.json
+++ b/tests/imodels-clients-tests-browser/package.json
@@ -29,9 +29,9 @@
     "lint": "eslint --resolve-plugins-relative-to node_modules/@itwin/imodels-client-common-config ./src/**/*.ts 1>&2",
     "lint-fix": "eslint --resolve-plugins-relative-to node_modules/@itwin/imodels-client-common-config --fix ./src/**/*.ts 1>&2 && sort-package-json",
     "spell-check": "cspell \"**\" --config ./node_modules/@itwin/imodels-client-common-config/cspell.json",
+    "test": "npm run test:integration",
     "test:integration": "cypress run",
-    "test:integration:debug": "cypress open",
-    "test:unit": ""
+    "test:integration:debug": "cypress open"
   },
   "prettier": "./node_modules/@itwin/imodels-client-common-config/prettier.json",
   "eslintConfig": {

--- a/tests/imodels-clients-tests/package.json
+++ b/tests/imodels-clients-tests/package.json
@@ -29,6 +29,7 @@
     "lint": "eslint --resolve-plugins-relative-to node_modules/@itwin/imodels-client-common-config ./src/**/*.ts 1>&2",
     "lint-fix": "eslint --resolve-plugins-relative-to node_modules/@itwin/imodels-client-common-config --fix ./src/**/*.ts 1>&2 && sort-package-json",
     "spell-check": "cspell \"**\" --config ./node_modules/@itwin/imodels-client-common-config/cspell.json",
+    "test": "npm run test:unit && npm run test:integration",
     "test:integration": "mocha lib/integration/**/*.test.js --color --timeout 180000 --exit",
     "test:unit": "mocha lib/unit/**/*.test.js --color --timeout 180000 --exit"
   },
@@ -43,6 +44,7 @@
     "@itwin/imodels-client-test-utils": "workspace:*",
     "@itwin/object-storage-azure": "^3.0.0-dev.0",
     "@itwin/object-storage-core": "^3.0.0-dev.0",
+    "@itwin/object-storage-google": "^3.0.0-dev.0",
     "axios": "^1.8.2",
     "chai": "~4.3.10",
     "chai-as-promised": "~7.1.1",

--- a/utils/imodels-client-test-utils/package.json
+++ b/utils/imodels-client-test-utils/package.json
@@ -33,7 +33,9 @@
   "dependencies": {
     "@itwin/imodels-client-authoring": "workspace:*",
     "@itwin/imodels-client-management": "workspace:*",
+    "@itwin/object-storage-azure": "^3.0.0-dev.0",
     "@itwin/object-storage-core": "^3.0.0-dev.0",
+    "@itwin/object-storage-google": "^3.0.0-dev.0",
     "@puppeteer/browsers": "^2.10.0",
     "axios": "^1.8.2",
     "chai": "~4.3.10",

--- a/utils/imodels-client-test-utils/src/test-context-providers/imodel/TestIModelsClientOptions.ts
+++ b/utils/imodels-client-test-utils/src/test-context-providers/imodel/TestIModelsClientOptions.ts
@@ -4,16 +4,23 @@
  *--------------------------------------------------------------------------------------------*/
 import { injectable } from "inversify";
 
-import { IModelsClientOptions } from "@itwin/imodels-client-authoring";
+import {
+  createDefaultClientStorage,
+  IModelsClientOptions,
+} from "@itwin/imodels-client-authoring";
 import { ApiOptions } from "@itwin/imodels-client-management";
+
+import { ClientStorage } from "@itwin/object-storage-core";
 
 import { IModelsClientsTestsConfig } from "../../IModelsClientsTestsConfig";
 
 @injectable()
 export class TestIModelsClientOptions implements IModelsClientOptions {
   public api: ApiOptions;
+  public cloudStorage: ClientStorage;
 
   constructor(config: IModelsClientsTestsConfig) {
     this.api = { baseUrl: config.apis.iModels.baseUrl };
+    this.cloudStorage = createDefaultClientStorage();
   }
 }


### PR DESCRIPTION
Make the choice on which object storage to use explicit. This will require all users provide the cloudStorage object they want to use (installing optional peer dependencies will allow them to use `createDefaultClientStorage` factory function), but will allow some users who want to avoid installing google dependencies.

Also added `rush test` to run all tests in the package.