### PR TITLE
Expose IModelsClient from itwin-platform-access

### DIFF
--- a/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-backend/src/BackendIModelsAccess.ts
@@ -118,7 +118,7 @@ export type BackendIModelsAccessOptions = Pick<
   Omit<IModelsClientOptions, "cloudStorage">;
 
 export class BackendIModelsAccess implements BackendHubAccess {
-  private readonly _iModelsClient: IModelsClient;
+  protected readonly _iModelsClient: IModelsClient;
 
   constructor(iModelsClient?: IModelsClient | BackendIModelsAccessOptions) {
     this._iModelsClient =
@@ -129,6 +129,10 @@ export class BackendIModelsAccess implements BackendHubAccess {
             cloudStorage:
               iModelsClient?.cloudStorage ?? createDefaultClientStorage(),
           });
+  }
+
+  public get iModelsClient(): IModelsClient {
+    return this._iModelsClient;
   }
 
   public async downloadChangesets(

--- a/itwin-platform-access/imodels-access-frontend/src/FrontendIModelsAccess.ts
+++ b/itwin-platform-access/imodels-access-frontend/src/FrontendIModelsAccess.ts
@@ -49,6 +49,10 @@ export class FrontendIModelsAccess implements FrontendHubAccess {
         : new IModelsClient(iModelsClient);
   }
 
+  public get iModelsClient(): IModelsClient {
+    return this._iModelsClient;
+  }
+
   private async getChangesetFromId(
     arg: IModelIdArg & { changeSetId: string }
   ): Promise<ChangesetIndexAndId> {


### PR DESCRIPTION
Expose IModelsClient from access classes, so it wouldn't have to be constructed manually to access underlying methods that are not in the access interfaces.